### PR TITLE
Release version 0.3.0

### DIFF
--- a/docs/qsimcirq_tutorial.ipynb
+++ b/docs/qsimcirq_tutorial.ipynb
@@ -1,0 +1,594 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "qsimcirq_tutorial.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vAx5g2rPnlzt",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Getting started with qsimcirq\n",
+        "\n",
+        "The qsim library provides a Python interface to Cirq in the **qsimcirq** PyPI package."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "XcAhsIQdivnp",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "%%shell\n",
+        "pip install cirq==0.8.0 --quiet\n",
+        "pip install qsimcirq==0.3.0 --quiet"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FXytmQlBoeTT",
+        "colab_type": "text"
+      },
+      "source": [
+        "Simulating Cirq circuits with qsim is easy: just define the circuit as you normally would, then create a **QSimSimulator** to perform the simulation. This object implements Cirq's [simulator.py](https://github.com/quantumlib/Cirq/blob/master/cirq/sim/simulator.py) interfaces, so you can drop it in anywhere the basic Cirq simulator is used.\n",
+        "\n",
+        "## Full state-vector simulation\n",
+        "\n",
+        "qsim is optimized for computing the final state vector of a circuit. Try it by running the example below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "jd8DaJMbjkCM",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 139
+        },
+        "outputId": "c9f7a9cb-89d7-42b6-86a4-c82acb65682a"
+      },
+      "source": [
+        "import cirq\n",
+        "import qsimcirq\n",
+        "\n",
+        "states = ['00', '01', '10', '11']\n",
+        "\n",
+        "# Define qubits and a short circuit.\n",
+        "q0, q1 = cirq.LineQubit.range(2)\n",
+        "circuit = cirq.Circuit(cirq.H(q0), cirq.CX(q0, q1))\n",
+        "\n",
+        "# Simulate the circuit with Cirq and return the full state vector.\n",
+        "print('Cirq results:')\n",
+        "cirq_simulator = cirq.Simulator()\n",
+        "cirq_results = cirq_simulator.simulate(circuit)\n",
+        "print(cirq_results)\n",
+        "print()\n",
+        "\n",
+        "# Simulate the circuit with qsim and return the full state vector.\n",
+        "print('qsim results:')\n",
+        "qsim_simulator = qsimcirq.QSimSimulator()\n",
+        "qsim_results = qsim_simulator.simulate(circuit)\n",
+        "print(qsim_results)"
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Cirq results:\n",
+            "measurements: (no measurements)\n",
+            "output vector: 0.707|00⟩ + 0.707|11⟩\n",
+            "\n",
+            "qsim results:\n",
+            "measurements: (no measurements)\n",
+            "output vector: 0.707|00⟩ + 0.707|11⟩\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-kyXlKujtZcp",
+        "colab_type": "text"
+      },
+      "source": [
+        "To sample from this state, you can invoke Cirq's `sample_state_vector` method:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "-m6uzQ6ms9I7",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 192
+        },
+        "outputId": "bd5c1c0e-da22-4327-fc78-10f4f2eda697"
+      },
+      "source": [
+        "samples = cirq.sample_state_vector(\n",
+        "    qsim_results.state_vector(), indices=[0, 1], repetitions=10)\n",
+        "print(samples)"
+      ],
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[[0 0]\n",
+            " [0 0]\n",
+            " [0 0]\n",
+            " [0 0]\n",
+            " [0 0]\n",
+            " [0 0]\n",
+            " [0 0]\n",
+            " [0 0]\n",
+            " [1 1]\n",
+            " [1 1]]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pOhybi46sHwI",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Measurement sampling\n",
+        "\n",
+        "qsim also supports sampling from user-defined measurement gates. Note that since qsim and Cirq use different random number generators, identical runs on both simulators may give different results, even if they use the same seed."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "NRJvtqYrnylJ",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 157
+        },
+        "outputId": "19b5b63a-d1fd-4e57-ce12-fdd6f4217b69"
+      },
+      "source": [
+        "# Define a circuit with measurements.\n",
+        "q0, q1 = cirq.LineQubit.range(2)\n",
+        "circuit = cirq.Circuit(\n",
+        "    cirq.H(q0), cirq.X(q1), cirq.CX(q0, q1),\n",
+        "    cirq.measure(q0, key='qubit_0'),\n",
+        "    cirq.measure(q1, key='qubit_1'),\n",
+        ")\n",
+        "\n",
+        "# Simulate the circuit with Cirq and return just the measurement values.\n",
+        "print('Cirq results:')\n",
+        "cirq_simulator = cirq.Simulator()\n",
+        "cirq_results = cirq_simulator.run(circuit, repetitions=5)\n",
+        "print(cirq_results)\n",
+        "print()\n",
+        "\n",
+        "# Simulate the circuit with qsim and return just the measurement values.\n",
+        "print('qsim results:')\n",
+        "qsim_simulator = qsimcirq.QSimSimulator()\n",
+        "qsim_results = qsim_simulator.run(circuit, repetitions=5)\n",
+        "print(qsim_results)"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Cirq results:\n",
+            "qubit_0=10100\n",
+            "qubit_1=01011\n",
+            "\n",
+            "qsim results:\n",
+            "Provided circuit has no intermediate measurements. It may be faster to sample from the final state vector. Continuing with one-by-one sampling.\n",
+            "qubit_0=00100\n",
+            "qubit_1=11011\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "6NoSr0E_wgR_",
+        "colab_type": "text"
+      },
+      "source": [
+        "The warning above highlights an important distinction between the `simulate` and `run` methods:\n",
+        "\n",
+        "*   `simulate` only executes the circuit once. Sampling from the resulting state is fast, but if there are intermediate measurements the final state vector depends on the results of those measurements.\n",
+        "*   `run` will execute the circuit once for each repetition requested. As a result, sampling is much slower, but intermediate measurements are re-sampled for each repetition.\n",
+        "\n",
+        "The warning goes away if intermediate measurements are present:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "hFrwYjWM0Hpa",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 87
+        },
+        "outputId": "15e89037-dcbb-4619-a8ed-a10bbf8f8040"
+      },
+      "source": [
+        "# Define a circuit with intermediate measurements.\n",
+        "q0 = cirq.LineQubit(0)\n",
+        "circuit = cirq.Circuit(\n",
+        "    cirq.X(q0)**0.5, cirq.measure(q0, key='m0'),\n",
+        "    cirq.X(q0)**0.5, cirq.measure(q0, key='m1'),\n",
+        "    cirq.X(q0)**0.5, cirq.measure(q0, key='m2'),\n",
+        ")\n",
+        "\n",
+        "# Simulate the circuit with qsim and return just the measurement values.\n",
+        "print('qsim results:')\n",
+        "qsim_simulator = qsimcirq.QSimSimulator()\n",
+        "qsim_results = qsim_simulator.run(circuit, repetitions=5)\n",
+        "print(qsim_results)"
+      ],
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "qsim results:\n",
+            "m0=00001\n",
+            "m1=11100\n",
+            "m2=00001\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KhPHBKpi0lYE",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Amplitude evaluation\n",
+        "\n",
+        "qsim can also calculate amplitudes for specific output bitstrings."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "aCbvXO6M1jWB",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 104
+        },
+        "outputId": "e2d3a80f-00c1-4248-e7ef-175e007eadf1"
+      },
+      "source": [
+        "# Define a simple circuit.\n",
+        "q0, q1 = cirq.LineQubit.range(2)\n",
+        "circuit = cirq.Circuit(cirq.H(q0), cirq.CX(q0, q1))\n",
+        "\n",
+        "# Simulate the circuit with qsim and return the amplitudes for |00) and |01).\n",
+        "print('Cirq results:')\n",
+        "cirq_simulator = cirq.Simulator()\n",
+        "cirq_results = cirq_simulator.compute_amplitudes(\n",
+        "    circuit, bitstrings=[0b00, 0b01])\n",
+        "print(cirq_results)\n",
+        "print()\n",
+        "\n",
+        "# Simulate the circuit with qsim and return the amplitudes for |00) and |01).\n",
+        "print('qsim results:')\n",
+        "qsim_simulator = qsimcirq.QSimSimulator()\n",
+        "qsim_results = qsim_simulator.compute_amplitudes(\n",
+        "    circuit, bitstrings=[0b00, 0b01])\n",
+        "print(qsim_results)"
+      ],
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Cirq results:\n",
+            "[0.70710677+0.j 0.        +0.j]\n",
+            "\n",
+            "qsim results:\n",
+            "[(0.7071067690849304+0j), 0j]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zy5XRdkm219l",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Performance benchmark\n",
+        "\n",
+        "The code below generates a depth-16 circuit on a 4x5 qubit grid, then runs it against the basic Cirq simulator. For a circuit of this size, the difference in runtime can be significant - try it out!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "SyRpm08R3qCy",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 69
+        },
+        "outputId": "790ad8b5-e665-44e4-c33c-177cf98dba5a"
+      },
+      "source": [
+        "import time\n",
+        "\n",
+        "qubits = [cirq.GridQubit(i,j) for i in range(4) for j in range(5)]\n",
+        "\n",
+        "# Generates a random circuit on the provided qubits.\n",
+        "circuit = cirq.experiments.random_rotations_between_grid_interaction_layers_circuit(\n",
+        "    qubits=qubits, depth=16)\n",
+        "\n",
+        "# Simulate the circuit with Cirq and print the runtime.\n",
+        "cirq_simulator = cirq.Simulator()\n",
+        "cirq_start = time.time()\n",
+        "cirq_results = cirq_simulator.simulate(circuit)\n",
+        "cirq_elapsed = time.time() - cirq_start\n",
+        "print(f'Cirq runtime: {cirq_elapsed}')\n",
+        "print()\n",
+        "\n",
+        "# Simulate the circuit with qsim and print the runtime.\n",
+        "qsim_simulator = qsimcirq.QSimSimulator()\n",
+        "qsim_start = time.time()\n",
+        "qsim_results = qsim_simulator.simulate(circuit)\n",
+        "qsim_elapsed = time.time() - qsim_start\n",
+        "print(f'qsim runtime: {qsim_elapsed}')\n"
+      ],
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Cirq runtime: 6.024493217468262\n",
+            "\n",
+            "qsim runtime: 0.12877583503723145\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LgWOEMLKutsq",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Distributed execution\n",
+        "\n",
+        "qsimh (qsim-hybrid) is a second library in the qsim repository that takes a slightly different approach to circuit simulation. When simulating a quantum circuit, it's possible to simplify the execution by assigning fixed values to certain gates. This operation is called \"slicing\" (or \"cutting\") the gates, because it removes a portion of the overall state.\n",
+        "\n",
+        "qsimh takes advantage of the \"slicing\" operation by selecting a set of gates to \"slice\" and assigning each possible value of those gates across a set of executors running in parallel. By adding up the results afterwards, the total state can be recovered."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "t3OkT3FKuuhp",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 87
+        },
+        "outputId": "70e32f8c-7e25-4cff-fb73-9f305ba111c6"
+      },
+      "source": [
+        "# Pick a pair of qubits.\n",
+        "q0 = cirq.GridQubit(0, 0)\n",
+        "q1 = cirq.GridQubit(0, 1)\n",
+        "\n",
+        "# Create a circuit that entangles the pair.\n",
+        "circuit = cirq.Circuit(\n",
+        "    cirq.H(q0), cirq.CX(q0, q1), cirq.X(q1)\n",
+        ")\n",
+        "print(\"Circuit:\")\n",
+        "print(circuit)"
+      ],
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Circuit:\n",
+            "(0, 0): ───H───@───────\n",
+            "               │\n",
+            "(0, 1): ───────X───X───\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KUAwCOGeu0wA",
+        "colab_type": "text"
+      },
+      "source": [
+        "In order to let qsimh know how we want to split up the circuit, we need to pass it some additional options. More detail on these can be found in the qsim [usage doc](https://github.com/quantumlib/qsim/blob/master/docs/usage.md), but the fundamentals are explained below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "VXc-A8e7u262",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "94135f91-8da0-4c45-82e5-8b039a00a122"
+      },
+      "source": [
+        "options = {}\n",
+        "\n",
+        "# 'k' indicates the qubits on one side of the cut.\n",
+        "# We'll use qubit 0 for this.\n",
+        "options['k'] = [0]\n",
+        "\n",
+        "# 'p' and 'r' control when values are assigned to cut gates.\n",
+        "# There are some intricacies in choosing values for these options,\n",
+        "# but for now we'll set p=1 and r=0.\n",
+        "# This allows us to pre-assign the value of the CX gate\n",
+        "# and distribute its execution to multiple jobs.\n",
+        "options['p'] = 1\n",
+        "options['r'] = 0\n",
+        "\n",
+        "# 'w' indicates the value pre-assigned to the cut.\n",
+        "# This should change for each execution.\n",
+        "options['w'] = 0\n",
+        "\n",
+        "# Create the qsimh simulator with those options.\n",
+        "qsimh_simulator = qsimcirq.QSimhSimulator(options)\n",
+        "results_0 = qsimh_simulator.compute_amplitudes(\n",
+        "    circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])\n",
+        "print(results_0)"
+      ],
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[0j, (0.7071067690849304+0j), 0j, 0j]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eij3DsN4u5Om",
+        "colab_type": "text"
+      },
+      "source": [
+        "Now to run the other side of the cut..."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "py6I1omau6Gk",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "97d0424b-861a-465d-e814-a0d6776d7ecb"
+      },
+      "source": [
+        "options['w'] = 1\n",
+        "\n",
+        "qsimh_simulator = qsimcirq.QSimhSimulator(options)\n",
+        "results_1 = qsimh_simulator.compute_amplitudes(\n",
+        "    circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])\n",
+        "print(results_1)"
+      ],
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[0j, 0j, (0.7071067690849304+0j), 0j]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wnjmLDedu7j4",
+        "colab_type": "text"
+      },
+      "source": [
+        "...and add the two together. The results of a normal qsim simulation are shown for comparison."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "YQoyZ6ldu7--",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 87
+        },
+        "outputId": "8ea740bb-2d31-4b76-fd36-e8e994e9fc3b"
+      },
+      "source": [
+        "results = [r0 + r1 for r0, r1 in zip(results_0, results_1)]\n",
+        "print(\"qsimh results:\")\n",
+        "print(results)\n",
+        "\n",
+        "qsim_simulator = qsimcirq.QSimSimulator()\n",
+        "qsim_simulator.compute_amplitudes(circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])\n",
+        "print(\"qsim results:\")\n",
+        "print(results)"
+      ],
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "qsimh results:\n",
+            "[0j, (0.7071067690849304+0j), (0.7071067690849304+0j), 0j]\n",
+            "qsim results:\n",
+            "[0j, (0.7071067690849304+0j), (0.7071067690849304+0j), 0j]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "o11JcJJ8vEfW",
+        "colab_type": "text"
+      },
+      "source": [
+        "The key point to note here is that `results_0` and `results_1` are completely independent - they can be run in parallel on two separate machines, with no communication between the two. Getting the full result requires `2^p` executions, but each individual result is much cheaper to calculate than trying to do the whole circuit at once."
+      ]
+    }
+  ]
+}

