### PR TITLE
Swap xmmintrin for smmintrin

### DIFF
--- a/lib/statespace_sse.h
+++ b/lib/statespace_sse.h
@@ -15,7 +15,7 @@
 #ifndef STATESPACE_SSE_H_
 #define STATESPACE_SSE_H_
 
-#include <xmmintrin.h>
+#include <smmintrin.h>
 
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
The new measurement code calls SSE4.1 methods (e.g. `_mm_cmpeq_epi64`) which require `smmintrin.h`. I'm a little confused how this passed tests in its previous state...