### PR TITLE
Change fuser interface.

### DIFF
--- a/apps/qsim_base.cc
+++ b/apps/qsim_base.cc
@@ -129,7 +129,7 @@ int main(int argc, char* argv[]) {
   param.num_threads = opt.num_threads;
   param.verbosity = opt.verbosity;
 
-  if (Runner::Run(param, opt.maxtime, circuit, state)) {
+  if (Runner::Run(param, circuit, state)) {
     PrintAmplitudes(circuit.num_qubits, state_space, state);
   }
 

--- a/apps/qsim_von_neumann.cc
+++ b/apps/qsim_von_neumann.cc
@@ -120,7 +120,7 @@ int main(int argc, char* argv[]) {
   param.num_threads = opt.num_threads;
   param.verbosity = opt.verbosity;
 
-  Runner::Run(param, opt.maxtime, circuit, measure);
+  Runner::Run(param, circuit, measure);
 
   return 0;
 }

--- a/apps/qsimh_amplitudes.cc
+++ b/apps/qsimh_amplitudes.cc
@@ -200,10 +200,7 @@ int main(int argc, char* argv[]) {
 
   std::vector<std::complex<Simulator::fp_type>> results(bitstrings.size(), 0);
 
-  bool rc = Runner::Run(
-      param, opt.maxtime, circuit, parts, bitstrings, results);
-
-  if (rc) {
+  if (Runner::Run(param, circuit, parts, bitstrings, results)) {
     WriteAmplitudes(opt.output_file, bitstrings, results);
     IO::messagef("all done.\n");
   }

--- a/apps/qsimh_base.cc
+++ b/apps/qsimh_base.cc
@@ -165,10 +165,7 @@ int main(int argc, char* argv[]) {
 
   std::vector<std::complex<Simulator::fp_type>> results(num_bitstrings, 0);
 
-  bool rc = Runner::Run(
-      param, opt.maxtime, circuit, parts, bitstrings, results);
-
-  if (rc) {
+  if (Runner::Run(param, circuit, parts, bitstrings, results)) {
     static constexpr char const* bits[8] = {
       "000", "001", "010", "011", "100", "101", "110", "111",
     };
@@ -178,7 +175,7 @@ int main(int argc, char* argv[]) {
     for (std::size_t i = 0; i < num_bitstrings; ++i) {
       const auto& a = results[i];
       qsim::IO::messagef("%s:%16.8g%16.8g%16.8g\n", bits[i] + s,
-                        std::real(a), std::imag(a), std::norm(a));
+                         std::real(a), std::imag(a), std::norm(a));
     }
   }
 

--- a/lib/fuser_basic.h
+++ b/lib/fuser_basic.h
@@ -34,7 +34,7 @@ struct BasicGateFuser final {
    * multiplied together until ApplyFusedGate is called on the output.
    * To respect specific time boundaries while fusing gates, use the other
    * version of this method below.
-   * @param num_qubits The number of qubits acted on by gates.
+   * @param num_qubits The number of qubits acted on by 'gates'.
    * @param gates The gates to be fused.
    * @return A vector of fused gate objects. Each element is a set of gates
    *   acting on a specific pair of qubits which can be applied as a group.
@@ -48,7 +48,7 @@ struct BasicGateFuser final {
    * Stores ordered sets of gates, each acting on two qubits, that can be
    * applied together. Note that gates fused with this method are not
    * multiplied together until ApplyFusedGate is called on the output.
-   * @param num_qubits The number of qubits acted on by gates.
+   * @param num_qubits The number of qubits acted on by 'gates'.
    * @param gates The gates to be fused. Gate times should be ordered.
    * @param times_to_split_at Ordered list of time steps at which to separate
    *   fused gates. Each element of the output will contain gates from a single

--- a/lib/fuser_basic.h
+++ b/lib/fuser_basic.h
@@ -34,23 +34,21 @@ struct BasicGateFuser final {
    * multiplied together until ApplyFusedGate is called on the output.
    * To respect specific time boundaries while fusing gates, use the other
    * version of this method below.
-   * @param num_qubits The number of qubits acted on by 'gates'.
+   * @param num_qubits The number of qubits acted on by gates.
    * @param gates The gates to be fused.
-   * @param maxtime Maximum number of timesteps to fuse with this operation.
    * @return A vector of fused gate objects. Each element is a set of gates
    *   acting on a specific pair of qubits which can be applied as a group.
    */
-  static std::vector<GateFused> FuseGates(unsigned num_qubits,
-      const std::vector<Gate>& gates, unsigned maxtime) {
-    std::vector<unsigned> times_to_split_at(1, maxtime);
-    return FuseGates(num_qubits, gates, times_to_split_at);
+  static std::vector<GateFused> FuseGates(
+      unsigned num_qubits, const std::vector<Gate>& gates) {
+    return FuseGates(num_qubits, gates.cbegin(), gates.cend(), {});
   }
 
   /**
    * Stores ordered sets of gates, each acting on two qubits, that can be
    * applied together. Note that gates fused with this method are not
    * multiplied together until ApplyFusedGate is called on the output.
-   * @param num_qubits The number of qubits acted on by 'gates'.
+   * @param num_qubits The number of qubits acted on by gates.
    * @param gates The gates to be fused. Gate times should be ordered.
    * @param times_to_split_at Ordered list of time steps at which to separate
    *   fused gates. Each element of the output will contain gates from a single
@@ -61,14 +59,57 @@ struct BasicGateFuser final {
   static std::vector<GateFused> FuseGates(
       unsigned num_qubits, const std::vector<Gate>& gates,
       const std::vector<unsigned>& times_to_split_at) {
+    return
+        FuseGates(num_qubits, gates.cbegin(), gates.cend(), times_to_split_at);
+  }
+
+  /**
+   * Stores ordered sets of gates, each acting on two qubits, that can be
+   * applied together. Note that gates fused with this method are not
+   * multiplied together until ApplyFusedGate is called on the output.
+   * To respect specific time boundaries while fusing gates, use the other
+   * version of this method below.
+   * @param num_qubits The number of qubits acted on by gates.
+   * @param gfirst, glast The iterator range [gfirst, glast) to fuse gates in.
+   *   Gate times should be ordered.
+   * @return A vector of fused gate objects. Each element is a set of gates
+   *   acting on a specific pair of qubits which can be applied as a group.
+   */
+  static std::vector<GateFused> FuseGates(
+      unsigned num_qubits,
+      typename std::vector<Gate>::const_iterator gfirst,
+      typename std::vector<Gate>::const_iterator glast) {
+    return FuseGates(num_qubits, gfirst, glast, {});
+  }
+
+  /**
+   * Stores ordered sets of gates, each acting on two qubits, that can be
+   * applied together. Note that gates fused with this method are not
+   * multiplied together until ApplyFusedGate is called on the output.
+   * @param num_qubits The number of qubits acted on by gates.
+   * @param gfirst, glast The iterator range [gfirst, glast) to fuse gates in.
+   *   Gate times should be ordered.
+   * @param times_to_split_at Ordered list of time steps at which to separate
+   *   fused gates. Each element of the output will contain gates from a single
+   *   'window' in this list.
+   * @return A vector of fused gate objects. Each element is a set of gates
+   *   acting on a specific pair of qubits which can be applied as a group.
+   */
+  static std::vector<GateFused> FuseGates(
+      unsigned num_qubits,
+      typename std::vector<Gate>::const_iterator gfirst,
+      typename std::vector<Gate>::const_iterator glast,
+      const std::vector<unsigned>& times_to_split_at) {
     std::vector<GateFused> gates_fused;
 
-    if (gates.size() == 0) return gates_fused;
+    if (gfirst >= glast) return gates_fused;
 
-    gates_fused.reserve(gates.size());
+    std::size_t num_gates = glast - gfirst;
+
+    gates_fused.reserve(num_gates);
 
     // Merge with measurement gate times to separate fused gates at.
-    auto times = MergeWithMeasurementTimes(gates, times_to_split_at);
+    auto times = MergeWithMeasurementTimes(gfirst, glast, times_to_split_at);
 
     // Map to keep track of measurement gates with equal times.
     std::map<unsigned, std::vector<const Gate*>> measurement_gates;
@@ -79,25 +120,23 @@ struct BasicGateFuser final {
     // Lattice of gates: qubits "hyperplane" and time direction.
     std::vector<std::vector<const Gate*>> gates_lat(num_qubits);
 
-    // Current unfused gate index.
-    std::size_t gate_index = 0;
+    // Current unfused gate.
+    auto gate_it = gfirst;
 
     for (std::size_t l = 0; l < times.size(); ++l) {
-      if (gate_index == gates.size()) break;
-
       gates_seq.resize(0);
-      gates_seq.reserve(gates.size());
+      gates_seq.reserve(num_gates);
 
       for (unsigned k = 0; k < num_qubits; ++k) {
         gates_lat[k].resize(0);
         gates_lat[k].reserve(128);
       }
 
-      auto prev_time = gates[gate_index].time;
+      auto prev_time = gate_it->time;
 
       // Fill gates_seq and gates_lat in.
-      for (; gate_index < gates.size(); ++gate_index) {
-        const auto& gate = gates[gate_index];
+      for (; gate_it < glast; ++gate_it) {
+        const auto& gate = *gate_it;
 
         if (gate.time > times[l]) break;
 
@@ -206,6 +245,8 @@ struct BasicGateFuser final {
 
         gates_fused.push_back(std::move(gate_f));
       }
+
+      if (gate_it == glast) break;
     }
 
     return gates_fused;
@@ -213,13 +254,17 @@ struct BasicGateFuser final {
 
  private:
   static std::vector<unsigned> MergeWithMeasurementTimes(
-      const std::vector<Gate>& gates, const std::vector<unsigned>& times) {
+      typename std::vector<Gate>::const_iterator gfirst,
+      typename std::vector<Gate>::const_iterator glast,
+      const std::vector<unsigned>& times) {
     std::vector<unsigned> times2;
-    times2.reserve(gates.size() + times.size());
+    times2.reserve(glast - gfirst + times.size());
 
     std::size_t last = 0;
 
-    for (const auto& gate : gates) {
+    for (auto gate_it = gfirst; gate_it < glast; ++gate_it) {
+      const auto& gate = *gate_it;
+
       if (gate.kind == gate::kMeasurement
           && (times2.size() == 0 || times2.back() < gate.time)) {
         times2.push_back(gate.time);
@@ -232,12 +277,10 @@ struct BasicGateFuser final {
           while (last < times.size() && times[last] <= prev) ++last;
         }
       }
-
-      if (last == times.size()) break;
     }
 
-    if (last < times.size()) {
-      times2.push_back(times[last]);
+    if (times2.size() == 0 || times2.back() < (glast - 1)->time) {
+      times2.push_back((glast - 1)->time);
     }
 
     return times2;

--- a/lib/run_qsimh.h
+++ b/lib/run_qsimh.h
@@ -38,7 +38,6 @@ struct QSimHRunner final {
    * Evaluates the amplitudes for a given circuit and set of output states.
    * @param param Options for parallelism and logging. Also specifies the size
    *   of the 'prefix' and 'root' sections of the lattice.
-   * @param maxtime Maximum number of time steps to run.
    * @param circuit The circuit to be simulated.
    * @param parts Lattice sections to be simulated.
    * @param bitstrings List of output states to simulate, as bitstrings.
@@ -47,8 +46,8 @@ struct QSimHRunner final {
    * @return True if the simulation completed successfully; false otherwise.
    */
   template <typename Circuit>
-  static bool Run(const Parameter& param, unsigned maxtime,
-                  const Circuit& circuit, const std::vector<unsigned>& parts,
+  static bool Run(const Parameter& param, const Circuit& circuit,
+                  const std::vector<unsigned>& parts,
                   const std::vector<uint64_t>& bitstrings,
                   std::vector<std::complex<fp_type>>& results) {
     if (circuit.num_qubits != parts.size()) {
@@ -81,12 +80,12 @@ struct QSimHRunner final {
       PrintInfo(param, hd);
     }
 
-    auto fgates0 = Fuser::FuseGates(hd.num_qubits0, hd.gates0, maxtime);
+    auto fgates0 = Fuser::FuseGates(hd.num_qubits0, hd.gates0);
     if (fgates0.size() == 0 && hd.gates0.size() > 0) {
       return false;
     }
 
-    auto fgates1 = Fuser::FuseGates(hd.num_qubits1, hd.gates1, maxtime);
+    auto fgates1 = Fuser::FuseGates(hd.num_qubits1, hd.gates1);
     if (fgates1.size() == 0 && hd.gates1.size() > 0) {
       return false;
     }

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -15,7 +15,6 @@
 #include "pybind_main.h"
 
 #include <complex>
-#include <limits>
 #include <sstream>
 #include <cmath>
 #include <algorithm>
@@ -299,7 +298,7 @@ std::vector<std::complex<float>> qsim_simulate(const py::dict &options) {
     IO::errorf(exp.what());
     return {};
   }
-  Runner::Run(param, std::numeric_limits<unsigned>::max(), circuit, measure);
+  Runner::Run(param, circuit, measure);
   return amplitudes;
 }
 
@@ -340,8 +339,7 @@ py::array_t<float> qsim_simulate_fullstate(const py::dict &options) {
 
   state_space.SetStateZero(state);
 
-  if (!Runner::Run(param, std::numeric_limits<unsigned>::max(), circuit,
-                   state)) {
+  if (!Runner::Run(param, circuit, state)) {
     IO::errorf("qsim full state simulation of the circuit errored out.\n");
     return {};
   }
@@ -391,8 +389,7 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options) {
   // Define container for amplitudes
   std::vector<std::complex<float>> amplitudes(bitstrings.size(), 0);
 
-  if (Runner::Run(param, std::numeric_limits<unsigned>::max(), circuit,
-                  parts, bitstrings, amplitudes)) {
+  if (Runner::Run(param, circuit, parts, bitstrings, amplitudes)) {
     return amplitudes;
   }
   IO::errorf("qsimh simulation of the circuit errored out.\n");

--- a/tests/fuser_basic_test.cc
+++ b/tests/fuser_basic_test.cc
@@ -66,7 +66,7 @@ TEST(FuserBasicTest, NoTimesToSplitAt) {
   EXPECT_EQ(circuit.gates.size(), 27);
 
   using Fuser = BasicGateFuser<IO, GateQSim<float>>;
-  auto fused_gates = Fuser::FuseGates(circuit.num_qubits, circuit.gates, 99);
+  auto fused_gates = Fuser::FuseGates(circuit.num_qubits, circuit.gates);
 
   EXPECT_EQ(fused_gates.size(), 5);
 
@@ -581,12 +581,12 @@ TEST(FuserBasicTest, OrphanedQubits1) {
   std::stringstream ss(circuit_string2);
   Circuit<GateQSim<float>> circuit;
 
-  EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
+  EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(2, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 3);
-  EXPECT_EQ(circuit.gates.size(), 9);
+  EXPECT_EQ(circuit.gates.size(), 7);
 
   using Fuser = BasicGateFuser<IO, GateQSim<float>>;
-  auto fused_gates = Fuser::FuseGates(circuit.num_qubits, circuit.gates, 2);
+  auto fused_gates = Fuser::FuseGates(circuit.num_qubits, circuit.gates);
 
   EXPECT_EQ(fused_gates.size(), 2);
 
@@ -718,15 +718,15 @@ TEST(FuserBasicTest, UnfusibleSingleQubitGate) {
   std::stringstream ss(circuit_string2);
   Circuit<GateQSim<float>> circuit;
 
-  EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
+  EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(2, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 3);
-  EXPECT_EQ(circuit.gates.size(), 9);
+  EXPECT_EQ(circuit.gates.size(), 7);
 
   circuit.gates[1].unfusible = true;
   circuit.gates[2].unfusible = true;
 
   using Fuser = BasicGateFuser<IO, GateQSim<float>>;
-  auto fused_gates = Fuser::FuseGates(circuit.num_qubits, circuit.gates, 2);
+  auto fused_gates = Fuser::FuseGates(circuit.num_qubits, circuit.gates);
 
   EXPECT_EQ(fused_gates.size(), 3);
 
@@ -808,7 +808,7 @@ TEST(FuserBasicTest, MeasurementGate) {
   EXPECT_EQ(circuit.gates.size(), 17);
 
   using Fuser = BasicGateFuser<IO, GateQSim<float>>;
-  auto fused_gates = Fuser::FuseGates(circuit.num_qubits, circuit.gates, 6);
+  auto fused_gates = Fuser::FuseGates(circuit.num_qubits, circuit.gates);
 
   EXPECT_EQ(fused_gates.size(), 11);
 

--- a/tests/hybrid_test.cc
+++ b/tests/hybrid_test.cc
@@ -84,8 +84,8 @@ R"(2
   EXPECT_EQ(hd.num_qubits1, 1);
   EXPECT_EQ(hd.num_gatexs, 7);
 
-  auto fgates0 = Fuser::FuseGates(hd.num_qubits0, hd.gates0, 99);
-  auto fgates1 = Fuser::FuseGates(hd.num_qubits1, hd.gates1, 99);
+  auto fgates0 = Fuser::FuseGates(hd.num_qubits0, hd.gates0);
+  auto fgates1 = Fuser::FuseGates(hd.num_qubits1, hd.gates1);
 
   EXPECT_EQ(fgates0.size(), 7);
   EXPECT_EQ(fgates1.size(), 7);
@@ -265,8 +265,8 @@ R"(4
   EXPECT_EQ(hd.num_qubits1, 2);
   EXPECT_EQ(hd.num_gatexs, 5);
 
-  auto fgates0 = Fuser::FuseGates(hd.num_qubits0, hd.gates0, 99);
-  auto fgates1 = Fuser::FuseGates(hd.num_qubits1, hd.gates1, 99);
+  auto fgates0 = Fuser::FuseGates(hd.num_qubits0, hd.gates0);
+  auto fgates1 = Fuser::FuseGates(hd.num_qubits1, hd.gates1);
 
   EXPECT_EQ(fgates0.size(), 10);
   EXPECT_EQ(fgates1.size(), 10);

--- a/tests/run_qsim_test.cc
+++ b/tests/run_qsim_test.cc
@@ -97,7 +97,7 @@ TEST(RunQSimTest, QSimRunner1) {
   param.num_threads = 1;
   param.verbosity = 0;
 
-  EXPECT_TRUE(Runner::Run(param, 99, circuit, measure));
+  EXPECT_TRUE(Runner::Run(param, circuit, measure));
 
   EXPECT_NEAR(entropy, 2.2192848, 1e-6);
 }
@@ -127,7 +127,7 @@ TEST(RunQSimTest, QSimRunner2) {
   param.num_threads = 1;
   param.verbosity = 0;
 
-  EXPECT_TRUE(Runner::Run(param, 99, circuit, state));
+  EXPECT_TRUE(Runner::Run(param, circuit, state));
 
   // Calculate entropy.
 
@@ -165,7 +165,7 @@ TEST(RunQSimTest, CirqGates) {
   param.num_threads = 1;
   param.verbosity = 0;
 
-  EXPECT_TRUE(Runner::Run(param, 99, circuit, state));
+  EXPECT_TRUE(Runner::Run(param, circuit, state));
 
   for (uint64_t i = 0; i < state_space.Size(); ++i) {
     auto ampl = state_space.GetAmpl(state, i);

--- a/tests/run_qsimh_test.cc
+++ b/tests/run_qsimh_test.cc
@@ -130,7 +130,7 @@ TEST(RunQSimHTest, QSimHRunner) {
     std::vector<std::complex<Simulator::fp_type>> results(8, 0);
     std::vector<unsigned> parts = {0, 0, 1, 1};
 
-    EXPECT_TRUE(Runner::Run(param, 99, circuit, parts, bitstrings, results));
+    EXPECT_TRUE(Runner::Run(param, circuit, parts, bitstrings, results));
 
     EXPECT_NEAR(std::real(results[0]), -0.08102149, 1e-6);
     EXPECT_NEAR(std::imag(results[0]), 0.08956901, 1e-6);
@@ -148,7 +148,7 @@ TEST(RunQSimHTest, QSimHRunner) {
 
     param.num_root_gatexs = 3;
 
-    EXPECT_TRUE(Runner::Run(param, 99, circuit, parts, bitstrings, results));
+    EXPECT_TRUE(Runner::Run(param, circuit, parts, bitstrings, results));
 
     EXPECT_NEAR(std::real(results[0]), -0.08102149, 1e-6);
     EXPECT_NEAR(std::imag(results[0]), 0.08956903, 1e-6);
@@ -189,7 +189,7 @@ TEST(RunQSimHTest, CirqGates) {
     std::vector<std::complex<Simulator::fp_type>> results(num_bitstrings, 0);
     std::vector<unsigned> parts = {1, 1, 0, 0};
 
-    EXPECT_TRUE(Runner::Run(param, 99, circuit, parts, bitstrings, results));
+    EXPECT_TRUE(Runner::Run(param, circuit, parts, bitstrings, results));
 
     for (uint64_t i = 0; i < num_bitstrings; ++i) {
       EXPECT_NEAR(std::real(results[i]), std::real(expected_results[i]), 2e-6);
@@ -201,7 +201,7 @@ TEST(RunQSimHTest, CirqGates) {
     std::vector<std::complex<Simulator::fp_type>> results(num_bitstrings, 0);
     std::vector<unsigned> parts = {1, 0, 1, 0};
 
-    EXPECT_TRUE(Runner::Run(param, 99, circuit, parts, bitstrings, results));
+    EXPECT_TRUE(Runner::Run(param, circuit, parts, bitstrings, results));
 
     for (uint64_t i = 0; i < num_bitstrings; ++i) {
       EXPECT_NEAR(std::real(results[i]), std::real(expected_results[i]), 2e-6);
@@ -213,7 +213,7 @@ TEST(RunQSimHTest, CirqGates) {
     std::vector<std::complex<Simulator::fp_type>> results(num_bitstrings, 0);
     std::vector<unsigned> parts = {1, 0, 0, 0};
 
-    EXPECT_TRUE(Runner::Run(param, 99, circuit, parts, bitstrings, results));
+    EXPECT_TRUE(Runner::Run(param, circuit, parts, bitstrings, results));
 
     for (uint64_t i = 0; i < num_bitstrings; ++i) {
       EXPECT_NEAR(std::real(results[i]), std::real(expected_results[i]), 2e-6);
@@ -225,7 +225,7 @@ TEST(RunQSimHTest, CirqGates) {
     std::vector<std::complex<Simulator::fp_type>> results(num_bitstrings, 0);
     std::vector<unsigned> parts = {0, 1, 0, 0};
 
-    EXPECT_TRUE(Runner::Run(param, 99, circuit, parts, bitstrings, results));
+    EXPECT_TRUE(Runner::Run(param, circuit, parts, bitstrings, results));
 
     for (uint64_t i = 0; i < num_bitstrings; ++i) {
       EXPECT_NEAR(std::real(results[i]), std::real(expected_results[i]), 2e-6);
@@ -237,7 +237,7 @@ TEST(RunQSimHTest, CirqGates) {
     std::vector<std::complex<Simulator::fp_type>> results(num_bitstrings, 0);
     std::vector<unsigned> parts = {0, 0, 1, 0};
 
-    EXPECT_TRUE(Runner::Run(param, 99, circuit, parts, bitstrings, results));
+    EXPECT_TRUE(Runner::Run(param, circuit, parts, bitstrings, results));
 
     for (uint64_t i = 0; i < num_bitstrings; ++i) {
       EXPECT_NEAR(std::real(results[i]), std::real(expected_results[i]), 2e-6);
@@ -249,7 +249,7 @@ TEST(RunQSimHTest, CirqGates) {
     std::vector<std::complex<Simulator::fp_type>> results(num_bitstrings, 0);
     std::vector<unsigned> parts = {0, 0, 0, 1};
 
-    EXPECT_TRUE(Runner::Run(param, 99, circuit, parts, bitstrings, results));
+    EXPECT_TRUE(Runner::Run(param, circuit, parts, bitstrings, results));
 
     for (uint64_t i = 0; i < num_bitstrings; ++i) {
       EXPECT_NEAR(std::real(results[i]), std::real(expected_results[i]), 2e-6);

--- a/tests/statespace_testfixture.h
+++ b/tests/statespace_testfixture.h
@@ -537,7 +537,7 @@ void TestSamplingCrossEntropyDifference() {
   param.num_threads = 1;
   param.verbosity = 0;
 
-  EXPECT_TRUE(Runner::Run(param, depth, circuit, state));
+  EXPECT_TRUE(Runner::Run(param, circuit, state));
 
   auto bitstrings = state_space.Sample(state, num_samples, 1);
   EXPECT_EQ(bitstrings.size(), num_samples);
@@ -713,7 +713,7 @@ void TestMeasurementLarge() {
   param.num_threads = 1;
   param.verbosity = 0;
 
-  EXPECT_TRUE(Runner::Run(param, depth, circuit, state));
+  EXPECT_TRUE(Runner::Run(param, circuit, state));
 
   std::mt19937 rgen(1);
   auto result = state_space.Measure({0, 4}, rgen, state);


### PR DESCRIPTION
This PR (slightly) changes the fuser interface. It adds a function that fuses gates in a range. It removes the notion of maxtime: now all the supplied gates are fused. This PR also clarifies what is meant by measurements in function documentation in lib/run_qsim.h.