--- a/docs/qsimcirq_tutorial.ipynb
+++ b/docs/qsimcirq_tutorial.ipynb
@@ -63,7 +63,7 @@
           "base_uri": "https://localhost:8080/",
           "height": 139
         },
-        "outputId": "c9f7a9cb-89d7-42b6-86a4-c82acb65682a"
+        "outputId": "a1b4abf1-3405-4d93-f514-eeb43cf06329"
       },
       "source": [
         "import cirq\n",
@@ -88,7 +88,7 @@
         "qsim_results = qsim_simulator.simulate(circuit)\n",
         "print(qsim_results)"
       ],
-      "execution_count": 4,
+      "execution_count": 2,
       "outputs": [
         {
           "output_type": "stream",
@@ -124,26 +124,26 @@
           "base_uri": "https://localhost:8080/",
           "height": 192
         },
-        "outputId": "bd5c1c0e-da22-4327-fc78-10f4f2eda697"
+        "outputId": "0c5a4363-bb23-4602-8c50-1f8935d9ac0c"
       },
       "source": [
         "samples = cirq.sample_state_vector(\n",
         "    qsim_results.state_vector(), indices=[0, 1], repetitions=10)\n",
         "print(samples)"
       ],
-      "execution_count": 5,
+      "execution_count": 3,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "[[0 0]\n",
+            "[[1 1]\n",
+            " [0 0]\n",
+            " [1 1]\n",
+            " [1 1]\n",
             " [0 0]\n",
             " [0 0]\n",
             " [0 0]\n",
