### PR TITLE
Update to latest Cirq release.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements for the python 3 version of cirq.
 
-cirq==0.7.0
+cirq==0.8.0
 numpy~=1.16
 typing_extensions
 


### PR DESCRIPTION
If and when Cirq commits to no further breaking changes, we'll be able to remove the version specifier on this requirement.