### PR TITLE
Don't reuse seeds between repetitions.

### DIFF
--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -171,6 +171,16 @@ class MainTest(unittest.TestCase):
 
     assert(qsim_result == cirq_result)
     
+  def test_sampling_nondeterminism(self):
+    # Ensure that reusing a QSimSimulator doesn't reuse the original seed.
+    q = cirq.GridQubit(0, 0)
+    circuit = cirq.Circuit(cirq.H(q), cirq.measure(q, key='m'))
+    qsim_simulator = qsimcirq.QSimSimulator()
+    qsim_result = qsim_simulator.run(circuit, repetitions=100)
+
+    result_counts = qsim_result.histogram(key='m')
+    assert(result_counts[0] > 1)
+    assert(result_counts[1] > 1)
 
   def test_matrix1_gate(self):
     q = cirq.LineQubit(0)


### PR DESCRIPTION
Previously, this code initialized `QSimSimulator` with a fixed seed which did not change between repetitions. This led to identical results for each repetition, which isn't what we want.

This PR instead saves the PRNG and queries it for a seed value immediately prior to invoking C++ qsim methods. I've verified that the new test fails at HEAD but passes with this PR.