-            " [0 0]\n",
-            " [0 0]\n",
-            " [0 0]\n",
-            " [0 0]\n",
+            " [1 1]\n",
             " [1 1]\n",
             " [1 1]]\n"
           ],
@@ -172,7 +172,7 @@
           "base_uri": "https://localhost:8080/",
           "height": 157
         },
-        "outputId": "19b5b63a-d1fd-4e57-ce12-fdd6f4217b69"
+        "outputId": "0c5ec393-116e-4c43-c090-3d680ca159a6"
       },
       "source": [
         "# Define a circuit with measurements.\n",
@@ -196,19 +196,19 @@
         "qsim_results = qsim_simulator.run(circuit, repetitions=5)\n",
         "print(qsim_results)"
       ],
-      "execution_count": 6,
+      "execution_count": 4,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
             "Cirq results:\n",
-            "qubit_0=10100\n",
-            "qubit_1=01011\n",
+            "qubit_0=00110\n",
+            "qubit_1=11001\n",
             "\n",
             "qsim results:\n",
             "Provided circuit has no intermediate measurements. It may be faster to sample from the final state vector. Continuing with one-by-one sampling.\n",
-            "qubit_0=00100\n",
-            "qubit_1=11011\n"
+            "qubit_0=10101\n",
+            "qubit_1=01010\n"
           ],
           "name": "stdout"
         }
