### PR TITLE
Out of order gates.

### DIFF
--- a/lib/circuit_qsim_parser.h
+++ b/lib/circuit_qsim_parser.h
@@ -56,6 +56,8 @@ class CircuitQsimParser final {
     gate_name.reserve(16);
     fp_type phi, theta;
 
+    unsigned prev_time = 0;
+
     while (std::getline(fs, line)) {
       ++k;
 
@@ -80,6 +82,14 @@ class CircuitQsimParser final {
         InvalidGateError(provider, k);
         return false;
       }
+
+      if (time < prev_time) {
+        IO::errorf("gate time is out of order in %s in line %u.\n",
+                   provider.c_str(), k);
+        return false;
+      }
+
+      prev_time = time;
 
       unsigned num_qubits = circuit.num_qubits;
       auto& gates = circuit.gates;

--- a/tests/circuit_qsim_parser_test.cc
+++ b/tests/circuit_qsim_parser_test.cc
@@ -256,6 +256,22 @@ R"(2
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
 
+TEST(CircuitQsimParserTest, TimeOutOfOrder) {
+  constexpr char invalid_circuit[] =
+R"(2
+0 h 0
+0 h 1
+1 cz 0 1
+2 t 0
+2 t 1
+1 cz 0 1)";
+
+  std::stringstream ss(invalid_circuit);
+  Circuit<GateQSim<float>> circuit;
+
+  EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
+}
+
 TEST(CircuitQsimParserTest, InvalidQubitRange2) {
   constexpr char invalid_circuit[] =
 R"(2


### PR DESCRIPTION
Raise error if gate times are out of order in lib/circuit_qsim_parser.h.