### PR TITLE
Fix setting a uniform state

### DIFF
--- a/lib/statespace_avx.h
+++ b/lib/statespace_avx.h
@@ -60,7 +60,21 @@ struct StateSpaceAVX : public StateSpace<ParallelFor, float> {
     uint64_t size = uint64_t{1} << num_qubits_;
 
     __m256 val0 = _mm256_setzero_ps();
-    __m256 valu = _mm256_set1_ps(fp_type{1} / std::sqrt(size));
+    __m256 valu;
+
+    fp_type v = double{1} / std::sqrt(size);
+
+    switch (num_qubits_) {
+    case 1:
+      valu = _mm256_set_ps(0, 0, 0, 0, 0, 0, v, v);
+      break;
+    case 2:
+      valu = _mm256_set_ps(0, 0, 0, 0, v, v, v, v);
+      break;
+    default:
+      valu = _mm256_set1_ps(v);
+      break;
+    }
 
     auto f = [](unsigned n, unsigned m, uint64_t i,
                 const __m256& val0, const __m256& valu, State& state) {

--- a/lib/statespace_basic.h
+++ b/lib/statespace_basic.h
@@ -57,7 +57,7 @@ struct StateSpaceBasic : public StateSpace<ParallelFor, FP> {
     };
 
     ParallelFor::Run(
-        Base::num_threads_, Base::size_, f, state, val, state);
+        Base::num_threads_, Base::size_, f, val, state);
   }
 
   // |0> state.

--- a/lib/statespace_sse.h
+++ b/lib/statespace_sse.h
@@ -60,7 +60,15 @@ struct StateSpaceSSE : public StateSpace<ParallelFor, float> {
     uint64_t size = uint64_t{1} << num_qubits_;
 
     __m128 val0 = _mm_setzero_ps();
-    __m128 valu = _mm_set1_ps(fp_type{1} / std::sqrt(size));
+    __m128 valu;
+
+    fp_type v = double{1} / std::sqrt(size);
+
+    if (num_qubits_ == 1) {
+      valu = _mm_set_ps(0, 0, v, v);
+    } else {
+      valu = _mm_set1_ps(v);
+    }
 
     auto f = [](unsigned n, unsigned m, uint64_t i,
                 const __m128& val0, const __m128& valu, State& state) {

--- a/tests/statespace_avx_test.cc
+++ b/tests/statespace_avx_test.cc
@@ -22,6 +22,10 @@
 
 namespace qsim {
 
+TEST(StateSpaceAVXTest, NormSmall) {
+  TestNormSmall<StateSpaceAVX<ParallelFor>>();
+}
+
 TEST(StateSpaceAVXTest, NormAndInnerProductSmall) {
   TestNormAndInnerProductSmall<StateSpaceAVX<ParallelFor>>();
 }

--- a/tests/statespace_basic_test.cc
+++ b/tests/statespace_basic_test.cc
@@ -22,6 +22,10 @@
 
 namespace qsim {
 
+TEST(StateSpaceBasicTest, NormSmall) {
+  TestNormSmall<StateSpaceBasic<ParallelFor, float>>();
+}
+
 TEST(StateSpaceBasicTest, NormAndInnerProductSmall) {
   TestNormAndInnerProductSmall<StateSpaceBasic<ParallelFor, float>>();
 }

--- a/tests/statespace_sse_test.cc
+++ b/tests/statespace_sse_test.cc
@@ -22,6 +22,10 @@
 
 namespace qsim {
 
+TEST(StateSpaceSSETest, NormSmall) {
+  TestNormSmall<StateSpaceSSE<ParallelFor>>();
+}
+
 TEST(StateSpaceSSETest, NormAndInnerProductSmall) {
   TestNormAndInnerProductSmall<StateSpaceSSE<ParallelFor>>();
 }

--- a/tests/statespace_testfixture.h
+++ b/tests/statespace_testfixture.h
@@ -352,6 +352,35 @@ R"(20
 )";
 
 template <typename StateSpace>
+void TestNormSmall() {
+  using State = typename StateSpace::State;
+
+  constexpr unsigned num_qubits1 = 1;
+  StateSpace state_space1(num_qubits1, 1);
+  State state1 = state_space1.CreateState();
+  state_space1.SetStateZero(state1);
+  EXPECT_NEAR(state_space1.Norm(state1), 1, 1e-6);
+  state_space1.SetStateUniform(state1);
+  EXPECT_NEAR(state_space1.Norm(state1), 1, 1e-6);
+
+  constexpr unsigned num_qubits2 = 2;
+  StateSpace state_space2(num_qubits2, 1);
+  State state2 = state_space2.CreateState();
+  state_space2.SetStateZero(state2);
+  EXPECT_NEAR(state_space2.Norm(state2), 1, 1e-6);
+  state_space2.SetStateUniform(state2);
+  EXPECT_NEAR(state_space2.Norm(state2), 1, 1e-6);
+
+  constexpr unsigned num_qubits3 = 3;
+  StateSpace state_space3(num_qubits3, 1);
+  State state3 = state_space3.CreateState();
+  state_space3.SetStateZero(state3);
+  EXPECT_NEAR(state_space3.Norm(state3), 1, 1e-6);
+  state_space3.SetStateUniform(state3);
+  EXPECT_NEAR(state_space3.Norm(state3), 1, 1e-6);
+}
+
+template <typename StateSpace>
 void TestNormAndInnerProductSmall() {
   constexpr unsigned num_qubits = 2;
   constexpr uint64_t size = uint64_t{1} << num_qubits;


### PR DESCRIPTION
This PR fixes SetStateUniform functions for one- and two-qubit circuits and a typo in statespace_basic.h.