@@ -238,7 +238,7 @@
           "base_uri": "https://localhost:8080/",
           "height": 87
         },
-        "outputId": "15e89037-dcbb-4619-a8ed-a10bbf8f8040"
+        "outputId": "82069260-0824-4cb4-e5ef-ff606a89ce3d"
       },
       "source": [
         "# Define a circuit with intermediate measurements.\n",
@@ -255,15 +255,15 @@
         "qsim_results = qsim_simulator.run(circuit, repetitions=5)\n",
         "print(qsim_results)"
       ],
-      "execution_count": 7,
+      "execution_count": 5,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
             "qsim results:\n",
-            "m0=00001\n",
-            "m1=11100\n",
-            "m2=00001\n"
+            "m0=00011\n",
+            "m1=11111\n",
+            "m2=00110\n"
           ],
           "name": "stdout"
         }
@@ -290,7 +290,7 @@
           "base_uri": "https://localhost:8080/",
           "height": 104
         },
-        "outputId": "e2d3a80f-00c1-4248-e7ef-175e007eadf1"
+        "outputId": "b6044896-ce55-4de6-b2a2-4cb73851d06d"
       },
       "source": [
         "# Define a simple circuit.\n",
@@ -312,7 +312,7 @@
         "    circuit, bitstrings=[0b00, 0b01])\n",
         "print(qsim_results)"
       ],
