### PR TITLE
Add objects for full state output.

### DIFF
--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -14,7 +14,16 @@
 
 from typing import Any, Dict, List, Sequence
 
-from cirq import study, ops, circuits, protocols, SimulatesAmplitudes, SimulatesFinalState, SimulationTrialResult
+from cirq import (
+  circuits,
+  ops,
+  protocols,
+  sim,
+  study,
+  SimulatesAmplitudes,
+  SimulatesFinalState,
+  SimulationTrialResult,
+)
 
 import numpy as np
 
@@ -22,22 +31,22 @@ from qsimcirq import qsim
 import qsimcirq.qsim_circuit as qsimc
 
 
-class QSimSimulatorState():
+class QSimSimulatorState(sim.WaveFunctionSimulatorState):
 
     def __init__(self,
                  qsim_data: np.ndarray,
                  qubit_map: Dict[ops.Qid, int]):
-      self.qubit_map = qubit_map
       # Generate state vector from qsim results
       amplitudes = qsim_data
-      N = len(self.qubit_map)
+      N = len(qubit_map)
       amplitudes = np.reshape(amplitudes, [2]*(N+1))
       amplitudes = np.transpose(amplitudes)
       amplitudes = amplitudes[0] + 1j * amplitudes[1]
-      self.state_vector = amplitudes.flatten()
+      state_vector = amplitudes.flatten()
+      super().__init__(state_vector=state_vector, qubit_map=qubit_map)
 
 
-class QSimSimulatorTrialResult(SimulationTrialResult):
+class QSimSimulatorTrialResult(sim.WaveFunctionTrialResult):
     
     def __init__(self,
                  params: study.ParamResolver,
@@ -46,9 +55,6 @@ class QSimSimulatorTrialResult(SimulationTrialResult):
       super().__init__(params=params,
                        measurements=measurements,
                        final_simulator_state=final_simulator_state)
-
-      # This field exposes the final state to external users.
-      self.final_state = final_simulator_state.state_vector
 
 
 class QSimSimulator(SimulatesAmplitudes, SimulatesFinalState):

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Sequence
+from typing import Any, Dict, List, Sequence
 
 from cirq import study, ops, circuits, protocols, SimulatesAmplitudes, SimulatesFinalState, SimulationTrialResult
 
@@ -20,6 +20,35 @@ import numpy as np
 
 from qsimcirq import qsim
 import qsimcirq.qsim_circuit as qsimc
+
+
+class QSimSimulatorState():
+
+    def __init__(self,
+                 qsim_data: np.ndarray,
+                 qubit_map: Dict[ops.Qid, int]):
+      self.qubit_map = qubit_map
+      # Generate state vector from qsim results
+      amplitudes = qsim_data
+      N = len(self.qubit_map)
+      amplitudes = np.reshape(amplitudes, [2]*(N+1))
+      amplitudes = np.transpose(amplitudes)
+      amplitudes = amplitudes[0] + 1j * amplitudes[1]
+      self.state_vector = amplitudes.flatten()
+
+
+class QSimSimulatorTrialResult(SimulationTrialResult):
+    
+    def __init__(self,
+                 params: study.ParamResolver,
+                 measurements: Dict[str, np.ndarray],
+                 final_simulator_state: QSimSimulatorState):
+      super().__init__(params=params,
+                       measurements=measurements,
+                       final_simulator_state=final_simulator_state)
+
+      # This field exposes the final state to external users.
+      self.final_state = final_simulator_state.state_vector
 
 
 class QSimSimulator(SimulatesAmplitudes, SimulatesFinalState):
@@ -118,14 +147,21 @@ class QSimSimulator(SimulatesAmplitudes, SimulatesFinalState):
       solved_circuit = protocols.resolve_parameters(program, prs)
 
       options['c'] = solved_circuit.translate_cirq_to_qsim(qubit_order)
+      ordered_qubits = ops.QubitOrder.as_qubit_order(qubit_order).order_for(
+        solved_circuit.all_qubits())
+      qubit_map = {
+        qubit: index for index, qubit in enumerate(ordered_qubits)
+      }
 
-      final_state = qsim.qsim_simulate_fullstate(options)
-      assert final_state.dtype == np.float32
-      assert final_state.ndim == 1
+      qsim_state = qsim.qsim_simulate_fullstate(options)
+      assert qsim_state.dtype == np.float32
+      assert qsim_state.ndim == 1
+      final_state = QSimSimulatorState(qsim_state, qubit_map)
       # create result for this parameter
       # TODO: We need to support measurements.
-      result = SimulationTrialResult(
-          params=prs, measurements={}, final_simulator_state=final_state)
+      result = QSimSimulatorTrialResult(params=prs,
+                                        measurements={},
+                                        final_simulator_state=final_state)
       trials_results.append(result)
 
     return trials_results

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -53,18 +53,38 @@ class MainTest(unittest.TestCase):
         cirq.GridQubit(1, 0)
     ]
 
-    # Create a circuit
+    # Create a circuit.
     cirq_circuit = cirq.Circuit(
-        cirq.X(a)**0.5,  # Square root of X.
-        cirq.Y(b)**0.5,  # Square root of Y.
-        cirq.Z(c),  # Z.
-        cirq.CZ(a, d)  # ControlZ.
+        cirq.Moment([
+            cirq.X(a)**0.5,  # Square root of X.
+            cirq.H(b),       # Hadamard.
+            cirq.X(c),       # X.
+            cirq.H(d),       # Hadamard.
+        ]),
+        cirq.Moment([
+            cirq.X(a)**0.5,  # Square root of X.
+            cirq.CX(b, c),   # ControlX.
+            cirq.Z(d),       # Z.
+        ])
     )
+    # Expected output state is:
+    # |1> (|01> + |10>) (|0> - |1>)
+    # = 1/2 * (|1010> - |1011> + |1100> - |1101>)
 
     qsim_circuit = qsimcirq.QSimCircuit(cirq_circuit)
 
     qsimSim = qsimcirq.QSimSimulator()
-    result = qsimSim.simulate(qsim_circuit)
+    result = qsimSim.simulate(qsim_circuit, qubit_order=[a, b, c, d])
+    print(result)
+    assert result.final_state.shape == (16,)
+    np.testing.assert_array_almost_equal(
+        result.final_state,
+        [
+            0,   0,    0,   0,
+            0,   0,    0,   0,
+            0,   0,    0.5, -0.5,
+            0.5, -0.5, 0,   0,
+        ])
 
   def test_cirq_qsimh_simulate(self):
     # Pick qubits.


### PR DESCRIPTION
Fixes #40: allows users to get final state from the result with `result.final_state`. The final state is an ordered vector of complex-valued amplitudes for each output state; this format should match the output of e.g. `WaveFunctionSimulator` in Cirq.

@gecrooks, please let me know if you see any issues with this PR.