### PR TITLE
Conform to input type of cirq.SimulateAmplitudes interface

### DIFF
--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -20,6 +20,7 @@ from cirq import (
   protocols,
   sim,
   study,
+  value,
   SimulatesAmplitudes,
   SimulatesFinalState,
 )
@@ -64,7 +65,7 @@ class QSimSimulator(SimulatesAmplitudes, SimulatesFinalState):
   def compute_amplitudes_sweep(
       self,
       program: circuits.Circuit,
-      bitstrings: Sequence[str],
+      bitstrings: Sequence[int],
       params: study.Sweepable,
       qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
   ) -> Sequence[Sequence[complex]]:
@@ -89,8 +90,12 @@ class QSimSimulator(SimulatesAmplitudes, SimulatesFinalState):
     if not isinstance(program, qsimc.QSimCircuit):
       raise ValueError('{!r} is not a QSimCircuit'.format(program))
 
+    n_qubits = len(program.all_qubits())
+    bitstrings = [value.big_endian_int_to_bits(bitstring, bit_count=n_qubits)
+                  for bitstring in bitstrings]
     # qsim numbers qubits in reverse order from cirq
     bitstrings = [bs[::-1] for bs in bitstrings]
+    bitstrings = [''.join(str(b) for b in bs) for bs in bitstrings]
 
     options = {'i': '\n'.join(bitstrings)}
     options.update(self.qsim_options)

--- a/qsimcirq/qsimh_simulator.py
+++ b/qsimcirq/qsimh_simulator.py
@@ -14,7 +14,7 @@
 
 from typing import Union, Sequence
 
-from cirq import study, ops, protocols, circuits, SimulatesAmplitudes
+from cirq import study, ops, protocols, circuits, value,  SimulatesAmplitudes
 
 from qsimcirq import qsim
 import qsimcirq.qsim_circuit as qsimc
@@ -29,7 +29,7 @@ class QSimhSimulator(SimulatesAmplitudes):
   def compute_amplitudes_sweep(
       self,
       program: circuits.Circuit,
-      bitstrings: Sequence[str],
+      bitstrings: Sequence[int],
       params: study.Sweepable,
       qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
   ) -> Sequence[Sequence[complex]]:
@@ -37,8 +37,12 @@ class QSimhSimulator(SimulatesAmplitudes):
     if not isinstance(program, qsimc.QSimCircuit):
       raise ValueError('{!r} is not a QSimCircuit'.format(program))
 
+    n_qubits = len(program.all_qubits())
+    bitstrings = [value.big_endian_int_to_bits(bitstring, bit_count=n_qubits)
+                  for bitstring in bitstrings]
     # qsim numbers qubits in reverse order from cirq
     bitstrings = [bs[::-1] for bs in bitstrings]
+    bitstrings = [''.join(str(b) for b in bs) for bs in bitstrings]
 
     options = {'i': '\n'.join(bitstrings)}
     options.update(self.qsimh_options)

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -40,7 +40,7 @@ class MainTest(unittest.TestCase):
 
     qsimSim = qsimcirq.QSimSimulator()
     result = qsimSim.compute_amplitudes(
-        qsim_circuit, bitstrings=['0100', '1011'])
+        qsim_circuit, bitstrings=[0b0100, 0b1011])
     self.assertSequenceEqual(result, [0.5j, 0j])
 
   def test_cirq_qsim_simulate_fullstate(self):
@@ -122,7 +122,7 @@ class MainTest(unittest.TestCase):
     qsimh_options = {'k': [0], 'w': 0, 'p': 1, 'r': 1}
     qsimhSim = qsimcirq.QSimhSimulator(qsimh_options)
     result = qsimhSim.compute_amplitudes(
-        qsim_circuit, bitstrings=['00', '01', '10', '11'])
+        qsim_circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])
     self.assertSequenceEqual(result, [0j, 0j, (1 + 0j), 0j])
 
 


### PR DESCRIPTION
cirq.SimulatesAmplitudes takes its bitstrings as integers, not strings.