### PR TITLE
Convert to QSimCircuit after resolving params.

### DIFF
--- a/docs/cirq_interface.md
+++ b/docs/cirq_interface.md
@@ -147,7 +147,7 @@ Known gates with no decomposition:
 
 ### Parametrized circuits
 
-In theory, QSimCircuit objects can contain
+QSimCircuit objects can also contain
 [parameterized gates](https://cirq.readthedocs.io/en/stable/tutorial.html#parameterizing-the-ansatz)
-which have values assigned by Cirq's `ParamResolver`. However, this
-functionality has not been tested extensively.
+which have values assigned by Cirq's `ParamResolver`. See the link above for
+details on how to use this feature.

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -126,7 +126,6 @@ class QSimCircuit(cirq.Circuit):
     return super().__eq__(other)
 
   def _resolve_parameters_(self, param_resolver: cirq.study.ParamResolver):
-
     return QSimCircuit(
       super()._resolve_parameters_(param_resolver), device=self.device)
 

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -127,11 +127,8 @@ class QSimCircuit(cirq.Circuit):
 
   def _resolve_parameters_(self, param_resolver: cirq.study.ParamResolver):
 
-    qsim_circuit = super()._resolve_parameters_(param_resolver)
-
-    qsim_circuit.device = self.device
-
-    return qsim_circuit
+    return QSimCircuit(
+      super()._resolve_parameters_(param_resolver), device=self.device)
 
   def translate_cirq_to_qsim(
       self,

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import numpy as np
+import sympy
 import unittest
 import cirq
 import qsimcirq
@@ -282,6 +283,22 @@ class MainTest(unittest.TestCase):
     result = qsimhSim.compute_amplitudes(
         cirq_circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])
     assert np.allclose(result, [0j, 0j, (1 + 0j), 0j])
+
+
+  def test_cirq_qsim_params(self):
+    qubit = cirq.GridQubit(0,0)
+
+    circuit = cirq.Circuit(cirq.X(qubit)**sympy.Symbol("beta"))
+    params = cirq.ParamResolver({'beta': 0.5})
+
+    simulator = cirq.Simulator()
+    cirq_result = simulator.simulate(circuit, param_resolver = params)
+
+    qsim_simulator = qsimcirq.QSimSimulator()
+    qsim_result = qsim_simulator.simulate(circuit, param_resolver = params)
+
+    assert cirq.linalg.allclose_up_to_global_phase(
+        qsim_result.state_vector(), cirq_result.state_vector())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This also resolves a long-standing question of whether qsim supports parameterized circuits: now it does!