-      "execution_count": 8,
+      "execution_count": 6,
       "outputs": [
         {
           "output_type": "stream",
@@ -348,7 +348,7 @@
           "base_uri": "https://localhost:8080/",
           "height": 69
         },
-        "outputId": "790ad8b5-e665-44e4-c33c-177cf98dba5a"
+        "outputId": "2ac571b0-a9c9-4ea7-8c22-2acbe6e33d04"
       },
       "source": [
         "import time\n",
@@ -374,14 +374,56 @@
         "qsim_elapsed = time.time() - qsim_start\n",
         "print(f'qsim runtime: {qsim_elapsed}')\n"
       ],
-      "execution_count": 9,
+      "execution_count": 7,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "Cirq runtime: 6.024493217468262\n",
+            "Cirq runtime: 6.540446519851685\n",
             "\n",
-            "qsim runtime: 0.12877583503723145\n"
+            "qsim runtime: 0.11791229248046875\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OUjhKoRVZGKZ",
+        "colab_type": "text"
+      },
+      "source": [
+        "qsim performance can be tuned further by passing options to the simulator constructor. These options use the same format as the qsim_base binary - a full description can be found in the qsim [usage doc](https://github.com/quantumlib/qsim/blob/master/docs/usage.md)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "yE6ZXAKzZL5P",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "1b833005-f23a-42ea-a7d7-b57624bbd3cf"
+      },
+      "source": [
+        "# Use eight threads to parallelize simulation.\n",
+        "options = {'t': 8}\n",
+        "\n",
+        "qsim_simulator = qsimcirq.QSimSimulator(options)\n",
+        "qsim_start = time.time()\n",
+        "qsim_results = qsim_simulator.simulate(circuit)\n",
+        "qsim_elapsed = time.time() - qsim_start\n",
+        "print(f'qsim runtime: {qsim_elapsed}')"
+      ],
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "qsim runtime: 0.12204647064208984\n"
           ],
           "name": "stdout"
         }
