### PR TITLE
Apply patch for clean Centos 8 build.

### DIFF
--- a/lib/run_qsim.h
+++ b/lib/run_qsim.h
@@ -124,7 +124,7 @@ struct QSimRunner final {
   template <typename Circuit>
   static bool Run(const Parameter& param, unsigned maxtime,
                   const Circuit& circuit, typename Simulator::State& state) {
-    double t0, t1;
+    double t0=0.0, t1=0.0;
     if (param.verbosity > 0) {
       t0 = GetTime();
     }

--- a/lib/run_qsimh.h
+++ b/lib/run_qsimh.h
@@ -52,7 +52,7 @@ struct QSimHRunner final {
                   const std::vector<Gate>& gates,
                   const std::vector<uint64_t>& bitstrings,
                   std::vector<std::complex<fp_type>>& results) {
-    double t0;
+    double t0 = 0.0;
 
     if (param.verbosity > 0) {
       t0 = GetTime();

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,7 +6,7 @@ GMOCK_DIR = $(CURDIR)/googletest/googlemock
 
 CMAKE=cmake
 
-TESTFLAGS = -I$(GTEST_DIR)/include -L$(GTEST_DIR)/make/lib -lpthread -lgtest
+TESTFLAGS = -I$(GTEST_DIR)/include -L$(GTEST_DIR)/make/lib -mavx2 -mfma -fopenmp -lgtest
 
 .PHONY: all
 all: $(TARGETS)


### PR DESCRIPTION
Applied patch provided by @kkissell in #78.

In addition to fixing the Centos 8 build, this should silence warnings about uninitialized variables and allow tests to be run from the test directory (previously the `CXXFLAGS` from the top-level Makefile had to be inherited for this to build correctly).