### PR TITLE
Upgrade to v0.1.0 and document release.

### DIFF
--- a/docs/release-qsimcirq.md
+++ b/docs/release-qsimcirq.md
@@ -1,0 +1,30 @@
+# Release process
+
+The qsimcirq release is maintained by Google contributors through a dedicated
+Kokoro build (a Google-internal variant of Jenkins). If you are a Google
+contributor and need to cut a release, check with @95-martin-orion.
+
+<!-- TODO(95-martin-orion): redirect to internal docs when available -->
+
+## Version semantics
+
+Version numbering follows the semantic versioning guidelines at
+[semver.org](https://semver.org/), whose summary is copied below:
+
+```
+Given a version number MAJOR.MINOR.PATCH, increment the:
+
+  1. MAJOR version when you make incompatible API changes,
+  2. MINOR version when you add functionality in a backwards compatible manner, and
+  3. PATCH version when you make backwards compatible bug fixes.
+
+Additional labels for pre-release and build metadata are available
+as extensions to the MAJOR.MINOR.PATCH format.
+```
+
+Note that this behavior is altered for MAJOR version zero (0.y.z):
+
+```
+Major version zero (0.y.z) is for initial development. Anything MAY change at
+any time. The public API SHOULD NOT be considered stable.
+```

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ description = ('Schrödinger and Schrödinger-Feynman simulators for quantum cir
 # README file as long_description.
 long_description = open('README.md', encoding='utf-8').read()
 
-__version__ = '0.0.4.dev202006030832'
+__version__ = '0.1.0'
 
 setup(
     name='qsimcirq',


### PR DESCRIPTION
I chose to update the minor version number in this PR to reflect the new release process and versioning semantics; future PRs should continue to follow the major-version-zero version numbering outlined here.

Following this PR, I will tag the current repo state as `qsim v0.1.0` and release qsimcirq to pypi.