### PR TITLE
Set qsimcirq version to 0.0.4 (dev branch)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ description = ('Schrödinger and Schrödinger-Feynman simulators for quantum cir
 # README file as long_description.
 long_description = open('README.md', encoding='utf-8').read()
 
-__version__ = '0.0.3'
+__version__ = '0.0.4.dev202006030832'
 
 setup(
     name='qsimcirq',


### PR DESCRIPTION
Trailing digits in the dev version have the format `YYYYMMDDhhmm`:
`Y: year, M: month, D: day, h: hour (Pacific time), m: minute`

This will only appear if installing directly from Github; version will be set to non-dev value prior to actual release.