### PR TITLE
Populate "extra" array element.

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -72,6 +72,8 @@ inline std::vector<DistrRealType> GenerateRandomValues(
   }
 
   std::sort(rs.begin(), rs.end());
+  // Populate the final element to prevent sanitizer errors.
+  rs.emplace_back(norm);
 
   return rs;
 }


### PR DESCRIPTION
This is required to prevent sanitizer errors. (The alternative, seen in #80, has a larger impact on runtime).