### PR TITLE
Add TF reference to WORKSPACE.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,3 +6,14 @@ http_archive(
     strip_prefix = "googletest-b6cd405286ed8635ece71c72f118e659f4ade3fb",
     url = "https://github.com/google/googletest/archive/b6cd405286ed8635ece71c72f118e659f4ade3fb.zip",
 )
+
+# Required for testing compatibility with TF Quantum:
+# https://github.com/tensorflow/quantum
+http_archive(
+    name = "org_tensorflow",
+    sha256 = "e82f3b94d863e223881678406faa5071b895e1ff928ba18578d2adbbc6b42a4c",
+    strip_prefix = "tensorflow-2.1.0",
+    urls = [
+        "https://github.com/tensorflow/tensorflow/archive/v2.1.0.zip",
+    ],
+)


### PR DESCRIPTION
Compare with TFQ's [WORKSPACE file](https://github.com/tensorflow/quantum/blob/master/WORKSPACE). This change is required for testing cross-platform compatibility at the level required by TFQ.