### PR TITLE
Docstrings for gate operations.

### DIFF
--- a/lib/fuser_basic.h
+++ b/lib/fuser_basic.h
@@ -28,19 +28,18 @@ struct BasicGateFuser final {
   using GateFused = qsim::GateFused<Gate>;
 
   /**
-   * Stores ordered sets of gates on 'num_qubits' that can be applied together.
+   * Stores a single sets of gates on 'num_qubits' that can be applied together.
    * Note that gates fused with this method are not multiplied together until
    * ApplyFusedGate is called on the resulting object(s).
    * @param num_qubits The number of qubits affected by 'gates'.
    * @param gates The gates to be fused.
-   * @param time Time step at which to separate fused gates. Each element of the
-   *   output will contain gates from either before or after this time step.
-   * @return A vector of fused gate objects. Each element represents a set of
+   * @param maxtime Maximum number of timesteps to fuse with this operation.
+   * @return A vector containing a single fused gate, representing a set of
    *   gates on up to 'num_qubits' qubits which can be applied as a group.
    */
   static std::vector<GateFused> FuseGates(unsigned num_qubits,
-      const std::vector<Gate>& gates, unsigned time) {
-    std::vector<unsigned> times_to_split_at(1, time);
+      const std::vector<Gate>& gates, unsigned maxtime) {
+    std::vector<unsigned> times_to_split_at(1, maxtime);
     return FuseGates(num_qubits, gates, times_to_split_at);
   }
 

--- a/lib/fuser_basic.h
+++ b/lib/fuser_basic.h
@@ -27,12 +27,35 @@ template <typename Gate>
 struct BasicGateFuser final {
   using GateFused = qsim::GateFused<Gate>;
 
+  /**
+   * Stores ordered sets of gates on 'num_qubits' that can be applied together.
+   * Note that gates fused with this method are not multiplied together until
+   * ApplyFusedGate is called on the resulting object(s).
+   * @param num_qubits The number of qubits affected by 'gates'.
+   * @param gates The gates to be fused.
+   * @param time Time step at which to separate fused gates. Each element of the
+   *   output will contain gates from either before or after this time step.
+   * @return A vector of fused gate objects. Each element represents a set of
+   *   gates on up to 'num_qubits' qubits which can be applied as a group.
+   */
   static std::vector<GateFused> FuseGates(unsigned num_qubits,
       const std::vector<Gate>& gates, unsigned time) {
     std::vector<unsigned> times_to_split_at(1, time);
     return FuseGates(num_qubits, gates, times_to_split_at);
   }
 
+  /**
+   * Stores ordered sets of gates on 'num_qubits' that can be applied together.
+   * Note that gates fused with this method are not multiplied together until
+   * ApplyFusedGate is called on the resulting object(s).
+   * @param num_qubits The number of qubits affected by 'gates'.
+   * @param gates The gates to be fused.
+   * @param times_to_split_at Ordered list of time steps at which to separate
+   *   fused gates. Each element of the output will contain gates from a single
+   *   'window' in this list.
+   * @return A vector of fused gate objects. Each element represents a set of
+   *   gates on up to 'num_qubits' qubits which can be applied as a group.
+   */
   static std::vector<GateFused> FuseGates(
       unsigned num_qubits, const std::vector<Gate>& gates,
       const std::vector<unsigned>& times_to_split_at) {

--- a/lib/fuser_basic.h
+++ b/lib/fuser_basic.h
@@ -28,14 +28,16 @@ struct BasicGateFuser final {
   using GateFused = qsim::GateFused<Gate>;
 
   /**
-   * Stores a single sets of gates on 'num_qubits' that can be applied together.
-   * Note that gates fused with this method are not multiplied together until
-   * ApplyFusedGate is called on the resulting object(s).
-   * @param num_qubits The number of qubits affected by 'gates'.
+   * Stores ordered sets of gates, each acting on two qubits, that can be
+   * applied together. Note that gates fused with this method are not
+   * multiplied together until ApplyFusedGate is called on the output.
+   * To respect specific time boundaries while fusing gates, use the other
+   * version of this method below.
+   * @param num_qubits The number of qubits acted on by 'gates'.
    * @param gates The gates to be fused.
    * @param maxtime Maximum number of timesteps to fuse with this operation.
-   * @return A vector containing a single fused gate, representing a set of
-   *   gates on up to 'num_qubits' qubits which can be applied as a group.
+   * @return A vector of fused gate objects. Each element is a set of gates
+   *   acting on a specific pair of qubits which can be applied as a group.
    */
   static std::vector<GateFused> FuseGates(unsigned num_qubits,
       const std::vector<Gate>& gates, unsigned maxtime) {
@@ -44,16 +46,16 @@ struct BasicGateFuser final {
   }
 
   /**
-   * Stores ordered sets of gates on 'num_qubits' that can be applied together.
-   * Note that gates fused with this method are not multiplied together until
-   * ApplyFusedGate is called on the resulting object(s).
-   * @param num_qubits The number of qubits affected by 'gates'.
+   * Stores ordered sets of gates, each acting on two qubits, that can be
+   * applied together. Note that gates fused with this method are not
+   * multiplied together until ApplyFusedGate is called on the output.
+   * @param num_qubits The number of qubits acted on by 'gates'.
    * @param gates The gates to be fused.
    * @param times_to_split_at Ordered list of time steps at which to separate
    *   fused gates. Each element of the output will contain gates from a single
    *   'window' in this list.
-   * @return A vector of fused gate objects. Each element represents a set of
-   *   gates on up to 'num_qubits' qubits which can be applied as a group.
+   * @return A vector of fused gate objects. Each element is a set of gates
+   *   acting on a specific pair of qubits which can be applied as a group.
    */
   static std::vector<GateFused> FuseGates(
       unsigned num_qubits, const std::vector<Gate>& gates,

--- a/lib/gates_appl.h
+++ b/lib/gates_appl.h
@@ -41,7 +41,7 @@ inline void CalcMatrix2(
 /**
  * Calculates the 4x4 matrix for a two-qubit fused gate.
  * @param q0 Index of the first qubit affected by the fused gate.
- * @param q0 Index of the second qubit affected by the fused gate.
+ * @param q1 Index of the second qubit affected by the fused gate.
  * @param gates Component gates that make up the fused gate.
  * @param matrix Output matrix representing the entire fused gate.
  */

--- a/lib/gates_appl.h
+++ b/lib/gates_appl.h
@@ -22,7 +22,12 @@
 
 namespace qsim {
 
-// Calculate 2x2 fused gate matrix.
+/**
+ * Calculates the 2x2 matrix for a single-qubit fused gate.
+ * @param q0 Index of the qubit affected by the fused gate.
+ * @param gates Component gates that make up the fused gate.
+ * @param matrix Output matrix representing the entire fused gate.
+ */
 template <typename Gate, typename Array2>
 inline void CalcMatrix2(
     unsigned q0, const std::vector<Gate*>& gates, Array2& matrix) {
@@ -33,7 +38,13 @@ inline void CalcMatrix2(
   }
 }
 
-// Calculate 4x4 fused gate matrix.
+/**
+ * Calculates the 4x4 matrix for a two-qubit fused gate.
+ * @param q0 Index of the first qubit affected by the fused gate.
+ * @param q0 Index of the second qubit affected by the fused gate.
+ * @param gates Component gates that make up the fused gate.
+ * @param matrix Output matrix representing the entire fused gate.
+ */
 template <typename Gate, typename Array2>
 inline void CalcMatrix4(unsigned q0, unsigned q1,
                         const std::vector<Gate*>& gates, Array2& matrix) {
@@ -52,7 +63,13 @@ inline void CalcMatrix4(unsigned q0, unsigned q1,
   }
 }
 
-// Apply gate.
+/**
+ * Applies the given gate to the simulator state.
+ * @param simulator Simulator object. Provides specific implementations for
+ *   applying one- and two-qubit gates.
+ * @param gate The gate to be applied.
+ * @param state The state of the system, to be updated by this method.
+ */
 template <typename Gate, typename Simulator, typename State>
 inline void ApplyGate(
     const Simulator& simulator, const Gate& gate, State& state) {
@@ -69,7 +86,13 @@ inline void ApplyGate(
   }
 }
 
-// Apply fused gate.
+/**
+ * Applies the given fused gate to the simulator state.
+ * @param simulator Simulator object. Provides specific implementations for
+ *   applying one- and two-qubit gates.
+ * @param gate The gate to be applied.
+ * @param state The state of the system, to be updated by this method.
+ */
 template <typename Gate, typename Simulator, typename State>
 inline void ApplyFusedGate(
     const Simulator& simulator, const Gate& gate, State& state) {

--- a/lib/simulator_avx.h
+++ b/lib/simulator_avx.h
@@ -35,7 +35,12 @@ class SimulatorAVX final {
   SimulatorAVX(unsigned num_qubits, unsigned num_threads)
       : num_qubits_(num_qubits), num_threads_(num_threads) {}
 
-  // Apply a single-qubit gate.
+  /**
+   * Applies a single-qubit gate using AVX instructions.
+   * @param q0 Index of the qubit affected by this gate.
+   * @param matrix Matrix representation of the gate to be applied.
+   * @param state The state of the system, to be updated by this method.
+   */
   void ApplyGate1(unsigned q0, const fp_type* matrix, State& state) const {
     if (q0 > 2) {
       ApplyGate1H(q0, matrix, state);
@@ -44,8 +49,14 @@ class SimulatorAVX final {
     }
   }
 
-  // Apply a two-qubit gate.
-  // The order of qubits is inverse.
+  /**
+   * Applies a two-qubit gate using AVX instructions.
+   * Note that qubit order is inverted in this operation.
+   * @param q0 Index of the second qubit affected by this gate.
+   * @param q1 Index of the first qubit affected by this gate.
+   * @param matrix Matrix representation of the gate to be applied.
+   * @param state The state of the system, to be updated by this method.
+   */
   void ApplyGate2(
       unsigned q0, unsigned q1, const fp_type* matrix, State& state) const {
     // Assume q0 < q1.

--- a/lib/simulator_basic.h
+++ b/lib/simulator_basic.h
@@ -32,9 +32,13 @@ class SimulatorBasic final {
   SimulatorBasic(unsigned num_qubits, unsigned num_threads)
       : num_qubits_(num_qubits), num_threads_(num_threads) {}
 
-  // Apply a single-qubit gate.
-  // Perform a sparse matrix-vector multiplication.
-  // The inner loop (V_i = \sum_j M_ij V_j) is unrolled by hand.
+  /**
+   * Applies a single-qubit gate using sparse matrix-vector multiplication.
+   * The inner loop (V_i = \sum_j M_ij V_j) is unrolled by hand.
+   * @param q0 Index of the qubit affected by this gate.
+   * @param matrix Matrix representation of the gate to be applied.
+   * @param state The state of the system, to be updated by this method.
+   */
   void ApplyGate1(unsigned q0, const fp_type* matrix, State& state) const {
     uint64_t sizei = uint64_t{1} << num_qubits_;
     uint64_t sizek = uint64_t{1} << (q0 + 1);
@@ -67,10 +71,15 @@ class SimulatorBasic final {
                      sizek, mask0, mask1, matrix, rstate);
   }
 
-  // Apply a two-qubit gate.
-  // Perform a sparse matrix-vector multiplication.
-  // The inner loop (V_i = \sum_j M_ij V_j) is unrolled by hand.
-  // The order of qubits is inverse.
+  /**
+   * Apply a two-qubit gate using sparse matrix-vector multiplication.
+   * The inner loop (V_i = \sum_j M_ij V_j) is unrolled by hand.
+   * Note that qubit order is inverted in this operation.
+   * @param q0 Index of the second qubit affected by this gate.
+   * @param q1 Index of the first qubit affected by this gate.
+   * @param matrix Matrix representation of the gate to be applied.
+   * @param state The state of the system, to be updated by this method.
+   */
   void ApplyGate2(
       unsigned q0, unsigned q1, const fp_type* matrix, State& state) const {
     // Assume q0 < q1.


### PR DESCRIPTION
@sergeisakov, one question on this - in the `simulator` files, I wasn't able to make sense of this message on the two-qubit ApplyGate methods:
```
The order of qubits is inverse.
```
What effect does this have on the method? e.g. should the names `q0` and `q1` be swapped?