### PR TITLE
Document potential pitfalls in install testing.

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,4 +29,8 @@ make run-py-tests
 ```
 
 **NOTE:** Due to how Python handles imports, this will fail if run from any
-directory except the top-level `qsim` directory. Also make sure that the qsim pybind interface `.so` file is included in the `$PYTHONPATH`.
+directory except the top-level `qsim` directory. Similarly, attempting to run
+tests using an installed version of qsimcirq (e.g. with `pip3 install qsimcirq`)
+can misbehave if there is a `qsimcirq/` directory _anywhere_ in the current
+working directory. For more information, see the
+[Python module documentation](https://docs.python.org/3/tutorial/modules.html#the-module-search-path).

--- a/pybind_interface/Dockerfile
+++ b/pybind_interface/Dockerfile
@@ -16,5 +16,4 @@ WORKDIR /qsim/
 RUN make -C /qsim/ pybind
 
 # Compile and run qsim tests
-ENV PYTHONPATH "${PYTHONPATH}:/qsim/qsimcirq"
 ENTRYPOINT make -C /qsim/ run-py-tests

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -18,7 +18,7 @@ from cirq import study, ops, circuits, protocols, SimulatesAmplitudes, Simulates
 
 import numpy as np
 
-import qsim
+from qsimcirq import qsim
 import qsimcirq.qsim_circuit as qsimc
 
 

--- a/qsimcirq/qsimh_simulator.py
+++ b/qsimcirq/qsimh_simulator.py
@@ -16,7 +16,7 @@ from typing import Union, Sequence
 
 from cirq import study, ops, protocols, circuits, SimulatesAmplitudes
 
-import qsim
+from qsimcirq import qsim
 import qsimcirq.qsim_circuit as qsimc
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,8 @@
 cirq==0.6.0
 numpy~=1.16
 typing_extensions
+
+# Build and test requirements
+
+pybind11
+pytest


### PR DESCRIPTION
(Part of #22) This patch has been verified with three test processes:
```
# Starting in the git repo directory
pip3 install -r requirements.txt

# Direct testing:
make run-tests

# Docker testing:
make clean
sudo docker-compose up --build

# Install testing (see note below):
pip3 install .
cp -r qsimcirq_tests/ ~/test-dir
cd ~/test-dir
python3 -m pytest .
```

Note that `~/test-dir` must be completely separate from the git repo directory - it cannot be a parent directory or a subdirectory of the git repo directory.

I'll update #20 to reflect the expectations this places on the install process.