### PR TITLE
Add *SAN tests and config for tcmalloc.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,7 @@
 build --copt -std=c++11
 build --copt -D_GLIBCXX_USE_CXX11_ABI=0
 
-##### Sanitizers (can be added to any build) #####
+##### Sanitizers (choose one, or nosan for none) #####
 
 # Shared config for sanitizers
 build:sanitizer --strip=never
@@ -19,6 +19,9 @@ build:msan --config=sanitizer
 build:msan --copt -fsanitize=leak
 build:msan --linkopt -fsanitize=leak
 
+# No sanitizers
+build:nosan --
+
 ##### Instruction set options (choose one) #####
 
 # Build with AVX2 + FMA
@@ -33,9 +36,22 @@ build:sse --copt -msse4
 # Build without AVX or SSE
 build:basic --copt -O3
 
+##### Parallelization (choose one, or nopenmp for none) #####
+
 # Build with OpenMP
 build:openmp --copt -fopenmp
 build:openmp --linkopt -lgomp
+
+# No OpenMP
+build:nopenmp --
+
+##### Memory handler (choose one) #####
+
+# Build with tcmalloc
+build:tcmalloc --linkopt="-ltcmalloc"
+
+# Build using malloc (default)
+build:malloc --
 
 # Test flags
 test --test_output=errors

--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -19,10 +19,6 @@ jobs:
         hardware_opt: [avx,sse,basic]
         # Optimizers for parallelism.
         parallel_opt: [openmp,nopenmp]
-        # Test sanitizers
-        sanitizer_opt: [msan,asan,nosan]
-        # Memory handlers
-        malloc_opt: [tcmalloc,malloc]
 
     steps:
       - uses: actions/checkout@v2
@@ -35,13 +31,47 @@ jobs:
       - name: Run C++ tests
         run: |
           bazel test --config=${{ matrix.hardware_opt }} \
-          --config=${{ matrix.sanitizer_opt }} \
-          --config=${{ matrix.malloc_opt }} \
           --config=${{ matrix.parallel_opt }} tests:all
       - name: Run sample simulation
         run: |
           bazel run --config=${{ matrix.hardware_opt }} \
-          --config=${{ matrix.sanitizer_opt }} \
-          --config=${{ matrix.malloc_opt }} \
           --config=${{ matrix.parallel_opt }} apps:qsim_base \
           -- -c circuits/circuit_q24
+
+  test-san:
+    name: Sanitizer tests
+    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        # Test sanitizers
+        sanitizer_opt: [msan,asan]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Install Bazel on CI
+        run: |
+          wget https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel_0.26.0-linux-x86_64.deb
+          sudo dpkg -i bazel_0.26.0-linux-x86_64.deb
+      - name: Run C++ tests
+        run: |
+          bazel test --config=avx --config=openmp \
+          --config=${{ matrix.sanitizer_opt }} tests:all
+  
+  test-mem:
+    name: Test with tcmalloc
+    runs-on: ubuntu-16.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Install Bazel on CI
+        run: |
+          wget https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel_0.26.0-linux-x86_64.deb
+          sudo dpkg -i bazel_0.26.0-linux-x86_64.deb
+      - name: Run C++ tests
+        run: |
+          bazel test --config=avx --config=openmp \
+          --config=tcmalloc tests:all

--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -71,6 +71,8 @@ jobs:
         run: |
           wget https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel_0.26.0-linux-x86_64.deb
           sudo dpkg -i bazel_0.26.0-linux-x86_64.deb
+      - name: Install google-perftools for tcmalloc
+        run: sudo apt-get install libgoogle-perftools-dev
       - name: Run C++ tests
         run: |
           bazel test --config=avx --config=openmp \

--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -18,7 +18,11 @@ jobs:
         # Hardware optimizers.
         hardware_opt: [avx,sse,basic]
         # Optimizers for parallelism.
-        parallel_opt: [openmp,basic]
+        parallel_opt: [openmp,nopenmp]
+        # Test sanitizers
+        sanitizer_opt: [msan,asan,nosan]
+        # Memory handlers
+        malloc_opt: [tcmalloc,malloc]
 
     steps:
       - uses: actions/checkout@v2
@@ -31,9 +35,13 @@ jobs:
       - name: Run C++ tests
         run: |
           bazel test --config=${{ matrix.hardware_opt }} \
+          --config=${{ matrix.sanitizer_opt }} \
+          --config=${{ matrix.malloc_opt }} \
           --config=${{ matrix.parallel_opt }} tests:all
       - name: Run sample simulation
         run: |
           bazel run --config=${{ matrix.hardware_opt }} \
+          --config=${{ matrix.sanitizer_opt }} \
+          --config=${{ matrix.malloc_opt }} \
           --config=${{ matrix.parallel_opt }} apps:qsim_base \
           -- -c circuits/circuit_q24

--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -18,7 +18,7 @@ jobs:
         # Hardware optimizers.
         hardware_opt: [avx,sse,basic]
         # Optimizers for parallelism.
-        parallel_opt: [openmp,nopenmp]
+        parallel_opt: [openmp,basic,nopenmp]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #151. tcmalloc can be used by specifying `--config=tcmalloc` in the Bazel invocation.

Also expands the test matrix to include *SAN tests and tcmalloc/malloc variants. This might increase CI test times, but since Docker is the current bottleneck by a large margin I don't think that's a serious issue.