### PR TITLE
Make unitaryspace_basic deps explicit

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -329,7 +329,10 @@ cc_library(
 cc_library(
     name = "unitaryspace_basic",
     hdrs = ["unitaryspace_basic.h"],
-    deps = [":unitaryspace"],
+    deps = [
+        ":unitaryspace",
+        ":util",
+    ],
 )
 
 ### Unitary calculator libraries ###


### PR DESCRIPTION
The Google-internal version of bazel doesn't allow transitive header dependencies through `deps`. Sadly, there's not a great way of testing this in GitHub, but it won't affect builds that use the open-source version of bazel.