### PR TITLE
cirq v0.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements for the python 3 version of cirq.
 
-cirq==0.8.0
+cirq==0.8.2
 numpy~=1.16
 typing_extensions
 


### PR DESCRIPTION
Bumps cirq version to v0.8.2 for qsimcirq. 

This helps removing a warning with Colab as Cirq 0.8.2 now requires protobuf 3.12.*: 

```
ERROR: tensorflow 2.3.0 has requirement protobuf>=3.9.2, but you'll have protobuf 3.8.0 which is incompatible.
Installing collected packages: protobuf, freezegun, cirq, pybind11, qsimcirq
  Found existing installation: protobuf 3.12.4
    Uninstalling protobuf-3.12.4:
      Successfully uninstalled protobuf-3.12.4
Successfully installed cirq-0.8.0 freezegun-0.3.15 protobuf-3.8.0 pybind11-2.5.0 qsimcirq-0.2.0
WARNING: The following packages were previously imported in this runtime:
  [google]
You must restart the runtime in order to use newly installed versions.
```