### PR TITLE
Docstrings for gate types.

### DIFF
--- a/lib/gate.h
+++ b/lib/gate.h
@@ -27,7 +27,9 @@ enum GateAnyKind {
   kGateAny = -1,
 };
 
-// Gate is a generic gate to make it easier to use qsim with external gate sets.
+/**
+ * A generic gate to make it easier to use qsim with external gate sets.
+ */
 template <typename FP, typename GK = GateAnyKind>
 struct Gate {
   using fp_type = FP;

--- a/lib/gates_cirq.h
+++ b/lib/gates_cirq.h
@@ -83,6 +83,9 @@ constexpr double is2_double = 0.7071067811865475;
 
 // Gates from cirq/ops/identity.py:
 
+/**
+ * A one-qubit identity gate.
+ */
 template <typename fp_type>
 struct I {
   static constexpr GateKind kind = kI;
@@ -95,6 +98,9 @@ struct I {
   }
 };
 
+/**
+ * A two-qubit identity gate.
+ */
 template <typename fp_type>
 struct I2 {
   static constexpr GateKind kind = kI2;
@@ -118,6 +124,9 @@ struct I2 {
 
 // Gates form cirq/ops/common_gates.py:
 
+/**
+ * A gate that rotates around the X axis of the Bloch sphere.
+ */
 template <typename fp_type>
 struct XPowGate {
   static constexpr GateKind kind = kXPowGate;
@@ -139,6 +148,9 @@ struct XPowGate {
   }
 };
 
+/**
+ * A gate that rotates around the Y axis of the Bloch sphere.
+ */
 template <typename fp_type>
 struct YPowGate {
   static constexpr GateKind kind = kYPowGate;
@@ -160,6 +172,9 @@ struct YPowGate {
   }
 };
 
+/**
+ * A gate that rotates around the Z axis of the Bloch sphere.
+ */
 template <typename fp_type>
 struct ZPowGate {
   static constexpr GateKind kind = kZPowGate;
@@ -181,6 +196,9 @@ struct ZPowGate {
   }
 };
 
+/**
+ * A gate that rotates around the X+Z axis of the Bloch sphere.
+ */
 template <typename fp_type>
 struct HPowGate {
   static constexpr GateKind kind = kHPowGate;
@@ -206,6 +224,9 @@ struct HPowGate {
   }
 };
 
+/**
+ * A gate that applies a phase to the |11⟩ state of two qubits.
+ */
 template <typename fp_type>
 struct CZPowGate {
   static constexpr GateKind kind = kCZPowGate;
@@ -242,6 +263,9 @@ struct CZPowGate {
   }
 };
 
+/**
+ * A gate that applies a controlled power of an X gate.
+ */
 template <typename fp_type>
 struct CXPowGate {
   static constexpr GateKind kind = kCXPowGate;
@@ -285,8 +309,10 @@ struct CXPowGate {
   }
 };
 
-// The (exponent=phi/pi, global_shift=-0.5) instance of XPowGate.
-// This is a function in Cirq.
+/**
+ * The `(exponent = phi/pi, global_shift = -0.5)` instance of XPowGate.
+ * This is a function in Cirq.
+ */
 template <typename fp_type>
 struct rx {
   static constexpr GateKind kind = krx;
@@ -302,8 +328,10 @@ struct rx {
   }
 };
 
-// The (exponent=phi/pi, global_shift=-0.5) instance of YPowGate.
-// This is a function in Cirq.
+/**
+ * The `(exponent = phi/pi, global_shift = -0.5)` instance of YPowGate.
+ * This is a function in Cirq.
+ */
 template <typename fp_type>
 struct ry {
   static constexpr GateKind kind = kry;
@@ -319,8 +347,10 @@ struct ry {
   }
 };
 
-// The (exponent=phi/pi, global_shift=-0.5) instance of ZPowGate.
-// This is a function in Cirq.
+/**
+ * The `(exponent = phi/pi, global_shift = -0.5)` instance of ZPowGate.
+ * This is a function in Cirq.
+ */
 template <typename fp_type>
 struct rz {
   static constexpr GateKind kind = krz;
@@ -336,7 +366,9 @@ struct rz {
   }
 };
 
-// The (exponent=1, global_shift=0) instance of HPowGate.
+/**
+ * The `(exponent = 1, global_shift = 0)` instance of HPowGate.
+ */
 template <typename fp_type>
 struct H {
   static constexpr GateKind kind = kH;
@@ -351,7 +383,9 @@ struct H {
   }
 };
 
-// The (exponent=0.5, global_shift=0) instance of ZPowGate.
+/**
+ * The `(exponent = 0.5, global_shift = 0)` instance of ZPowGate.
+ */
 template <typename fp_type>
 struct S {
   static constexpr GateKind kind = kS;
@@ -364,7 +398,9 @@ struct S {
   }
 };
 
-// The (exponent=0.25, global_shift=0) instance of ZPowGate.
+/**
+ * The `(exponent = 0.25, global_shift = 0)` instance of ZPowGate.
+ */
 template <typename fp_type>
 struct T {
   static constexpr GateKind kind = kT;
@@ -379,7 +415,9 @@ struct T {
   }
 };
 
-// The (exponent=1, global_shift=0) instance of CZPowGate.
+/**
+ * The `(exponent = 1, global_shift = 0)` instance of CZPowGate.
+ */
 template <typename fp_type>
 struct CZ {
   static constexpr GateKind kind = kCZ;
@@ -405,7 +443,9 @@ struct CZ {
 template <typename fp_type>
 using CNotPowGate = CXPowGate<fp_type>;
 
-// The (exponent=1, global_shift=0) instance of CZPowGate.
+/**
+ * The `(exponent = 1, global_shift = 0)` instance of CXPowGate.
+ */
 template <typename fp_type>
 struct CX {
   static constexpr GateKind kind = kCX;
@@ -434,7 +474,9 @@ using CNOT = CX<fp_type>;
 
 // Gates from cirq/ops/pauli_gates.py:
 
-// The (exponent=1, global_shift=0) instance of XPowGate.
+/**
+ * The `(exponent = 1, global_shift = 0)` instance of XPowGate.
+ */
 template <typename fp_type>
 struct X : public XPowGate<fp_type> {
   static constexpr GateKind kind = kX;
@@ -447,7 +489,9 @@ struct X : public XPowGate<fp_type> {
   }
 };
 
-// The (exponent=1, global_shift=0) instance of YPowGate.
+/**
+ * The `(exponent = 1, global_shift = 0)` instance of YPowGate.
+ */
 template <typename fp_type>
 struct Y : public YPowGate<fp_type> {
   static constexpr GateKind kind = kY;
@@ -460,7 +504,9 @@ struct Y : public YPowGate<fp_type> {
   }
 };
 
-// The (exponent=1, global_shift=0) instance of ZPowGate.
+/**
+ * The `(exponent = 1, global_shift = 0)` instance of ZPowGate.
+ */
 template <typename fp_type>
 struct Z : public ZPowGate<fp_type> {
   static constexpr GateKind kind = kZ;
@@ -475,6 +521,9 @@ struct Z : public ZPowGate<fp_type> {
 
 // Gates from cirq/ops/phased_x_gate.py:
 
+/**
+ * An XPowGate conjugated by ZPowGate%s.
+ */
 template <typename fp_type>
 struct PhasedXPowGate {
   static constexpr GateKind kind = kPhasedXPowGate;
@@ -507,6 +556,9 @@ struct PhasedXPowGate {
 
 // Gates from cirq/ops/phased_x_z_gate.py:
 
+/**
+ * A PhasedXPowGate followed by a ZPowGate.
+ */
 template <typename fp_type>
 struct PhasedXZGate {
   static constexpr GateKind kind = kPhasedXZGate;
@@ -542,6 +594,9 @@ struct PhasedXZGate {
 
 // Gates from cirq/ops/parity_gates.py:
 
+/**
+ * The X-parity gate, possibly raised to an exponent.
+ */
 template <typename fp_type>
 struct XXPowGate {
   static constexpr GateKind kind = kXXPowGate;
@@ -586,6 +641,9 @@ struct XXPowGate {
   }
 };
 
+/**
+ * The Y-parity gate, possibly raised to an exponent.
+ */
 template <typename fp_type>
 struct YYPowGate {
   static constexpr GateKind kind = kYYPowGate;
@@ -630,6 +688,9 @@ struct YYPowGate {
   }
 };
 
+/**
+ * The Z-parity gate, possibly raised to an exponent.
+ */
 template <typename fp_type>
 struct ZZPowGate {
   static constexpr GateKind kind = kZZPowGate;
@@ -670,7 +731,9 @@ struct ZZPowGate {
   }
 };
 
-// The (exponent=1, global_shift=0) instance of XXPowGate.
+/**
+ * The `(exponent = 1, global_shift = 0)` instance of XXPowGate.
+ */
 template <typename fp_type>
 struct XX {
   static constexpr GateKind kind = kXX;
@@ -692,7 +755,9 @@ struct XX {
   }
 };
 
-// The (exponent=1, global_shift=0) instance of YYPowGate.
+/**
+ * The `(exponent = 1, global_shift = 0)` instance of YYPowGate.
+ */
 template <typename fp_type>
 struct YY {
   static constexpr GateKind kind = kYY;
@@ -714,7 +779,9 @@ struct YY {
   }
 };
 
-// The (exponent=1, global_shift=0) instance of ZZPowGate.
+/**
+ * The `(exponent = 1, global_shift = 0)` instance of ZZPowGate.
+ */
 template <typename fp_type>
 struct ZZ {
   static constexpr GateKind kind = kZZ;
@@ -738,6 +805,9 @@ struct ZZ {
 
 // Gates from cirq/ops/swap_gates.py:
 
+/**
+ * The SWAP gate, possibly raised to a power. Exchanges qubits.
+ */
 template <typename fp_type>
 struct SwapPowGate {
   static constexpr GateKind kind = kSwapPowGate;
@@ -785,6 +855,9 @@ struct SwapPowGate {
   }
 };
 
+/**
+ * Rotates the |01⟩ vs |10⟩ subspace of two qubits around its Bloch X-axis.
+ */
 template <typename fp_type>
 struct ISwapPowGate {
   static constexpr GateKind kind = kISwapPowGate;
@@ -828,8 +901,10 @@ struct ISwapPowGate {
   }
 };
 
-// The (exponent=2*phi/pi, global_shift=0) instance of ISwapPowGate.
-// This is a function in Cirq.
+/**
+ * The `(exponent = 2*phi/pi, global_shift = 0)` instance of ISwapPowGate.
+ * This is a function in Cirq.
+ */
 template <typename fp_type>
 struct riswap {
   static constexpr GateKind kind = kriswap;
@@ -864,7 +939,9 @@ struct riswap {
   }
 };
 
-// The (exponent=1, global_shift=0) instance of SwapPowGate.
+/**
+ * The `(exponent = 1, global_shift = 0)` instance of SwapPowGate.
+ */
 template <typename fp_type>
 struct SWAP {
   static constexpr GateKind kind = kSWAP;
@@ -891,7 +968,9 @@ struct SWAP {
   }
 };
 
-// The (exponent=1, global_shift=0) instance of ISwapPowGate.
+/**
+ * The `(exponent = 1, global_shift = 0)` instance of ISwapPowGate.
+ */
 template <typename fp_type>
 struct ISWAP {
   static constexpr GateKind kind = kISWAP;
@@ -921,6 +1000,9 @@ struct ISWAP {
 
 // Gates from cirq/ops/phased_iswap_gate.py:
 
+/**
+ * An ISwapPowGate conjugated by ZPowGate%s.
+ */
 template <typename fp_type>
 struct PhasedISwapPowGate {
   static constexpr GateKind kind = kPhasedISwapPowGate;
@@ -963,8 +1045,10 @@ struct PhasedISwapPowGate {
   }
 };
 
-// The (phase_exponent=0.25, exponent=2*phi/pi) instance of PhasedISwapPowGate.
-// This is a function in Cirq.
+/**
+ * The `(phase_exponent = 0.25, exponent = 2*phi/pi)` instance of
+ * PhasedISwapPowGate. This is a function in Cirq.
+ */
 template <typename fp_type>
 struct givens {
   static constexpr GateKind kind = kgivens;
@@ -1002,6 +1086,9 @@ struct givens {
 
 // Gates from cirq/ops/fsim_gate.py:
 
+/**
+ * The fermionic simulation gate family.
+ */
 template <typename fp_type>
 struct FSimGate {
   static constexpr GateKind kind = kFSimGate;
@@ -1073,6 +1160,9 @@ struct FSimGate {
 
 // Gates from cirq/ops/matrix_gates.py:
 
+/**
+ * A unitary one-qubit gate defined entirely by its matrix.
+ */
 template <typename fp_type>
 struct MatrixGate1 {
   static constexpr GateKind kind = kMatrixGate1;
@@ -1089,6 +1179,9 @@ struct MatrixGate1 {
   }
 };
 
+/**
+ * A unitary two-qubit gate defined entirely by its matrix.
+ */
 template <typename fp_type>
 struct MatrixGate2 {
   static constexpr GateKind kind = kMatrixGate2;

--- a/lib/gates_cirq.h
+++ b/lib/gates_cirq.h
@@ -126,6 +126,7 @@ struct I2 {
 
 /**
  * A gate that rotates around the X axis of the Bloch sphere.
+ * This is a generalization of the X gate.
  */
 template <typename fp_type>
 struct XPowGate {
@@ -150,6 +151,7 @@ struct XPowGate {
 
 /**
  * A gate that rotates around the Y axis of the Bloch sphere.
+ * This is a generalization of the Y gate.
  */
 template <typename fp_type>
 struct YPowGate {
@@ -174,6 +176,7 @@ struct YPowGate {
 
 /**
  * A gate that rotates around the Z axis of the Bloch sphere.
+ * This is a generalization of the Z gate.
  */
 template <typename fp_type>
 struct ZPowGate {
@@ -198,6 +201,7 @@ struct ZPowGate {
 
 /**
  * A gate that rotates around the X+Z axis of the Bloch sphere.
+ * This is a generalization of the Hadamard gate.
  */
 template <typename fp_type>
 struct HPowGate {
@@ -226,6 +230,7 @@ struct HPowGate {
 
 /**
  * A gate that applies a phase to the |11⟩ state of two qubits.
+ * This is a generalization of the CZ gate.
  */
 template <typename fp_type>
 struct CZPowGate {
@@ -265,6 +270,7 @@ struct CZPowGate {
 
 /**
  * A gate that applies a controlled power of an X gate.
+ * This is a generalization of the CX (or CNOT) gate.
  */
 template <typename fp_type>
 struct CXPowGate {
@@ -311,6 +317,7 @@ struct CXPowGate {
 
 /**
  * The `(exponent = phi/pi, global_shift = -0.5)` instance of XPowGate.
+ * This is equivalent to an X gate with a global phase.
  * This is a function in Cirq.
  */
 template <typename fp_type>
@@ -330,6 +337,7 @@ struct rx {
 
 /**
  * The `(exponent = phi/pi, global_shift = -0.5)` instance of YPowGate.
+ * This is equivalent to a Y gate with a global phase.
  * This is a function in Cirq.
  */
 template <typename fp_type>
@@ -349,6 +357,7 @@ struct ry {
 
 /**
  * The `(exponent = phi/pi, global_shift = -0.5)` instance of ZPowGate.
+ * This is equivalent to a Z gate with a global phase.
  * This is a function in Cirq.
  */
 template <typename fp_type>
@@ -368,6 +377,7 @@ struct rz {
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of HPowGate.
+ * This is the canonical Hadamard (or H) gate.
  */
 template <typename fp_type>
 struct H {
@@ -385,6 +395,7 @@ struct H {
 
 /**
  * The `(exponent = 0.5, global_shift = 0)` instance of ZPowGate.
+ * This is the canonical S gate.
  */
 template <typename fp_type>
 struct S {
@@ -400,6 +411,7 @@ struct S {
 
 /**
  * The `(exponent = 0.25, global_shift = 0)` instance of ZPowGate.
+ * This is the canonical T gate.
  */
 template <typename fp_type>
 struct T {
@@ -417,6 +429,7 @@ struct T {
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of CZPowGate.
+ * This is the canonical CZ gate.
  */
 template <typename fp_type>
 struct CZ {
@@ -445,6 +458,7 @@ using CNotPowGate = CXPowGate<fp_type>;
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of CXPowGate.
+ * This is the canonical CX (or CNOT) gate.
  */
 template <typename fp_type>
 struct CX {
@@ -476,6 +490,7 @@ using CNOT = CX<fp_type>;
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of XPowGate.
+ * This is the canonical Pauli X gate.
  */
 template <typename fp_type>
 struct X : public XPowGate<fp_type> {
@@ -491,6 +506,7 @@ struct X : public XPowGate<fp_type> {
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of YPowGate.
+ * This is the canonical Pauli Y gate.
  */
 template <typename fp_type>
 struct Y : public YPowGate<fp_type> {
@@ -506,6 +522,7 @@ struct Y : public YPowGate<fp_type> {
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of ZPowGate.
+ * This is the canonical Pauli Z gate.
  */
 template <typename fp_type>
 struct Z : public ZPowGate<fp_type> {
@@ -523,6 +540,7 @@ struct Z : public ZPowGate<fp_type> {
 
 /**
  * An XPowGate conjugated by ZPowGate%s.
+ * Equivalent to the circuit `───Z^-p───X^t───Z^p───`.
  */
 template <typename fp_type>
 struct PhasedXPowGate {
@@ -558,6 +576,7 @@ struct PhasedXPowGate {
 
 /**
  * A PhasedXPowGate followed by a ZPowGate.
+ * Equivalent to the circuit `───Z^(-a)──X^x──Z^a───Z^z───`.
  */
 template <typename fp_type>
 struct PhasedXZGate {
@@ -733,6 +752,7 @@ struct ZZPowGate {
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of XXPowGate.
+ * This is the X-parity gate.
  */
 template <typename fp_type>
 struct XX {
@@ -757,6 +777,7 @@ struct XX {
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of YYPowGate.
+ * This is the Y-parity gate.
  */
 template <typename fp_type>
 struct YY {
@@ -781,6 +802,7 @@ struct YY {
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of ZZPowGate.
+ * This is the Z-parity gate.
  */
 template <typename fp_type>
 struct ZZ {
@@ -857,6 +879,7 @@ struct SwapPowGate {
 
 /**
  * Rotates the |01⟩ vs |10⟩ subspace of two qubits around its Bloch X-axis.
+ * This is a generalization of the ISWAP gate.
  */
 template <typename fp_type>
 struct ISwapPowGate {
@@ -903,6 +926,7 @@ struct ISwapPowGate {
 
 /**
  * The `(exponent = 2*phi/pi, global_shift = 0)` instance of ISwapPowGate.
+ * This is equivalent to an ISWAP gate with a global phase.
  * This is a function in Cirq.
  */
 template <typename fp_type>
@@ -941,6 +965,7 @@ struct riswap {
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of SwapPowGate.
+ * This is the canonical SWAP gate.
  */
 template <typename fp_type>
 struct SWAP {
@@ -970,6 +995,7 @@ struct SWAP {
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of ISwapPowGate.
+ * This is the canonical ISWAP gate.
  */
 template <typename fp_type>
 struct ISWAP {
@@ -1002,6 +1028,7 @@ struct ISWAP {
 
 /**
  * An ISwapPowGate conjugated by ZPowGate%s.
+ * Equivalent to the composition `(Z^-p ⊗ Z^p) ISWAP^t (Z^p ⊗ Z^-p)`. 
  */
 template <typename fp_type>
 struct PhasedISwapPowGate {
@@ -1047,7 +1074,9 @@ struct PhasedISwapPowGate {
 
 /**
  * The `(phase_exponent = 0.25, exponent = 2*phi/pi)` instance of
- * PhasedISwapPowGate. This is a function in Cirq.
+ * PhasedISwapPowGate.
+ * This is the "Givens rotation" from numerical linear algebra.
+ * This is a function in Cirq.
  */
 template <typename fp_type>
 struct givens {
@@ -1087,7 +1116,8 @@ struct givens {
 // Gates from cirq/ops/fsim_gate.py:
 
 /**
- * The fermionic simulation gate family.
+ * The fermionic simulation gate family. Contains all two-qubit interactions
+ * that preserve excitations, up to single-qubit rotations and global phase.
  */
 template <typename fp_type>
 struct FSimGate {
@@ -1161,7 +1191,7 @@ struct FSimGate {
 // Gates from cirq/ops/matrix_gates.py:
 
 /**
- * A unitary one-qubit gate defined entirely by its matrix.
+ * A one-qubit gate defined entirely by its matrix.
  */
 template <typename fp_type>
 struct MatrixGate1 {
@@ -1180,7 +1210,7 @@ struct MatrixGate1 {
 };
 
 /**
- * A unitary two-qubit gate defined entirely by its matrix.
+ * A two-qubit gate defined entirely by its matrix.
  */
 template <typename fp_type>
 struct MatrixGate2 {

--- a/lib/gates_cirq.h
+++ b/lib/gates_cirq.h
@@ -317,7 +317,7 @@ struct CXPowGate {
 
 /**
  * The `(exponent = phi/pi, global_shift = -0.5)` instance of XPowGate.
- * This is equivalent to an X gate with a global phase.
+ * This is a generalization of the X gate with a fixed global phase.
  * This is a function in Cirq.
  */
 template <typename fp_type>
@@ -337,7 +337,7 @@ struct rx {
 
 /**
  * The `(exponent = phi/pi, global_shift = -0.5)` instance of YPowGate.
- * This is equivalent to a Y gate with a global phase.
+ * This is a generalization of the Y gate with a fixed global phase.
  * This is a function in Cirq.
  */
 template <typename fp_type>
@@ -357,7 +357,7 @@ struct ry {
 
 /**
  * The `(exponent = phi/pi, global_shift = -0.5)` instance of ZPowGate.
- * This is equivalent to a Z gate with a global phase.
+ * This is a generalization of the Z gate with a fixed global phase.
  * This is a function in Cirq.
  */
 template <typename fp_type>
@@ -614,7 +614,7 @@ struct PhasedXZGate {
 // Gates from cirq/ops/parity_gates.py:
 
 /**
- * The X-parity gate, possibly raised to an exponent.
+ * The tensor product of two X gates, possibly raised to an exponent.
  */
 template <typename fp_type>
 struct XXPowGate {
@@ -661,7 +661,7 @@ struct XXPowGate {
 };
 
 /**
- * The Y-parity gate, possibly raised to an exponent.
+ * The tensor product of two Y gates, possibly raised to an exponent.
  */
 template <typename fp_type>
 struct YYPowGate {
@@ -708,7 +708,7 @@ struct YYPowGate {
 };
 
 /**
- * The Z-parity gate, possibly raised to an exponent.
+ * The tensor product of two Z gates, possibly raised to an exponent.
  */
 template <typename fp_type>
 struct ZZPowGate {
@@ -752,7 +752,7 @@ struct ZZPowGate {
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of XXPowGate.
- * This is the X-parity gate.
+ * This is the tensor product of two X gates.
  */
 template <typename fp_type>
 struct XX {
@@ -777,7 +777,7 @@ struct XX {
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of YYPowGate.
- * This is the Y-parity gate.
+ * This is the tensor product of two Y gates.
  */
 template <typename fp_type>
 struct YY {
@@ -802,7 +802,7 @@ struct YY {
 
 /**
  * The `(exponent = 1, global_shift = 0)` instance of ZZPowGate.
- * This is the Z-parity gate.
+ * This is the tensor product of two Z gates.
  */
 template <typename fp_type>
 struct ZZ {
@@ -926,7 +926,7 @@ struct ISwapPowGate {
 
 /**
  * The `(exponent = 2*phi/pi, global_shift = 0)` instance of ISwapPowGate.
- * This is equivalent to an ISWAP gate with a global phase.
+ * This is a generalization of the ISWAP gate with a fixed global phase of zero.
  * This is a function in Cirq.
  */
 template <typename fp_type>

--- a/lib/gates_qsim.h
+++ b/lib/gates_qsim.h
@@ -59,6 +59,9 @@ constexpr double is2_double = 0.7071067811865475;
 
 // One-qubit gates:
 
+/**
+ * The one-qubit identity gate.
+ */
 template <typename fp_type>
 struct GateId1 {
   static constexpr GateKind kind = kGateId1;
@@ -71,6 +74,9 @@ struct GateId1 {
   }
 };
 
+/**
+ * The Hadamard gate.
+ */
 template <typename fp_type>
 struct GateHd {
   static constexpr GateKind kind = kGateHd;
@@ -85,6 +91,9 @@ struct GateHd {
   }
 };
 
+/**
+ * The T gate, equivalent to `Z ^ 0.25`.
+ */
 template <typename fp_type>
 struct GateT {
   static constexpr GateKind kind = kGateT;
@@ -99,6 +108,9 @@ struct GateT {
   }
 };
 
+/**
+ * The Pauli X (or "NOT") gate.
+ */
 template <typename fp_type>
 struct GateX {
   static constexpr GateKind kind = kGateX;
@@ -111,6 +123,9 @@ struct GateX {
   }
 };
 
+/**
+ * The Pauli Y gate.
+ */
 template <typename fp_type>
 struct GateY {
   static constexpr GateKind kind = kGateY;
@@ -123,6 +138,9 @@ struct GateY {
   }
 };
 
+/**
+ * The Pauli Z gate.
+ */
 template <typename fp_type>
 struct GateZ {
   static constexpr GateKind kind = kGateZ;
@@ -135,6 +153,9 @@ struct GateZ {
   }
 };
 
+/**
+ * The "square root of X" gate.
+ */
 template <typename fp_type>
 struct GateX2 {
   static constexpr GateKind kind = kGateX2;
@@ -149,6 +170,9 @@ struct GateX2 {
   }
 };
 
+/**
+ * The "square root of Y" gate.
+ */
 template <typename fp_type>
 struct GateY2 {
   static constexpr GateKind kind = kGateY2;
@@ -163,6 +187,9 @@ struct GateY2 {
   }
 };
 
+/**
+ * A gate that rotates around the X axis of the Bloch sphere.
+ */
 template <typename fp_type>
 struct GateRX {
   static constexpr GateKind kind = kGateRX;
@@ -179,6 +206,9 @@ struct GateRX {
   }
 };
 
+/**
+ * A gate that rotates around the Y axis of the Bloch sphere.
+ */
 template <typename fp_type>
 struct GateRY {
   static constexpr GateKind kind = kGateRY;
@@ -195,6 +225,9 @@ struct GateRY {
   }
 };
 
+/**
+ * A gate that rotates around the Z axis of the Bloch sphere.
+ */
 template <typename fp_type>
 struct GateRZ {
   static constexpr GateKind kind = kGateRZ;
@@ -211,6 +244,9 @@ struct GateRZ {
   }
 };
 
+/**
+ * A gate that rotates around an arbitrary axis in the XY-plane.
+ */
 template <typename fp_type>
 struct GateRXY {
   static constexpr GateKind kind = kGateRXY;
@@ -230,6 +266,10 @@ struct GateRXY {
   }
 };
 
+/**
+ * A pi / 2 rotation around the X + Y axis.
+ * Analogous to the Hadamard gate, which rotates around the X + Z axis.
+ */
 template <typename fp_type>
 struct GateHZ2 {
   static constexpr GateKind kind = kGateHZ2;
@@ -246,6 +286,9 @@ struct GateHZ2 {
   }
 };
 
+/**
+ * The S gate, equivalent to "square root of Z".
+ */
 template <typename fp_type>
 struct GateS {
   static constexpr GateKind kind = kGateS;
@@ -260,6 +303,9 @@ struct GateS {
 
 // Two-qubit gates:
 
+/**
+ * The two-qubit identity gate.
+ */
 template <typename fp_type>
 struct GateId2 {
   static constexpr GateKind kind = kGateId2;
@@ -281,6 +327,9 @@ struct GateId2 {
   }
 };
 
+/**
+ * The controlled-Z (CZ) gate.
+ */
 template <typename fp_type>
 struct GateCZ {
   static constexpr GateKind kind = kGateCZ;
@@ -303,6 +352,9 @@ struct GateCZ {
   }
 };
 
+/**
+ * The controlled-X (CX or CNOT) gate.
+ */
 template <typename fp_type>
 struct GateCNot {
   static constexpr GateKind kind = kGateCNot;
@@ -326,6 +378,9 @@ struct GateCNot {
   }
 };
 
+/**
+ * The SWAP gate. Exchanges two qubits.
+ */
 template <typename fp_type>
 struct GateSwap {
   static constexpr GateKind kind = kGateSwap;
@@ -352,6 +407,9 @@ struct GateSwap {
   }
 };
 
+/**
+ * The ISWAP gate.
+ */
 template <typename fp_type>
 struct GateIS {
   static constexpr GateKind kind = kGateIS;
@@ -379,6 +437,9 @@ struct GateIS {
   }
 };
 
+/**
+ * The fermionic simulation (FSim) gate.
+ */
 template <typename fp_type>
 struct GateFS {
   static constexpr GateKind kind = kGateFS;
@@ -448,6 +509,9 @@ struct GateFS {
   }
 };
 
+/**
+ * The controlled phase gate. A generalized version of GateCZ.
+ */
 template <typename fp_type>
 struct GateCP {
   static constexpr GateKind kind = kGateCP;

--- a/lib/gates_qsim.h
+++ b/lib/gates_qsim.h
@@ -271,7 +271,6 @@ struct GateRXY {
 
 /**
  * A pi / 2 rotation around the X + Y axis.
- * Analogous to the Hadamard gate, which rotates around the X + Z axis.
  */
 template <typename fp_type>
 struct GateHZ2 {

--- a/lib/gates_qsim.h
+++ b/lib/gates_qsim.h
@@ -189,6 +189,7 @@ struct GateY2 {
 
 /**
  * A gate that rotates around the X axis of the Bloch sphere.
+ * This is a generalization of the X gate.
  */
 template <typename fp_type>
 struct GateRX {
@@ -208,6 +209,7 @@ struct GateRX {
 
 /**
  * A gate that rotates around the Y axis of the Bloch sphere.
+ * This is a generalization of the Y gate.
  */
 template <typename fp_type>
 struct GateRY {
@@ -227,6 +229,7 @@ struct GateRY {
 
 /**
  * A gate that rotates around the Z axis of the Bloch sphere.
+ * This is a generalization of the Z gate.
  */
 template <typename fp_type>
 struct GateRZ {
@@ -438,7 +441,9 @@ struct GateIS {
 };
 
 /**
- * The fermionic simulation (FSim) gate.
+ * The fermionic simulation (FSim) gate family. Contains all two-qubit
+ * interactions that preserve excitations, up to single-qubit rotations and
+ * global phase.
  */
 template <typename fp_type>
 struct GateFS {


### PR DESCRIPTION
This builds upon #184 by adding descriptions for each gate in the docs site. Some of these are admittedly self-explanatory, but I opted to provide a description for every gate for visual consistency.