### PR TITLE
Clean up tests.

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -10,7 +10,6 @@ cc_test(
     deps = [
         "@com_google_googletest//:gtest_main",
         "//lib:bitstring",
-        "//lib:io",
     ],
 )
 
@@ -21,7 +20,6 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "//lib:circuit_qsim_parser",
         "//lib:gates_qsim",
-        "//lib:io",
     ],
 )
 

--- a/tests/bitstring_test.cc
+++ b/tests/bitstring_test.cc
@@ -17,9 +17,13 @@
 #include "gtest/gtest.h"
 
 #include "../lib/bitstring.h"
-#include "../lib/io.h"
 
 namespace qsim {
+
+struct IO {
+  static void errorf(const char* format, ...) {}
+  static void messagef(const char* format, ...) {}
+};
 
 constexpr char provider[] = "bitstring_test";
 
@@ -79,8 +83,6 @@ R"(1000000
   EXPECT_EQ(BitstringsFromStream<IO>(7, provider, ss, bitstrings), false);
   EXPECT_EQ(bitstrings.size(), 0);
 }
-
-// The following tests print error messages if passed. This is okay.
 
 }  // namespace qsim
 

--- a/tests/circuit_qsim_parser_test.cc
+++ b/tests/circuit_qsim_parser_test.cc
@@ -18,9 +18,13 @@
 
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/gates_qsim.h"
-#include "../lib/io.h"
 
 namespace qsim {
+
+struct IO {
+  static void errorf(const char* format, ...) {}
+  static void messagef(const char* format, ...) {}
+};
 
 constexpr char provider[] = "circuit_qsim_parser_test";
 
@@ -64,8 +68,6 @@ R"(2
   EXPECT_EQ(circuit.num_qubits, 2);
   EXPECT_EQ(circuit.gates.size(), 10);
 }
-
-// The following tests print error messages if passed. This is okay.
 
 TEST(CircuitQsimParserTest, InvalidGateName) {
   constexpr char invalid_circuit[] =

--- a/tests/gates_qsim_test.cc
+++ b/tests/gates_qsim_test.cc
@@ -20,7 +20,7 @@
 
 namespace qsim {
 
-TEST(GatesDefTest, GateRX) {
+TEST(GatesQsimTest, GateRX) {
   float phi = 0.42;
   unsigned time = 7;
   unsigned qubit = 11;
@@ -44,7 +44,7 @@ TEST(GatesDefTest, GateRX) {
   EXPECT_FLOAT_EQ(gate.matrix[7], 0);
 }
 
-TEST(GatesDefTest, GateRY) {
+TEST(GatesQsimTest, GateRY) {
   float phi = 0.42;
   unsigned time = 7;
   unsigned qubit = 11;
@@ -68,7 +68,7 @@ TEST(GatesDefTest, GateRY) {
   EXPECT_FLOAT_EQ(gate.matrix[7], 0);
 }
 
-TEST(GatesDefTest, GateRZ) {
+TEST(GatesQsimTest, GateRZ) {
   float phi = 0.42;
   unsigned time = 7;
   unsigned qubit = 11;
@@ -92,7 +92,7 @@ TEST(GatesDefTest, GateRZ) {
   EXPECT_FLOAT_EQ(gate.matrix[7], -s);
 }
 
-TEST(GatesDefTest, GateRXY) {
+TEST(GatesQsimTest, GateRXY) {
   float theta = 0.84;
   float phi = 0.42;
   unsigned time = 7;
@@ -119,7 +119,7 @@ TEST(GatesDefTest, GateRXY) {
   EXPECT_FLOAT_EQ(gate.matrix[7], 0);
 }
 
-TEST(GatesDefTest, GateFS) {
+TEST(GatesQsimTest, GateFS) {
   float theta = 0.84;
   float phi = 0.42;
   unsigned time = 7;
@@ -240,7 +240,7 @@ TEST(GatesDefTest, GateFS) {
   EXPECT_NEAR(schmidt_decomp[3][1][7], 0.16863659, 1e-6);
 }
 
-TEST(GatesDefTest, GateCP) {
+TEST(GatesQsimTest, GateCP) {
   float phi = 0.42;
   unsigned time = 7;
   unsigned qubit0 = 11;

--- a/tests/hybrid_test.cc
+++ b/tests/hybrid_test.cc
@@ -31,7 +31,7 @@ namespace qsim {
 
 constexpr char provider[] = "hybrid_test";
 
-TEST(QSimRunner, Hybrid2) {
+TEST(HybridTest, Hybrid2) {
   constexpr char circuit_string[] =
 R"(2
 0 h 0
@@ -168,7 +168,7 @@ R"(2
   param.num_root_gatexs = 6;
 }
 
-TEST(QSimRunner, Hybrid4) {
+TEST(HybridTest, Hybrid4) {
   constexpr char circuit_string[] =
 R"(4
 0 h 0

--- a/tests/run_qsim_test.cc
+++ b/tests/run_qsim_test.cc
@@ -62,7 +62,7 @@ R"(4
 10 h 3
 )";
 
-TEST(QSimRunner, RunQSim1) {
+TEST(RunQSimTest, QSimRunner1) {
   std::stringstream ss(circuit_string);
   Circuit<GateQSim<float>> circuit;
 
@@ -99,7 +99,7 @@ TEST(QSimRunner, RunQSim1) {
   EXPECT_NEAR(entropy, 2.2192848, 1e-6);
 }
 
-TEST(QSimRunner, RunQSim2) {
+TEST(RunQSimTest, QSimRunner2) {
   std::stringstream ss(circuit_string);
   Circuit<GateQSim<float>> circuit;
 

--- a/tests/run_qsimh_test.cc
+++ b/tests/run_qsimh_test.cc
@@ -98,7 +98,7 @@ R"(4
 21 h 3
 )";
 
-TEST(QSimRunner, RunQSimH) {
+TEST(RunQSimHTest, QSimHRunner) {
   std::stringstream ss(circuit_string);
   Circuit<GateQSim<float>> circuit;
 


### PR DESCRIPTION
This PR also silences error messages when invalid bitstrings and circuits are tested.