@@ -396,9 +438,9 @@
       "source": [
         "# Distributed execution\n",
         "\n",
-        "qsimh (qsim-hybrid) is a second library in the qsim repository that takes a slightly different approach to circuit simulation. When simulating a quantum circuit, it's possible to simplify the execution by assigning fixed values to certain gates. This operation is called \"slicing\" (or \"cutting\") the gates, because it removes a portion of the overall state.\n",
+        "qsimh (qsim-hybrid) is a second library in the qsim repository that takes a slightly different approach to circuit simulation. When simulating a quantum circuit, it's possible to simplify the execution by decomposing a subset of two-qubit gates into pairs of one-qubit gates with shared indices. This operation is called \"slicing\" (or \"cutting\") the gates.\n",
         "\n",
-        "qsimh takes advantage of the \"slicing\" operation by selecting a set of gates to \"slice\" and assigning each possible value of those gates across a set of executors running in parallel. By adding up the results afterwards, the total state can be recovered."
+        "qsimh takes advantage of the \"slicing\" operation by selecting a set of gates to \"slice\" and assigning each possible value of the shared indices across a set of executors running in parallel. By adding up the results afterwards, the total state can be recovered."
       ]
     },
     {
@@ -410,7 +452,7 @@
           "base_uri": "https://localhost:8080/",
           "height": 87
         },
-        "outputId": "70e32f8c-7e25-4cff-fb73-9f305ba111c6"
+        "outputId": "d75c1530-9630-48f7-a08e-e7f176748688"
       },
       "source": [
         "# Pick a pair of qubits.\n",
@@ -424,7 +466,7 @@
         "print(\"Circuit:\")\n",
         "print(circuit)"
       ],
-      "execution_count": 10,
+      "execution_count": 9,
       "outputs": [
         {
           "output_type": "stream",
@@ -457,7 +499,7 @@
           "base_uri": "https://localhost:8080/",
           "height": 34
         },
-        "outputId": "94135f91-8da0-4c45-82e5-8b039a00a122"
+        "outputId": "bac79fd2-c2a6-47b6-8eec-fb41c6e5cf83"
       },
       "source": [
         "options = {}\n",
@@ -466,10 +508,10 @@
         "# We'll use qubit 0 for this.\n",
         "options['k'] = [0]\n",
         "\n",
-        "# 'p' and 'r' control when values are assigned to cut gates.\n",
+        "# 'p' and 'r' control when values are assigned to cut indices.\n",
         "# There are some intricacies in choosing values for these options,\n",
         "# but for now we'll set p=1 and r=0.\n",
-        "# This allows us to pre-assign the value of the CX gate\n",
+        "# This allows us to pre-assign the value of the CX indices\n",
         "# and distribute its execution to multiple jobs.\n",
         "options['p'] = 1\n",
         "options['r'] = 0\n",
@@ -484,7 +526,7 @@
         "    circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])\n",
         "print(results_0)"
       ],
-      "execution_count": 11,
+      "execution_count": 10,
       "outputs": [
         {
           "output_type": "stream",
@@ -514,7 +556,7 @@
           "base_uri": "https://localhost:8080/",
           "height": 34
         },
-        "outputId": "97d0424b-861a-465d-e814-a0d6776d7ecb"
+        "outputId": "e5aaedd0-50f4-4917-fa3b-dca3b983cd50"
       },
       "source": [
         "options['w'] = 1\n",
@@ -524,7 +566,7 @@
         "    circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])\n",
         "print(results_1)"
       ],
-      "execution_count": 12,
+      "execution_count": 11,
       "outputs": [
         {
           "output_type": "stream",
@@ -554,7 +596,7 @@
           "base_uri": "https://localhost:8080/",
           "height": 87
         },
-        "outputId": "8ea740bb-2d31-4b76-fd36-e8e994e9fc3b"
+        "outputId": "86999786-a399-4128-f82b-84da694f1875"
       },
       "source": [
         "results = [r0 + r1 for r0, r1 in zip(results_0, results_1)]\n",
@@ -566,7 +608,7 @@
         "print(\"qsim results:\")\n",
         "print(results)"
       ],
-      "execution_count": 13,
+      "execution_count": 12,
       "outputs": [
         {
           "output_type": "stream",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ description = ('Schrödinger and Schrödinger-Feynman simulators for quantum cir
 # README file as long_description.
 long_description = open('README.md', encoding='utf-8').read()
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 setup(
     name='qsimcirq',


### PR DESCRIPTION
Contingent on PR #176. The Jupyter notebook has been tested with the HEAD version of qsim, but in its current state it will fail until version 0.3.0 is released. Requesting review from @karlunho for this notebook.

To run the notebook, replace the qsimcirq installation line with this:
```
pip install git+https://github.com/quantumlib/qsim.git --quiet
```

This PR will be immediately followed by the 0.3.0 release of qsimcirq on PyPI.