### PR TITLE
Support matrix gates and decomposition.

### DIFF
--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -275,7 +275,7 @@ void add_gate(const qsim::Cirq::GateKind gate_kind, const unsigned time,
         Cirq::FSimGate<float>::Create(time, qubits[0], qubits[1],
                                       params.at("theta"), params.at("phi")));
       break;
-    // TODO: support translating matrix gates.
+    // Matrix gates are handled in the add_matrix methods below.
     default:
       throw std::invalid_argument("GateKind not supported.");
   }

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -281,6 +281,20 @@ void add_gate(const qsim::Cirq::GateKind gate_kind, const unsigned time,
   }
 }
 
+// The Matrix(1|2)q objects are typedefs for Python-compatible objects.
+void add_matrix1(const unsigned time, const std::vector<unsigned>& qubits,
+                 const qsim::Cirq::Matrix1q<float>& matrix,
+                 Circuit<Cirq::GateCirq<float>>* circuit) {
+  circuit->gates.push_back(
+    Cirq::MatrixGate1<float>::Create(time, qubits[0], matrix));
+}
+void add_matrix2(const unsigned time, const std::vector<unsigned>& qubits,
+                 const qsim::Cirq::Matrix2q<float>& matrix,
+                 Circuit<Cirq::GateCirq<float>>* circuit) {
+  circuit->gates.push_back(
+    Cirq::MatrixGate2<float>::Create(time, qubits[0], qubits[1], matrix));
+}
+
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options) {
   Circuit<Cirq::GateCirq<float>> circuit;
   std::vector<Bitstring> bitstrings;

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -31,6 +31,14 @@ void add_gate(const qsim::Cirq::GateKind gate_kind, const unsigned time,
               const std::map<std::string, float>& params,
               qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit);
 
+void add_matrix1(const unsigned time, const std::vector<unsigned>& qubits,
+                 const qsim::Cirq::Matrix1q<float>& matrix,
+                 qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit);
+
+void add_matrix2(const unsigned time, const std::vector<unsigned>& qubits,
+                 const qsim::Cirq::Matrix2q<float>& matrix,
+                 qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit);
+
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options);
 
 py::array_t<float> qsim_simulate_fullstate(const py::dict &options);
@@ -96,6 +104,10 @@ PYBIND11_MODULE(qsim, m) {
     .export_values();
 
   m.def("add_gate", &add_gate, "Adds a gate to the given circuit.");
+  m.def("add_matrix1", &add_matrix1,
+        "Adds a one-qubit matrix-defined gate to the given circuit.");
+  m.def("add_matrix2", &add_matrix2,
+        "Adds a two-qubit matrix-defined gate to the given circuit.");
 }
 
 #endif

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -150,7 +150,7 @@ class QSimCircuit(cirq.Circuit):
 
     qubit_to_index_dict = {q: i for i, q in enumerate(ordered_qubits)}
     time_offset = 0
-    for mi, moment in enumerate(self):
+    for moment in self:
       moment_length = 1
       for op in moment:
         qsim_ops = cirq.decompose(
@@ -159,7 +159,7 @@ class QSimCircuit(cirq.Circuit):
 
         for gi, qsim_op in enumerate(qsim_ops):
           gate_kind = _cirq_gate_kind(qsim_op.gate)
-          time = mi + time_offset + gi
+          time = time_offset + gi
           qubits = [qubit_to_index_dict[q] for q in qsim_op.qubits]
           params = {
             p.strip('_'): val for p, val in vars(qsim_op.gate).items()

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -20,16 +20,6 @@ import qsimcirq
 
 class MainTest(unittest.TestCase):
 
-  def test_cirq_unimplemented_gate(self):
-    a = cirq.GridQubit(0, 0)
-
-    # Create a circuit with an unsupported gate.
-    cirq_circuit = cirq.Circuit(cirq.QuantumFourierTransformGate(1).on(a))
-
-    qsimSim = qsimcirq.QSimSimulator()
-    with self.assertRaises(NotImplementedError):
-      qsimSim.compute_amplitudes(cirq_circuit, bitstrings=[0b0, 0b1])
-
   def test_cirq_too_big_gate(self):
     # Pick qubits.
     a, b, c, d = [
@@ -105,6 +95,68 @@ class MainTest(unittest.TestCase):
     # to other simulators. This is fine, as the result is equivalent.
     assert cirq.linalg.allclose_up_to_global_phase(
         result.state_vector(), cirq_result.state_vector())
+
+  def test_matrix1_gate(self):
+    q = cirq.LineQubit(0)
+    m = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
+
+    cirq_circuit = cirq.Circuit(cirq.MatrixGate(m).on(q))
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit)
+    assert result.state_vector().shape == (2,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector())
+
+  def test_matrix2_gate(self):
+    qubits = cirq.LineQubit.range(2)
+    m = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+
+    cirq_circuit = cirq.Circuit(cirq.MatrixGate(m).on(*qubits))
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (4,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector())
+
+  def test_decomposable_gate(self):
+    qubits = cirq.LineQubit.range(3)
+
+    # The Toffoli gate (CCX) decomposes into multiple qsim-supported gates.
+    cirq_circuit = cirq.Circuit(
+        cirq.H(qubits[0]),
+        cirq.H(qubits[1]),
+        cirq.CCX(*qubits),
+        cirq.H(qubits[2]),
+    )
+
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (8,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    # Decomposition may result in gates which add a global phase.
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector())
+
+  def test_cirq_irreconcilable_gate(self):
+    a, b, c, d = [
+        cirq.GridQubit(0, 0),
+        cirq.GridQubit(0, 1),
+        cirq.GridQubit(1, 1),
+        cirq.GridQubit(1, 0)
+    ]
+
+    # The QFT gate does not decompose cleanly into the qsim gateset.
+    cirq_circuit = cirq.Circuit(
+        cirq.QuantumFourierTransformGate(4).on(a, b, c, d))
+
+    qsimSim = qsimcirq.QSimSimulator()
+    with self.assertRaises(ValueError):
+      qsimSim.simulate(cirq_circuit)
 
   def test_cirq_qsim_simulate_random_unitary(self):
 


### PR DESCRIPTION
Unrecognized gate types will now be decomposed to qsim-friendly types if possible, and matrix gates are now properly supported.

Fixes #137.