### PR TITLE
Add state sampler

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -21,6 +21,7 @@ cc_library(
         "seqfor.h",
         "simulator_avx.h",
         "simulator_basic.h",
+        "state_sampler.h",
         "statespace_avx.h",
         "statespace_basic.h",
         "statespace.h",

--- a/lib/state_sampler.h
+++ b/lib/state_sampler.h
@@ -12,47 +12,41 @@ class StateSampler {
  public:
   using State = typename StateSpace::State;
 
-  // Function to draw m samples from a StateSpace Object in
-  // O(2 ** num_qubits + m * log(m)) time.
-  // Samples are stored as bit encoded integers.
-  //
-  // This method takes a seed for the RNG. To choose a random seed,
-  // Use the other version of this method.
-  void SampleState(const StateSpace& statespace, const State& state,
-                   const int m, unsigned seed,
+  void SampleState(const StateSpace& state_space, const State& state,
+                   const unsigned num_samples, unsigned seed,
                    std::vector<uint64_t>* samples) {
-    if (m == 0) {
+    if (num_samples <= 0) {
       return;
     }
-    std::mt19937 mt(seed);
-    std::uniform_real_distribution<float> dist(0.0, 1.0);
+    samples->reserve(num_samples);
 
-    double cdf_so_far = 0.0;
-    std::vector<float> random_vals(m, 0.0);
-    samples->reserve(m);
-    for (int i = 0; i < m; i++) {
-      random_vals[i] = dist(mt);
+    double norm = 0;
+    for (uint64_t k = 0; k < state_space.Size(state); ++k) {
+      norm += std::norm(state_space.GetAmpl(state, k));
     }
-    std::sort(random_vals.begin(), random_vals.end());
 
-    int j = 0;
-    for (uint64_t i = 0; i < statespace.Size(state); i++) {
-      const std::complex<float> f_amp = statespace.GetAmpl(state, i);
-      const std::complex<double> d_amp = std::complex<double>(
-        static_cast<double>(f_amp.real()),
-        static_cast<double>(f_amp.imag()));
-      cdf_so_far += std::norm(d_amp);
-      while (random_vals[j] < cdf_so_far && j < m) {
-        samples->push_back(i);
-        j++;
+    std::mt19937_64 rgen(seed);
+    double rgen_norm = norm / std::mt19937_64::max();
+
+    std::vector<double> rs;
+    rs.reserve(num_samples);
+
+    for (unsigned i = 0; i < num_samples; ++i) {
+      rs.emplace_back(rgen() * rgen_norm);
+    }
+
+    std::sort(rs.begin(), rs.end());
+
+    unsigned m = 0;
+    double csum = 0;
+
+    for (uint64_t k = 0; k < state_space.Size(state); ++k) {
+      csum += std::norm(state_space.GetAmpl(state, k));
+
+      while (m < num_samples && rs[m] <= csum) {
+        samples->emplace_back(k);
+        ++m;
       }
-    }
-
-    // Safety measure in case of state norm underflow.
-    // Likely to not have huge impact.
-    while (j < m) {
-      samples->push_back(samples->at(samples->size() - 1));
-      j++;
     }
   }
 };

--- a/lib/state_sampler.h
+++ b/lib/state_sampler.h
@@ -12,13 +12,6 @@ class StateSampler {
  public:
   using State = typename StateSpace::State;
 
-  // Sample using a random seed.
-  void SampleState(const StateSpace& statespace, const State& state,
-                   const int m, std::vector<uint64_t>* samples) {
-    std::random_device device;
-    SampleState(statespace, state, m, device(), samples);
-  }
-
   // Function to draw m samples from a StateSpace Object in
   // O(2 ** num_qubits + m * log(m)) time.
   // Samples are stored as bit encoded integers.

--- a/lib/state_sampler.h
+++ b/lib/state_sampler.h
@@ -1,0 +1,59 @@
+#ifndef STATE_SAMPLER_H_
+#define STATE_SAMPLER_H_
+
+#include <complex>
+#include <memory>
+#include <random>
+
+namespace qsim {
+
+template <typename StateSpace>
+class StateSampler {
+ public:
+  using State = typename StateSpace::State;
+
+  // Function to draw m samples from a StateSpace Object in
+  // O(2 ** num_qubits + m * log(m)) time.
+  // Samples are stored as bit encoded integers.
+  void SampleState(const StateSpace statespace, const State& state, const int m,
+                std::vector<uint64_t>* samples) {
+    if (m == 0) {
+      return;
+    }
+    std::random_device device;
+    std::mt19937 mt(device());
+    std::uniform_real_distribution<float> dist(0.0, 1.0);
+
+    double cdf_so_far = 0.0;
+    std::vector<float> random_vals(m, 0.0);
+    samples->reserve(m);
+    for (int i = 0; i < m; i++) {
+      random_vals[i] = dist(mt);
+    }
+    std::sort(random_vals.begin(), random_vals.end());
+
+    int j = 0;
+    for (uint64_t i = 0; i < statespace.Size(state); i++) {
+      const std::complex<float> f_amp = statespace.GetAmpl(state, i);
+      const std::complex<double> d_amp = std::complex<double>(
+        static_cast<double>(f_amp.real()),
+        static_cast<double>(f_amp.imag()));
+      cdf_so_far += std::norm(d_amp);
+      while (random_vals[j] < cdf_so_far && j < m) {
+        samples->push_back(i);
+        j++;
+      }
+    }
+
+    // Safety measure in case of state norm underflow.
+    // Likely to not have huge impact.
+    while (j < m) {
+      samples->push_back(samples->at(samples->size() - 1));
+      j++;
+    }
+  }
+};
+
+}  // namespace qsim
+
+#endif  // STATE_SAMPLER_H_

--- a/lib/state_sampler.h
+++ b/lib/state_sampler.h
@@ -12,16 +12,26 @@ class StateSampler {
  public:
   using State = typename StateSpace::State;
 
+  // Sample using a random seed.
+  void SampleState(const StateSpace statespace, const State& state,
+                   const int m, std::vector<uint64_t>* samples) {
+    std::random_device device;
+    SampleState(statespace, state, m, device(), samples);
+  }
+
   // Function to draw m samples from a StateSpace Object in
   // O(2 ** num_qubits + m * log(m)) time.
   // Samples are stored as bit encoded integers.
-  void SampleState(const StateSpace statespace, const State& state, const int m,
-                std::vector<uint64_t>* samples) {
+  //
+  // This method takes a seed for the RNG. To choose a random seed,
+  // Use the other version of this method.
+  void SampleState(const StateSpace statespace, const State& state,
+                   const int m, unsigned seed,
+                   std::vector<uint64_t>* samples) {
     if (m == 0) {
       return;
     }
-    std::random_device device;
-    std::mt19937 mt(device());
+    std::mt19937 mt(seed);
     std::uniform_real_distribution<float> dist(0.0, 1.0);
 
     double cdf_so_far = 0.0;

--- a/lib/state_sampler.h
+++ b/lib/state_sampler.h
@@ -13,7 +13,7 @@ class StateSampler {
   using State = typename StateSpace::State;
 
   // Sample using a random seed.
-  void SampleState(const StateSpace statespace, const State& state,
+  void SampleState(const StateSpace& statespace, const State& state,
                    const int m, std::vector<uint64_t>* samples) {
     std::random_device device;
     SampleState(statespace, state, m, device(), samples);
@@ -25,7 +25,7 @@ class StateSampler {
   //
   // This method takes a seed for the RNG. To choose a random seed,
   // Use the other version of this method.
-  void SampleState(const StateSpace statespace, const State& state,
+  void SampleState(const StateSpace& statespace, const State& state,
                    const int m, unsigned seed,
                    std::vector<uint64_t>* samples) {
     if (m == 0) {

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -87,3 +87,12 @@ cc_test(
         "//lib:qsim_lib",
     ],
 )
+
+cc_test(
+    name = "state_sampler_test",
+    srcs = ["state_sampler_test.cc"],
+    deps = [
+        "@com_google_googletest//:gtest_main",
+        "//lib:qsim_lib",
+    ],
+)

--- a/tests/state_sampler_test.cc
+++ b/tests/state_sampler_test.cc
@@ -1,0 +1,56 @@
+#include <complex>
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "../lib/gates_appl.h"
+#include "../lib/gates_def.h"
+#include "../lib/parfor.h"
+#include "../lib/simulator_avx.h"
+#include "../lib/state_sampler.h"
+#include "../lib/statespace.h"
+
+namespace qsim {
+
+TEST(SampleStatesTest, BasicStateSampling) {
+  unsigned num_qubits = 2;
+  unsigned num_threads = 1;
+
+  using Simulator = SimulatorAVX<ParallelFor>;
+  using StateSpace = typename Simulator::StateSpace;
+  using StateSampler = StateSampler<StateSpace>;
+
+  StateSpace state_space(num_qubits, num_threads);
+  Simulator simulator(num_qubits, num_threads);
+  StateSampler sampler;
+
+  auto state = state_space.CreateState();
+  state_space.SetStateZero(state);
+
+  unsigned num_samples = 100;
+  std::vector<uint64_t> measurements;
+  sampler.SampleState(state_space, state, num_samples, &measurements);
+  // Prior to applying gates, only the zero state should be observed.
+  for (const auto& measured_state : measurements) {
+    EXPECT_EQ(measured_state, 0);
+  }
+
+  // Construct a Bell state.
+  auto h_0_gate = GateHd<float>::Create(0, 0);
+  auto cx_0_1_gate = GateCNot<float>::Create(1, 0, 1);
+  ApplyGate(simulator, h_0_gate, state);
+  ApplyGate(simulator, cx_0_1_gate, state);
+
+  // Only |00> (0) and |11> (3) should be observed.
+  std::set<uint64_t> allowed_results = {0, 3};
+  for (const auto& measured_state : measurements) {
+    EXPECT_TRUE(allowed_results.find(measured_state) != allowed_results.end());
+  }
+}
+
+}  // namespace qsim
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/state_sampler_test.cc
+++ b/tests/state_sampler_test.cc
@@ -11,6 +11,7 @@
 #include "../lib/statespace.h"
 
 namespace qsim {
+namespace {
 
 TEST(SampleStatesTest, ZeroState) {
   unsigned num_qubits = 2;
@@ -27,11 +28,10 @@ TEST(SampleStatesTest, ZeroState) {
   auto state = state_space.CreateState();
   state_space.SetStateZero(state);
 
-  unsigned num_samples = 100000;
+  unsigned num_samples = 1000;
   unsigned seed = 0;
 
   // Prior to applying gates, only the zero state should be observed.
-  std::vector<float> expected_prob = {1, 0, 0, 0};
   std::vector<float> counts = {0, 0, 0, 0};
   std::vector<uint64_t> measurements;
   sampler.SampleState(state_space, state, num_samples, seed, &measurements);
@@ -40,9 +40,10 @@ TEST(SampleStatesTest, ZeroState) {
     int val = measurements[i];
     counts[val] += 1.0;
   }
-  for (unsigned i = 0; i < counts.size(); ++i) {
-    EXPECT_NEAR(counts[i] / num_samples, expected_prob[i], 1e-2);
-  }
+  EXPECT_EQ(counts[0], num_samples);
+  EXPECT_EQ(counts[1], 0);
+  EXPECT_EQ(counts[2], 0);
+  EXPECT_EQ(counts[3], 0);
 }
 
 TEST(SampleStatesTest, BellState) {
@@ -107,11 +108,10 @@ TEST(SampleStatesTest, ArbitraryAmplitudes) {
   // Assign amplitudes for each state with a rotation in the complex plane.
   std::vector<float> expected_prob = {0.0,  0.05, 0.07, 0.1,
                                       0.25, 0.2,  0.18, 0.15};
-  float pi = 3.14159265358979323846;
   for (unsigned i = 0; i < expected_prob.size(); ++i) {
     float ampl = std::sqrt(expected_prob[i]);
-    float real = std::cos(i * pi / 4.0) * ampl;
-    float imag = std::sin(i * pi / 4.0) * ampl;
+    float real = std::cos(i * M_PI / 4.0) * ampl;
+    float imag = std::sin(i * M_PI / 4.0) * ampl;
     state_space.SetAmpl(state, i, std::complex<float>(real, imag));
   }
 
@@ -128,6 +128,7 @@ TEST(SampleStatesTest, ArbitraryAmplitudes) {
   }
 }
 
+}  // namespace
 }  // namespace qsim
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Adds a sampler for quantum states, (mostly) copied from TFQuantum. See #39.

Remaining work before review: add tests to match those in TFQ.