### PR TITLE
Short circuit before index-out-of-bounds.

### DIFF
--- a/lib/statespace_avx.h
+++ b/lib/statespace_avx.h
@@ -198,7 +198,7 @@ struct StateSpaceAVX final : public StateSpace<ParallelFor, float> {
           auto re = v[k * 16 + j];
           auto im = v[k * 16 + 8 + j];
           csum += re * re + im * im;
-          while (rs[m] < csum && m < num_samples) {
+          while (m < num_samples && rs[m] < csum) {
             bitstrings.emplace_back(8 * k + j);
             ++m;
           }

--- a/lib/statespace_basic.h
+++ b/lib/statespace_basic.h
@@ -153,7 +153,7 @@ struct StateSpaceBasic final : public StateSpace<ParallelFor, FP> {
 
       for (uint64_t k = 0; k < size; k += 2) {
         csum += v[k] * v[k] + v[k + 1] * v[k + 1];
-        while (rs[m] < csum && m < num_samples) {
+        while (m < num_samples && rs[m] < csum) {
           bitstrings.emplace_back(k / 2);
           ++m;
         }


### PR DESCRIPTION
Fixes an address-sanitizer complaint - thanks to @MichaelBroughton for pointing this out. ASAN tests to be added at a later time.

This may also need to be applied to the SSE sampler.