### PR TITLE
Alternative fix for qsim and cirq opposite ordering of qubits

### DIFF
--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -60,6 +60,10 @@ class QSimCircuit(cirq.Circuit):
     circuit_data = []
     ordered_qubits = cirq.ops.QubitOrder.as_qubit_order(qubit_order).order_for(
         self.all_qubits())
+
+    # qsim numbers qubits in reverse order from cirq
+    ordered_qubits = list(reversed(ordered_qubits))
+
     qubit_to_index_dict = {q: i for i, q in enumerate(ordered_qubits)}
     for mi, moment in enumerate(self):
       for op in moment:

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -37,12 +37,9 @@ class QSimSimulatorState(sim.WaveFunctionSimulatorState):
                  qsim_data: np.ndarray,
                  qubit_map: Dict[ops.Qid, int]):
       # Generate state vector from qsim results
-      amplitudes = qsim_data
-      N = len(qubit_map)
-      amplitudes = np.reshape(amplitudes, [2]*(N+1))
-      amplitudes = np.transpose(amplitudes)
-      amplitudes = amplitudes[0] + 1j * amplitudes[1]
-      state_vector = amplitudes.flatten()
+      state_vector = np.reshape(qsim_data, [-1, 2])
+      state_vector = state_vector[:, 0] + 1j * state_vector[:, 1]
+
       super().__init__(state_vector=state_vector, qubit_map=qubit_map)
 
 
@@ -95,6 +92,9 @@ class QSimSimulator(SimulatesAmplitudes, SimulatesFinalState):
       """
     if not isinstance(program, qsimc.QSimCircuit):
       raise ValueError('{!r} is not a QSimCircuit'.format(program))
+
+    # qsim numbers qubits in reverse order from cirq
+    bitstrings = [bs[::-1] for bs in bitstrings]
 
     options = {'i': '\n'.join(bitstrings)}
     options.update(self.qsim_options)

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -151,6 +151,9 @@ class QSimSimulator(SimulatesAmplitudes, SimulatesFinalState):
       options['c'] = solved_circuit.translate_cirq_to_qsim(qubit_order)
       ordered_qubits = ops.QubitOrder.as_qubit_order(qubit_order).order_for(
         solved_circuit.all_qubits())
+      # qsim numbers qubits in reverse order from cirq
+      ordered_qubits = list(reversed(ordered_qubits))
+
       qubit_map = {
         qubit: index for index, qubit in enumerate(ordered_qubits)
       }

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -22,7 +22,6 @@ from cirq import (
   study,
   SimulatesAmplitudes,
   SimulatesFinalState,
-  SimulationTrialResult,
 )
 
 import numpy as np
@@ -36,10 +35,7 @@ class QSimSimulatorState(sim.WaveFunctionSimulatorState):
     def __init__(self,
                  qsim_data: np.ndarray,
                  qubit_map: Dict[ops.Qid, int]):
-      # Generate state vector from qsim results
-      state_vector = np.reshape(qsim_data, [-1, 2])
-      state_vector = state_vector[:, 0] + 1j * state_vector[:, 1]
-
+      state_vector = qsim_data.view(np.complex64)
       super().__init__(state_vector=state_vector, qubit_map=qubit_map)
 
 

--- a/qsimcirq/qsimh_simulator.py
+++ b/qsimcirq/qsimh_simulator.py
@@ -37,6 +37,9 @@ class QSimhSimulator(SimulatesAmplitudes):
     if not isinstance(program, qsimc.QSimCircuit):
       raise ValueError('{!r} is not a QSimCircuit'.format(program))
 
+    # qsim numbers qubits in reverse order from cirq
+    bitstrings = [bs[::-1] for bs in bitstrings]
+
     options = {'i': '\n'.join(bitstrings)}
     options.update(self.qsimh_options)
     param_resolvers = study.to_resolvers(params)

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -79,7 +79,7 @@ class MainTest(unittest.TestCase):
     cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=[a, b, c, d])
     # When using rotation gates such as S, qsim may add a global phase relative
     # to other simulators. This is fine, as the result is equivalent.
-    cirq.linalg.allclose_up_to_global_phase(
+    assert cirq.linalg.allclose_up_to_global_phase(
         result.state_vector(), cirq_result.state_vector())
 
   def test_cirq_qsimh_simulate(self):

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import cirq
 import qsimcirq
 
@@ -88,7 +87,7 @@ class MainTest(unittest.TestCase):
     a, b = [cirq.GridQubit(0, 0), cirq.GridQubit(0, 1)]
 
     # Create a circuit
-    cirq_circuit = cirq.Circuit(cirq.CNOT(a, b), cirq.CNOT(b, a), cirq.CZ(a, b))
+    cirq_circuit = cirq.Circuit(cirq.CNOT(a, b), cirq.CNOT(b, a), cirq.X(a))
 
     qsim_circuit = qsimcirq.QSimCircuit(cirq_circuit)
 
@@ -96,7 +95,7 @@ class MainTest(unittest.TestCase):
     qsimhSim = qsimcirq.QSimhSimulator(qsimh_options)
     result = qsimhSim.compute_amplitudes(
         qsim_circuit, bitstrings=['00', '01', '10', '11'])
-    self.assertSequenceEqual(result, [(1 + 0j), 0j, 0j, 0j])
+    self.assertSequenceEqual(result, [0j, 0j, (1 + 0j), 0j])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Rather than transposing the amplitudes (which is slow), instead number qubits in reverse order when constructing the qsim circuit. 