### PR TITLE
Finish nopenmp conversion.

### DIFF
--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -18,7 +18,7 @@ jobs:
         # Hardware optimizers.
         hardware_opt: [avx,sse,basic]
         # Optimizers for parallelism.
-        parallel_opt: [openmp,basic,nopenmp]
+        parallel_opt: [openmp,nopenmp]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Required tests are updated, so `basic` can now be specific to hardware optimizers. (Coverage of `nopenmp` and `basic` in the context of parallelization config is identical)