### PR TITLE
Enable identity gates in cirq interface

### DIFF
--- a/docs/input_format.md
+++ b/docs/input_format.md
@@ -34,3 +34,5 @@ CNOT                                                              | time cnot qu
 iSwap                                                             | time is qubit1 qubit2           | 4 is 6 7
 fSim(&theta;, &phi;)                                              | time fs qubit1 qubit2 theta phi | 5 fs 6 7 3.14 1.57
 CPhase(&phi;)                                                     | time cp qubit1 qubit2 phi       | 6 cp 0 1 0.78
+Identity (1-qubit)                                                | time id1 qubit                  | 7 id1 0
+Identity (2-qubit)                                                | time id2 qubit                  | 8 id2 0 1

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -25,13 +25,13 @@ class QSimCircuit(cirq.Circuit):
                allow_decomposition: bool = False):
 
     if allow_decomposition:
-      super().__init__([], device)
+      super().__init__([], device=device)
       for moment in cirq_circuit:
         for op in moment:
           # This should call decompose on the gates
           self.append(op)
     else:
-      super().__init__(cirq_circuit, device)
+      super().__init__(cirq_circuit, device=device)
 
   def __eq__(self, other):
     if not isinstance(other, QSimCircuit):

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -112,11 +112,17 @@ class QSimCircuit(cirq.Circuit):
         elif isinstance(op.gate, cirq.ops.FSimGate):
           qsim_gate = "fs"
           qsim_params = "{} {}".format(op.gate.theta, op.gate.phi)
-        elif isinstance(op.gate, cirq.ops.IdentityGate) \
-                and op.gate.num_qubits() == 1:
+        elif isinstance(op, cirq.ops.identity.IdentityOperation) \
+                and len(op.qubits) == 1:        # cirq version 0.6
           qsim_gate = "id1"
-        elif isinstance(op.gate, cirq.ops.IdentityGate) \
-                and op.gate.num_qubits() == 2:
+        elif isinstance(op.gate, cirq.ops.identity.IdentityGate) \
+                and op.gate.num_qubits() == 1:  # cirq version >=0.7
+          qsim_gate = "id1"
+        elif isinstance(op, cirq.ops.identity.IdentityOperation) \
+                and len(op.qubits) == 2:        # cirq version 0.6
+          qsim_gate = "id2"
+        elif isinstance(op.gate, cirq.ops.identity.IdentityGate) \
+                and op.gate.num_qubits() == 2:  # cirq version >=0.7
           qsim_gate = "id2"
         else:
           raise ValueError("{!r} No translation for ".format(op))

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -112,6 +112,12 @@ class QSimCircuit(cirq.Circuit):
         elif isinstance(op.gate, cirq.ops.FSimGate):
           qsim_gate = "fs"
           qsim_params = "{} {}".format(op.gate.theta, op.gate.phi)
+        elif isinstance(op.gate, cirq.ops.IdentityGate) \
+                and op.gate.num_qubits() == 1:
+          qsim_gate = "id1"
+        elif isinstance(op.gate, cirq.ops.IdentityGate) \
+                and op.gate.num_qubits() == 2:
+          qsim_gate = "id2"
         else:
           raise ValueError("{!r} No translation for ".format(op))
 

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -65,7 +65,10 @@ class MainTest(unittest.TestCase):
             cirq.X(a)**0.5,  # Square root of X.
             cirq.CX(b, c),   # ControlX.
             cirq.S(d),       # S (square root of Z).
-        ])
+        ]),
+        cirq.Moment([
+            cirq.I(a),
+            ])
     )
     # Expected output state is:
     # |1> (|01> + |10>) (|0> - |1>)


### PR DESCRIPTION
Enabling identity gates removes one failure mode when converting cirq circuits to qsim.