### PR TITLE
Update usage and qsimcirq docs.

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -29,13 +29,25 @@ Vector arithmetic optimizers (pick one at most):
 
 # Use SSE instructions for vector arithmetic.
 --config=sse
+
+# Do not use vector arithmetic optimization (default).
+--config=basic
 ```
 
 Parallelism optimizers (pick one at most):
 ```
 # Use OpenMP to run operations in parallel when possible.
---config=avx
+--config=openmp
+
+# Do not use OpenMP for parallelism (default).
+--config=nopenmp
 ```
 
-We also provide `--config=basic`. This flag does not affect the build or test,
-but can be useful in scripts (e.g. where `--config=" "` is not valid).
+Memory allocation (pick one at most):
+```
+# Use tcmalloc for memory allocation.
+--config=tcmalloc
+
+# Use malloc for memory allocation (default).
+--config=malloc
+```

--- a/docs/cirq_interface.md
+++ b/docs/cirq_interface.md
@@ -71,9 +71,14 @@ QSimhSimulator, depending on the output required:
 #### QSimSimulator
 
 QSimSimulator uses a Schrödinger full state-vector simulator, suitable for
-acquiring the complete state of a reasonably-sized circuit (~35 qubits):
+acquiring the complete state of a reasonably-sized circuit (~35 qubits).
+Options for the simulator, including number of threads and verbosity, can be
+set with the `qsim_options` field using the `qsim_base` flag format defined in
+the [usage docs](/docs/usage.md).
+
 ```
-my_sim = qsimcirq.QSimSimulator()
+qsim_options = {'t': 8, 'v': 0}
+my_sim = qsimcirq.QSimSimulator(qsim_options)
 myres = my_sim.simulate(program = my_circuit)
 ```
 
@@ -122,6 +127,8 @@ myres = my_sim.compute_amplitudes(program = my_circuit,
                                   bitstrings=['00', '01', '10', '11'])
 ```
 
+As with QSimSimulator, the options follow the flag format for `qsimh_base`
+outlined in the [usage docs](/docs/usage.md).
 
 ## Additional features
 

--- a/docs/install_qsimcirq.md
+++ b/docs/install_qsimcirq.md
@@ -21,7 +21,7 @@ Other prerequisites (including pybind11 and pytest) are included in the
 [`requirements.txt`](/requirements.txt) file, and will be automatically
 installed along with qsimcirq.
 
-To install the qsim-Cirq interface on Linux, simply run`pip3 install qsimcirq`.
+To install the qsim-Cirq interface on Linux, simply run `pip3 install qsimcirq`.
 For examples of how to use this package, see the tests in
 [qsim/qsimcirq_tests/](/qsimcirq_tests/).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -151,8 +151,7 @@ However, splitting the grid into roughly equal parts with the fewest cuts
 possible (as is done for the lattice above) produces a circuit that performs
 reasonably well in most cases.
 
-**-p** and **-r** specify the number of "prefix" and "root" gates respectively,
-and determine how much of the circuit must be repeated for each execution.
+**-p** and **-r** specify the number of "prefix" and "root" gates, respectively.
 Values for these flags should be chosen with this in mind:
 
 - Operations up to and including the "prefix" gates will only be run once, but

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -151,16 +151,14 @@ However, splitting the grid into roughly equal parts with the fewest cuts
 possible (as is done for the lattice above) produces a circuit that performs
 reasonably well in most cases.
 
-**-p** and **-r** specify the number of "prefix" and "root" gates, respectively.
-Values for these flags should be chosen with this in mind:
+The runtime of an execution is heavily influenced by **-p**, as there is no
+summation over the "prefix" gates. The unique "prefix" path is specified by
+**-w**; see the `Distributed execution` section below for details on this.
 
-- Operations up to and including the "prefix" gates will only be run once, but
-  only one path over the prefix gates will be run. (See the
-  `Distributed execution` section below for details on this.)
-- Operations after the "prefix" gates and leading up to the "root" gates will
-  run once for each value of the root gates.
-- Operations after the "root" gates will run `X` times for each value of the
-  root gates, where `X` is the number of values of the "suffix" gates.
+**-r** implicitly specifies the number of the "suffix" gates: the total number
+of gates on the cut minus the values specified by **-p** and **-r**. For
+performance, the "suffix" gates should typically be the gates on the cut with
+maximum "time".
 
 
 ## qsimh_amplitudes usage

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,10 +26,8 @@ qsim_base computes all the amplitudes and just prints the first eight of them
 
 Example:
 ```
-./qsim_base.x -c ../circuits/circuit_q30 -d 16 -t 8 -v 1
+./qsim_base.x -c ../circuits/circuit_q24 -d 16 -t 8 -v 1
 ```
