### PR TITLE
Emulate SWAP with fSim.

### DIFF
--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -109,6 +109,10 @@ class QSimCircuit(cirq.Circuit):
         elif isinstance(op.gate, cirq.ops.ISwapPowGate) \
                 and op.gate.exponent == 1.0:
           qsim_gate = "is"
+        # SWAP can be emulated with the fSim gate.
+        elif isinstance(op.gate, cirq.ops.SwapPowGate):
+          qsim_gate = "fs"
+          qsim_params = "{} {}".format(str(op.gate.exponent*np.pi/2), np.pi)
         elif isinstance(op.gate, cirq.ops.FSimGate):
           qsim_gate = "fs"
           qsim_params = "{} {}".format(op.gate.theta, op.gate.phi)

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -65,11 +65,14 @@ class MainTest(unittest.TestCase):
             cirq.X(a)**0.5,  # Square root of X.
             cirq.CX(b, c),   # ControlX.
             cirq.S(d),       # S (square root of Z).
+        ]),
+        cirq.Moment([
+            cirq.SWAP(c, d),  # SWAP.
         ])
     )
     # Expected output state is:
     # |1> (|01> + |10>) (|0> - |1>)
-    # = 1/2 * (|1010> - i|1011> + |1100> - i|1101>)
+    # = 1/2 * (|1001> - i|1011> + |1100> - i|1110>)
 
     qsim_circuit = qsimcirq.QSimCircuit(cirq_circuit)
 


### PR DESCRIPTION
As requested in #48. Note that iSWAP can also be emulated with fSim but isn't, which suggests that either it was added first or that there's a benefit to explicitly implementing he more specific gate.

@gecrooks for input.