### PR TITLE
Documentation for runner functions

### DIFF
--- a/lib/hybrid.h
+++ b/lib/hybrid.h
@@ -85,7 +85,7 @@ struct HybridSimulator final {
    * Splits the lattice into two parts, using Schmidt decomposition for gates
    * on the cut.
    * @param parts Lattice sections to be simulated.
-   * @param gates List of gates bridging the "cut" between lattice sections.
+   * @param gates List of all gates in the circuit.
    */
   static HybridData SplitLattice(const std::vector<unsigned>& parts,
                                  const std::vector<Gate>& gates) {

--- a/lib/hybrid.h
+++ b/lib/hybrid.h
@@ -81,8 +81,12 @@ struct HybridSimulator final {
     unsigned verbosity = 0;
   };
 
-  // Split the lattice into two parts.
-  // Use Schmidt decomposition for gates on the cut.
+  /**
+   * Splits the lattice into two parts, using Schmidt decomposition for gates
+   * on the cut.
+   * @param parts Lattice sections to be simulated.
+   * @param gates List of gates bridging the "cut" between lattice sections.
+   */
   static HybridData SplitLattice(const std::vector<unsigned>& parts,
                                  const std::vector<Gate>& gates) {
     HybridData hd;
@@ -196,7 +200,20 @@ struct HybridSimulator final {
     return hd;
   }
 
-  // Run hybrid simulator.
+  /**
+   * Runs the hybrid simulator on a sectioned lattice.
+   * @param param Options for parallelism and logging. Also specifies the size
+   *   of the 'prefix' and 'root' sections of the lattice.
+   * @param hd Container object for gates on the boundary between lattice
+   *   sections.
+   * @param parts Lattice sections to be simulated.
+   * @param fgates0 List of gates from one section of the lattice.
+   * @param fgates1 List of gates from the other section of the lattice.
+   * @param bitstrings List of output states to simulate, as bitstrings.
+   * @param results Output vector of amplitudes. After a successful run, this
+   *   will be populated with amplitudes for each state in 'bitstrings'.
+   * @return True if the simulation completed successfully; false otherwise.
+   */
   static bool Run(const Parameter& param, HybridData& hd,
                   const std::vector<unsigned>& parts,
                   const std::vector<GateFused>& fgates0,
@@ -325,6 +342,15 @@ struct HybridSimulator final {
   }
 
  private:
+  /**
+   * Identifies when to save "checkpoints" of the simulation state. These allow
+   * runs with different cut-index values to reuse parts of the simulation.
+   * @param param Options for parallelism and logging. Also specifies the size
+   *   of the 'prefix' and 'root' sections of the lattice.
+   * @param fgates Set of gates for which to find checkpoint locations.
+   * @return A pair of numbers specifying how many gates to apply before the
+   *   first and second checkpoints, respectively.
+   */
   static std::array<unsigned, 2> CheckpointLocations(
       const Parameter& param, const std::vector<GateFused>& fgates) {
     std::array<unsigned, 2> loc{0, 0};

--- a/lib/run_qsim.h
+++ b/lib/run_qsim.h
@@ -116,8 +116,9 @@ struct QSimRunner final {
    * @param param Options for parallelism and logging.
    * @param maxtime Maximum number of time steps to run.
    * @param circuit The circuit to be simulated.
-   * @param state The state of the system. After a successful run, this will be
-   *   populated with the final state of the system.
+   * @param state As an input parameter, this should contain the initial state
+   *   of the system. After a successful run, it will be populated with the
+   *   final state of the system.
    * @return True if the simulation completed successfully; false otherwise.
    */
   template <typename Circuit>

--- a/lib/run_qsim.h
+++ b/lib/run_qsim.h
@@ -32,6 +32,14 @@ struct QSimRunner final {
     unsigned verbosity;
   };
 
+  /**
+   * Runs the given circuit, only measuring at the end.
+   * @param param Options for parallelism and logging.
+   * @param maxtime Maximum number of time steps to run.
+   * @param circuit The circuit to be simulated.
+   * @param measure Function to apply to each measurement result.
+   * @return True if the simulation completed successfully; false otherwise.
+   */
   template <typename Circuit, typename MeasurementFunc>
   static bool Run(const Parameter& param, unsigned maxtime,
                   const Circuit& circuit, MeasurementFunc measure) {
@@ -39,6 +47,14 @@ struct QSimRunner final {
     return Run(param, times_to_measure_at, circuit, measure);
   }
 
+  /**
+   * Runs the given circuit, measuring all qubits at user-specified times.
+   * @param param Options for parallelism and logging.
+   * @param times_to_measure_at Time steps at which to measure the state.
+   * @param circuit The circuit to be simulated.
+   * @param measure Function to apply to each measurement result.
+   * @return True if the simulation completed successfully; false otherwise.
+   */
   template <typename Circuit, typename MeasurementFunc>
   static bool Run(const Parameter& param,
                   const std::vector<unsigned>& times_to_measure_at,
@@ -95,6 +111,15 @@ struct QSimRunner final {
     return true;
   }
 
+  /**
+   * Runs the given circuit and make the final state available to the caller.
+   * @param param Options for parallelism and logging.
+   * @param maxtime Maximum number of time steps to run.
+   * @param circuit The circuit to be simulated.
+   * @param state The state of the system. After a successful run, this will be
+   *   populated with the final state of the system.
+   * @return True if the simulation completed successfully; false otherwise.
+   */
   template <typename Circuit>
   static bool Run(const Parameter& param, unsigned maxtime,
                   const Circuit& circuit, typename Simulator::State& state) {

--- a/lib/run_qsimh.h
+++ b/lib/run_qsimh.h
@@ -40,7 +40,7 @@ struct QSimHRunner final {
    *   of the 'prefix' and 'root' sections of the lattice.
    * @param maxtime Maximum number of time steps to run.
    * @param parts Lattice sections to be simulated.
-   * @param gates List of gates bridging the "cut" between lattice sections.
+   * @param gates List of all gates in the circuit.
    * @param bitstrings List of output states to simulate, as bitstrings.
    * @param results Output vector of amplitudes. After a successful run, this
    *   will be populated with amplitudes for each state in 'bitstrings'.

--- a/lib/run_qsimh.h
+++ b/lib/run_qsimh.h
@@ -34,6 +34,18 @@ struct QSimHRunner final {
   using HybridData = typename HybridSimulator::HybridData;
   using Fuser = typename HybridSimulator::Fuser;
 
+  /**
+   * Evaluates the amplitudes for a given circuit and set of output states.
+   * @param param Options for parallelism and logging. Also specifies the size
+   *   of the 'prefix' and 'root' sections of the lattice.
+   * @param maxtime Maximum number of time steps to run.
+   * @param parts Lattice sections to be simulated.
+   * @param gates List of gates bridging the "cut" between lattice sections.
+   * @param bitstrings List of output states to simulate, as bitstrings.
+   * @param results Output vector of amplitudes. After a successful run, this
+   *   will be populated with amplitudes for each state in 'bitstrings'.
+   * @return True if the simulation completed successfully; false otherwise.
+   */
   static bool Run(const Parameter& param, unsigned maxtime,
                   const std::vector<unsigned>& parts,
                   const std::vector<Gate>& gates,


### PR DESCRIPTION
Adds docstrings for `run_qsim` and `run_qsimh`, along with a couple for `hybrid`. The remaining methods in `hybrid` were a little unclear to me, but as private methods it's less critical that they get documentation than the public methods.