-
-Note that this particular simulation requires 8 GB of RAM.
 
 ## qsim_von_neumann usage
 
@@ -111,19 +109,39 @@ Example:
 qsimh_base just computes and just prints the first eight amplitudes. The hybrid
 Schrödinger-Feynman method is used. The lattice is split into two parts.
 A two level checkpointing scheme is used to improve performance. Say, there
-are `k` gates on the cut. We split those into three parts: `p+r+s=k`, where
+are `N` gates on the cut. We split those into three parts: `p+r+s=N`, where
 `p` is the number of "prefix" gates, `r` is the number of "root" gates and
 `s` is the number of "suffix" gates. The first checkpoint is executed after
 applying all the gates up to and including the prefix gates and the second
 checkpoint is executed after applying all the gates up to and including the
 root gates. The full summation over all the paths for the root and suffix gates
-is performed. The path for the prefix gates is specified by `prefix`. It is
-just a value of bit-shifted path indices in the order of occurrence of prefix
-gates in the circuit file.
+is performed.
 
-Example:
+The path for the prefix gates is specified by `prefix`. It is just a value of
+bit-shifted path indices in the order of occurrence of prefix gates in the
+circuit file. This is primarily used for distributed execution - see the
+`Distributed execution` section below for more details.
+
+Example (running on one machine):
 ```
-./qsimh_base.x -c ../circuits/circuit_q30 -d 16 -k 0,1,2,6,7,8,12,13,14,18,19,20,24,25,26 -t 8 -w 0 -p 0 -r 5 -v 1
+./qsimh_base.x -c ../circuits/circuit_q30 -d 16 \
+               -k 0,1,2,6,7,8,12,13,14,18,19,20,24,25,26 \
+               -t 8 -w 0 -p 0 -r 5 -v 1
+```
+
+Note that -k defines how the lattice will be split up. In the examples above,
+the lattice has the structure below (cuts are denoted by the `|` symbol):
+
+```
+ 0    1    2 |  3    4    5
+
+ 6    7    8 |  9   10   11
+
+12   13   14 | 15   16   17
+
+18   19   20 | 21   22   23
+
+24   25   26 | 27   28   29
 ```
 
 ## qsimh_amplitudes usage
@@ -160,7 +178,30 @@ format.
 
 Example:
 ```
-./qsimh_amplitudes.x -c ../circuits/circuit_q40 -d 47 -k 0,1,2,3,4,5,6,7,8,9,10,13,14,15,16,17,23,24 -t 8 -w 0 -p 9 -r 4 -i ../circuits/bitstrings_q40_s1 -o ampl_q40_s1_w0 -v 1
-./qsimh_amplitudes.x -c ../circuits/circuit_q40 -d 47 -k 0,1,2,3,4,5,6,7,8,9,10,13,14,15,16,17,23,24 -t 8 -w 1 -p 9 -r 4 -i ../circuits/bitstrings_q40_s1 -o ampl_q40_s1_w1 -v 1
-...
+./qsimh_amplitudes.x -c ../circuits/circuit_q40 -d 47 -k 0,1,2,3,4,5,6,7,8,9,10,13,14,15,16,17,23,24 -t 8 -w 0 -p 0 -r 4 -i ../circuits/bitstrings_q40_s1 -o ampl_q40_s1_w0 -v 1
 ```
