### PR TITLE
Always run Bazel tests.

### DIFF
--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -6,14 +6,7 @@ on:
     branches:
       - master
 
-  # Only run tests for PRs affecting C++ code.
   pull_request:
-    paths-ignore:
-    - '**.md'
-    - 'install/**'
-    - 'pybind_interface/**'
-    - 'qsimcirq/**'
-    - 'qsimcirq_tests/**'
 
 jobs:
   # Run tests with Bazel v0.26.


### PR DESCRIPTION
As discussed in #135. Revisiting #69 (migrating all tests to Bazel) might make sense in this context.