### PR TITLE
Remove extra linking requirements.

### DIFF
--- a/apps/qsim_von_neumann.cc
+++ b/apps/qsim_von_neumann.cc
@@ -15,7 +15,6 @@
 #include <unistd.h>
 
 #include <algorithm>
-#include <cmath>
 #include <complex>
 #include <functional>
 #include <limits>

--- a/apps/qsim_von_neumann.cc
+++ b/apps/qsim_von_neumann.cc
@@ -15,6 +15,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <cmath>
 #include <complex>
 #include <functional>
 #include <limits>

--- a/lib/util.h
+++ b/lib/util.h
@@ -15,9 +15,8 @@
 #ifndef UTIL_H_
 #define UTIL_H_
 
-#include <time.h>
-
 #include <algorithm>
+#include <chrono>
 #include <random>
 #include <sstream>
 #include <string>
@@ -53,9 +52,10 @@ inline void SplitString(
 }
 
 inline double GetTime() {
-  struct timespec time;
-  clock_gettime(CLOCK_MONOTONIC, &time);
-  return time.tv_sec + 1e-9 * time.tv_nsec;
+  using namespace std::chrono;
+  steady_clock::duration since_epoch = steady_clock::now().time_since_epoch();
+  return double(since_epoch.count() * steady_clock::period::num)
+                                    / steady_clock::period::den;
 }
 
 template <typename DistrRealType>


### PR DESCRIPTION
Prior to this PR, additional static links `-lm` and `-lrt` were required to build qsim in the TFQ-compatible environment. This PR should remove these requirements.