+Note that this could take a very long time to run, since parallelism on a
+single machine is limited by the -t flag and the available cores on the device.
+For large circuits like this, distributed execution is recommended.
+
+### Distributed execution
+
+By setting -p to be greater than zero, the workload of qsimh_amplitudes can be
+distributed across multiple machines. Each machine will use the same arguments
+to `./qsimh_amplitudes.x`, with the exception of the -w flag, which specifies
+the path that machine will evaluate.
+
+Example:
+```
+# Machine 1
+./qsimh_amplitudes.x -c ../circuits/circuit_q40 -d 47 -k 0,1,2,3,4,5,6,7,8,9,10,13,14,15,16,17,23,24 -t 8 -w 0 -p 9 -r 4 -i ../circuits/bitstrings_q40_s1 -o ampl_q40_s1_w0 -v 1
+
+# Machine 2
+./qsimh_amplitudes.x -c ../circuits/circuit_q40 -d 47 -k 0,1,2,3,4,5,6,7,8,9,10,13,14,15,16,17,23,24 -t 8 -w 1 -p 9 -r 4 -i ../circuits/bitstrings_q40_s1 -o ampl_q40_s1_w1 -v 1
+
+# ...additional executions...
+```
+
+Each execution above computes a portion of the overall amplitude for the
+specified bitstrings. Summing across these results will give the final
+amplitudes, with fidelity dependent on the number of paths executed.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-# Usage
+# Usage of sample applications
 
 qsim and qsimh are designed to be extensible to a variety of different
 applications. The base versions of each are `qsim_base` and `qsimh_base`;
@@ -129,8 +129,10 @@ Example (running on one machine):
                -t 8 -w 0 -p 0 -r 5 -v 1
 ```
 
-Note that -k defines how the lattice will be split up. In the examples above,
-the lattice has the structure below (cuts are denoted by the `|` symbol):
+### Choosing flag values for qsimh
+
+**-k** defines how the lattice will be split up. In the examples above, the
+lattice has the structure below (cuts are denoted by the `|` symbol):
 
 ```
  0    1    2 |  3    4    5
@@ -143,6 +145,24 @@ the lattice has the structure below (cuts are denoted by the `|` symbol):
 
 24   25   26 | 27   28   29
 ```
+
+Deciding which cuts are optimal for a given circuit is computationally hard.
+However, splitting the grid into roughly equal parts with the fewest cuts
+possible (as is done for the lattice above) produces a circuit that performs
+reasonably well in most cases.
+
+**-p** and **-r** specify the number of "prefix" and "root" gates respectively,
+and determine how much of the circuit must be repeated for each execution.
+Values for these flags should be chosen with this in mind:
+
+- Operations up to and including the "prefix" gates will only be run once, but
+  only one path over the prefix gates will be run. (See the
+  `Distributed execution` section below for details on this.)
+- Operations after the "prefix" gates and leading up to the "root" gates will
+  run once for each value of the root gates.
+- Operations after the "root" gates will run `X` times for each value of the
+  root gates, where `X` is the number of values of the "suffix" gates.
+
 
 ## qsimh_amplitudes usage
 ```
@@ -176,20 +196,20 @@ method is used, see above.
 Bitstring files should contain bitstings (one bitstring per line) in text
 format.
 
-Example:
+Example (do not execute - see below):
 ```
-./qsimh_amplitudes.x -c ../circuits/circuit_q40 -d 47 -k 0,1,2,3,4,5,6,7,8,9,10,13,14,15,16,17,23,24 -t 8 -w 0 -p 0 -r 4 -i ../circuits/bitstrings_q40_s1 -o ampl_q40_s1_w0 -v 1
+./qsimh_amplitudes.x -c ../circuits/circuit_q40 -d 47 -k 0,1,2,3,4,5,6,7,8,9,10,13,14,15,16,17,23,24 -t 8 -w 0 -p 0 -r 13 -i ../circuits/bitstrings_q40_s1 -o ampl_q40_s1 -v 1
 ```
-Note that this could take a very long time to run, since parallelism on a
-single machine is limited by the -t flag and the available cores on the device.
-For large circuits like this, distributed execution is recommended.
+
+This command could take weeks to run, since parallelism on a single machine is
+limited by the -t flag and the available cores on the device. For large
+circuits like this, distributed execution is recommended.
 
 ### Distributed execution
 
 By setting -p to be greater than zero, the workload of qsimh_amplitudes can be
-distributed across multiple machines. Each machine will use the same arguments
-to `./qsimh_amplitudes.x`, with the exception of the -w flag, which specifies
-the path that machine will evaluate.
+distributed across multiple machines. Each machine should use the same
+arguments to `./qsimh_amplitudes.x`, with the exception of the -w flag, which specifies the path that machine will evaluate.
 
 Example:
 ```


### PR DESCRIPTION
This brings the qsimcirq and bazel docs up to speed and adds a bit of clarification to the usage docs.

@karlunho: I'm aware of e.g. #129 (tutorial colab) and #118 (API docs) - is there a plan for these already? Are there any other docs concerns that need to be addressed in this PR?