### PR TITLE
Remove --config=avx from CI tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,7 +27,7 @@ build:avx --copt -mavx2
 build:avx --copt -mfma
 
 # Build with SSE
-build:sse --copt -msse4.1
+build:sse --copt -msse4
 
 # Build without AVX or SSE
 build:basic

--- a/.bazelrc
+++ b/.bazelrc
@@ -27,7 +27,7 @@ build:avx --copt -mavx2
 build:avx --copt -mfma
 
 # Build with SSE
-build:sse --copt -msse4
+build:sse --copt -msse4.1
 
 # Build without AVX or SSE
 build:basic

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
 # Default build options
 build --copt -std=c++11
+build --copt -O3
 build --copt -D_GLIBCXX_USE_CXX11_ABI=0
 
 ##### Sanitizers (can be added to any build) #####
@@ -22,7 +23,6 @@ build:msan --linkopt -fsanitize=leak
 ##### Instruction set options (choose one) #####
 
 # Build with AVX2 + FMA
-build:avx --copt -O3
 build:avx --copt -mavx2
 build:avx --copt -mfma
 build:avx --copt -fopenmp
@@ -32,6 +32,8 @@ build:avx --linkopt -lgomp
 build:sse --copt -msse2
 build:sse --copt -msse3
 build:sse --copt -msse4
+build:sse --copt -fopenmp
+build:sse --linkopt -lgomp
 
 # Build without AVX or SSE - currently unsupported
 build:basic

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,5 @@
 # Default build options
 build --copt -std=c++11
-build --copt -O3
 build --copt -D_GLIBCXX_USE_CXX11_ABI=0
 
 ##### Sanitizers (can be added to any build) #####
@@ -23,20 +22,19 @@ build:msan --linkopt -fsanitize=leak
 ##### Instruction set options (choose one) #####
 
 # Build with AVX2 + FMA
+build:avx --copt -O3
 build:avx --copt -mavx2
 build:avx --copt -mfma
-build:avx --copt -fopenmp
-build:avx --linkopt -lgomp
 
-# Build with SSE - currently unsupported
-build:sse --copt -msse2
-build:sse --copt -msse3
+# Build with SSE
 build:sse --copt -msse4
-build:sse --copt -fopenmp
-build:sse --linkopt -lgomp
 
-# Build without AVX or SSE - currently unsupported
+# Build without AVX or SSE
 build:basic
+
+# Build with OpenMP
+build:openmp --copt -fopenmp
+build:openmp --linkopt -lgomp
 
 # Test flags
 test --test_output=errors

--- a/.bazelrc
+++ b/.bazelrc
@@ -27,10 +27,11 @@ build:avx --copt -mavx2
 build:avx --copt -mfma
 
 # Build with SSE
+build:sse --copt -O3
 build:sse --copt -msse4
 
 # Build without AVX or SSE
-build:basic
+build:basic --copt -O3
 
 # Build with OpenMP
 build:openmp --copt -fopenmp

--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -30,6 +30,6 @@ jobs:
           wget https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel_0.26.0-linux-x86_64.deb
           sudo dpkg -i bazel_0.26.0-linux-x86_64.deb
       - name: Run C++ tests
-        run: bazel test --config=avx tests:all
+        run: bazel test tests:all
       - name: Run sample simulation
-        run: bazel run --config=avx apps:qsim_base -- -c circuits/circuit_q24
+        run: bazel run apps:qsim_base -- -c circuits/circuit_q24

--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Run C++ tests
         run: bazel test tests:all
       - name: Run sample simulation
-        run: bazel run apps:qsim_base -- -c circuits/circuit_q24
+        run: bazel run --config=avx --config=openmp apps:qsim_base -- -c circuits/circuit_q24

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,3 +1,9 @@
+# Options for testing different simulator types.
+avx_copts = ['-mavx2', '-mfma']
+sse_copts = ['-msse4']
+omp_copts = ['-fopenmp']
+omp_linkopts = ['-lgomp']
+
 cc_test(
     name = "bitstring_test",
     srcs = ["bitstring_test.cc"],
@@ -41,6 +47,8 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "//lib:qsim_lib",
     ],
+    copts = avx_copts + omp_copts,
+    linkopts = omp_linkopts,
 )
 
 cc_test(
@@ -59,6 +67,8 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "//lib:qsim_lib",
     ],
+    copts = avx_copts + omp_copts,
+    linkopts = omp_linkopts,
 )
 
 cc_test(
@@ -68,6 +78,8 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "//lib:qsim_lib",
     ],
+    copts = avx_copts + omp_copts,
+    linkopts = omp_linkopts,
 )
 
 cc_library(
@@ -88,6 +100,8 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "//lib:qsim_lib",
     ],
+    copts = avx_copts + omp_copts,
+    linkopts = omp_linkopts,
 )
 
 cc_test(
@@ -98,6 +112,8 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "//lib:qsim_lib",
     ],
+    copts = omp_copts,
+    linkopts = omp_linkopts,
 )
 
 cc_test(
@@ -108,6 +124,8 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "//lib:qsim_lib",
     ],
+    copts = sse_copts + omp_copts,
+    linkopts = omp_linkopts,
 )
 
 cc_library(
@@ -128,6 +146,8 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "//lib:qsim_lib",
     ],
+    copts = avx_copts + omp_copts,
+    linkopts = omp_linkopts,
 )
 
 cc_test(
@@ -138,6 +158,8 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "//lib:qsim_lib",
     ],
+    copts = omp_copts,
+    linkopts = omp_linkopts,
 )
 
 cc_test(
@@ -148,4 +170,6 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "//lib:qsim_lib",
     ],
+    copts = sse_copts + omp_copts,
+    linkopts = omp_linkopts,
 )


### PR DESCRIPTION
Per-config testing is covered by the different `simulator_*_test` files.

Fixes #92.