### PR TITLE
Check all config flags in CI tests.

### DIFF
--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -20,6 +20,12 @@ jobs:
   test:
     name: Test with Bazel
     runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        # Hardware optimizers.
+        hardware_opt: [avx,sse,basic]
+        # Optimizers for parallelism.
+        parallel_opt: [openmp,basic]
 
     steps:
       - uses: actions/checkout@v2
@@ -30,6 +36,11 @@ jobs:
           wget https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel_0.26.0-linux-x86_64.deb
           sudo dpkg -i bazel_0.26.0-linux-x86_64.deb
       - name: Run C++ tests
-        run: bazel test tests:all
+        run: |
+          bazel test --config=${{ matrix.hardware_opt }} \
+          --config=${{ matrix.parallel_opt }} tests:all
       - name: Run sample simulation
-        run: bazel run --config=avx --config=openmp apps:qsim_base -- -c circuits/circuit_q24
+        run: |
+          bazel run --config=${{ matrix.hardware_opt }} \
+          --config=${{ matrix.parallel_opt }} apps:qsim_base \
+          -- -c circuits/circuit_q24

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -1,16 +1,41 @@
 # Building with Bazel
 
-<!-- TODO: expand to explain other Bazel build options. -->
 qsim provides [Bazel](https://github.com/bazelbuild/bazel) build rules for its
 applications and tests. To build and run all tests using Bazel, run the
 following command:
 ```
-bazel test --config=avx tests:all
+# AVX and OpenMP are recommended for best performance.
+# See "Build configs" section below for more information.
+bazel test --config=avx --config=openmp tests:all
 ```
 
 To run a sample simulation, use the command below. Note that this command
 requires the circuit file to be specified both on the command line and in the
 `data` field of the `qsim_base` BUILD rule.
 ```
-bazel run --config=avx apps:qsim_base -- -c circuits/circuit_q24
+bazel run --config=avx --config=openmp apps:qsim_base -- -c circuits/circuit_q24
 ```
+
+## Build configs
+
+Depending on the optimizers available on your machine, different config flags
+(such as `--config=avx`, above) can be set to control which optimizers are
+included in a given build or test run.
+
+Vector arithmetic optimizers (pick one at most):
+```
+# Use AVX instructions for vector arithmetic.
+--config=avx
+
+# Use SSE instructions for vector arithmetic.
+--config=sse
+```
+
+Parallelism optimizers (pick one at most):
+```
+# Use OpenMP to run operations in parallel when possible.
+--config=avx
+```
+
+We also provide `--config=basic`. This flag does not affect the build or test,
+but can be useful in scripts (e.g. where `--config=" "` is not valid).

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -144,7 +144,7 @@ cc_library(
     hdrs = ["seqfor.h"],
 )
 
-# All three state-vector simulators with multiplexer
+# Both parallelism control paths with multiplexer
 cc_library(
     name = "formux",
     hdrs = ["formux.h"],

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,8 +1,6 @@
 # Options for testing different simulator types.
 avx_copts = ['-mavx2', '-mfma']
 sse_copts = ['-msse4']
-omp_copts = ['-fopenmp']
-omp_linkopts = ['-lgomp']
 
 windows_copts = [
     "/arch:AVX",
@@ -92,13 +90,12 @@ cc_test(
         "//lib:gates_qsim",
         "//lib:hybrid",
         "//lib:io",
-        "//lib:simulator_avx",
+        "//lib:simulator",
     ],
     copts = select({
         ":windows": windows_copts,
-        "//conditions:default": avx_copts + omp_copts,
+        "//conditions:default": [],
     }),
-    linkopts = omp_linkopts,
 )
 
 cc_test(
@@ -124,9 +121,8 @@ cc_test(
     ],
     copts = select({
         ":windows": windows_copts,
-        "//conditions:default": avx_copts + omp_copts,
+        "//conditions:default": [],
     }),
-    linkopts = omp_linkopts,
 )
 
 cc_test(
@@ -139,9 +135,8 @@ cc_test(
     ],
     copts = select({
         ":windows": windows_copts,
-        "//conditions:default": avx_copts + omp_copts,
+        "//conditions:default": [],
     }),
-    linkopts = omp_linkopts,
 )
 
 cc_library(
@@ -171,9 +166,8 @@ cc_test(
     ],
     copts = select({
         ":windows": windows_copts,
-        "//conditions:default": avx_copts + omp_copts,
+        "//conditions:default": avx_copts,
     }),
-    linkopts = omp_linkopts,
 )
 
 cc_test(
@@ -187,9 +181,8 @@ cc_test(
     ],
     copts = select({
         ":windows": windows_copts,
-        "//conditions:default": omp_copts,
+        "//conditions:default": [],
     }),
-    linkopts = omp_linkopts,
 )
 
 cc_test(
@@ -203,9 +196,8 @@ cc_test(
     ],
     copts = select({
         ":windows": windows_copts,
-        "//conditions:default": sse_copts + omp_copts,
+        "//conditions:default": sse_copts,
     }),
-    linkopts = omp_linkopts,
 )
 
 cc_library(
@@ -238,9 +230,8 @@ cc_test(
     ],
     copts = select({
         ":windows": windows_copts,
-        "//conditions:default": avx_copts + omp_copts,
+        "//conditions:default": avx_copts,
     }),
-    linkopts = omp_linkopts,
 )
 
 cc_test(
@@ -255,9 +246,8 @@ cc_test(
     ],
     copts = select({
         ":windows": windows_copts,
-        "//conditions:default": omp_copts,
+        "//conditions:default": [],
     }),
-    linkopts = omp_linkopts,
 )
 
 cc_test(
@@ -272,7 +262,6 @@ cc_test(
     ],
     copts = select({
         ":windows": windows_copts,
-        "//conditions:default": sse_copts + omp_copts,
+        "//conditions:default": sse_copts,
     }),
-    linkopts = omp_linkopts,
 )

--- a/tests/hybrid_test.cc
+++ b/tests/hybrid_test.cc
@@ -25,7 +25,7 @@
 #include "../lib/gates_qsim.h"
 #include "../lib/hybrid.h"
 #include "../lib/io.h"
-#include "../lib/simulator_avx.h"
+#include "../lib/simmux.h"
 
 namespace qsim {
 
@@ -66,7 +66,7 @@ R"(2
   EXPECT_EQ(circuit.num_qubits, 2);
   EXPECT_EQ(circuit.gates.size(), 23);
 
-  using Simulator = SimulatorAVX<For>;
+  using Simulator = Simulator<For>;
   using HybridSimulator = HybridSimulator<IO, GateQSim<float>, BasicGateFuser,
                                           Simulator, For>;
   using Fuser = HybridSimulator::Fuser;
@@ -245,7 +245,7 @@ R"(4
   EXPECT_EQ(circuit.num_qubits, 4);
   EXPECT_EQ(circuit.gates.size(), 63);
 
-  using Simulator = SimulatorAVX<For>;
+  using Simulator = Simulator<For>;
   using HybridSimulator = HybridSimulator<IO, GateQSim<float>, BasicGateFuser,
                                           Simulator, For>;
   using Fuser = HybridSimulator::Fuser;

--- a/tests/run_qsim_test.cc
+++ b/tests/run_qsim_test.cc
@@ -27,7 +27,7 @@
 #include "../lib/gates_qsim.h"
 #include "../lib/io.h"
 #include "../lib/run_qsim.h"
-#include "../lib/simulator_avx.h"
+#include "../lib/simmux.h"
 
 namespace qsim {
 
@@ -72,7 +72,7 @@ TEST(RunQSimTest, QSimRunner1) {
   EXPECT_EQ(circuit.num_qubits, 4);
   EXPECT_EQ(circuit.gates.size(), 27);
 
-  using Simulator = SimulatorAVX<For>;
+  using Simulator = Simulator<For>;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
   using Runner = QSimRunner<IO, BasicGateFuser<GateQSim<float>>, Simulator>;
@@ -109,7 +109,7 @@ TEST(RunQSimTest, QSimRunner2) {
   EXPECT_EQ(circuit.num_qubits, 4);
   EXPECT_EQ(circuit.gates.size(), 27);
 
-  using Simulator = SimulatorAVX<For>;
+  using Simulator = Simulator<For>;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
   using Runner = QSimRunner<IO, BasicGateFuser<GateQSim<float>>, Simulator>;
@@ -144,7 +144,7 @@ TEST(RunQSimTest, CirqGates) {
   auto circuit = CirqCircuit1::GetCircuit<float>();
   const auto& expected_results = CirqCircuit1::expected_results;
 
-  using Simulator = SimulatorAVX<For>;
+  using Simulator = Simulator<For>;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
   using Runner = QSimRunner<IO, BasicGateFuser<Cirq::GateCirq<float>>,

--- a/tests/run_qsimh_test.cc
+++ b/tests/run_qsimh_test.cc
@@ -27,7 +27,7 @@
 #include "../lib/gates_qsim.h"
 #include "../lib/io.h"
 #include "../lib/run_qsimh.h"
-#include "../lib/simulator_avx.h"
+#include "../lib/simmux.h"
 
 namespace qsim {
 
@@ -108,7 +108,7 @@ TEST(RunQSimHTest, QSimHRunner) {
   EXPECT_EQ(circuit.num_qubits, 4);
   EXPECT_EQ(circuit.gates.size(), 63);
 
-  using Simulator = SimulatorAVX<For>;
+  using Simulator = Simulator<For>;
   using HybridSimulator = HybridSimulator<IO, GateQSim<float>, BasicGateFuser,
                                           Simulator, For>;
   using Runner = QSimHRunner<IO, HybridSimulator>;
@@ -165,7 +165,7 @@ TEST(RunQSimHTest, CirqGates) {
   auto circuit = CirqCircuit1::GetCircuit<float>();
   const auto& expected_results = CirqCircuit1::expected_results;
 
-  using Simulator = SimulatorAVX<For>;
+  using Simulator = Simulator<For>;
   using HybridSimulator = HybridSimulator<IO, Cirq::GateCirq<float>,
                                           BasicGateFuser, Simulator, For>;
   using Runner = QSimHRunner<IO, HybridSimulator>;


### PR DESCRIPTION
Fixes #124.

This ensures that all config flag combinations are tested in the CI tests, and allows a couple of tests (hybrid_test, run_qsim[h]_test) to run in SSE/unoptimized modes.

I think it may be possible to condense the simulator and statespace tests into a single file like this, but since all cases are currently covered I think we can consider that for a future PR.