### PR TITLE
Limit docs to external APIs.

### DIFF
--- a/docs/_scripts/build_api_docs.py
+++ b/docs/_scripts/build_api_docs.py
@@ -47,7 +47,15 @@ def main(unused_argv):
         code_url_prefix=FLAGS.code_url_prefix,
         search_hints=FLAGS.search_hints,
         site_path=FLAGS.site_path,
-        callbacks=[public_api.local_definitions_filter])
+        callbacks=[public_api.local_definitions_filter],
+        private_map={
+            "qsimcirq": [
+                "qsim_circuit",
+                "qsimc",
+                "qsim_simulator",
+                "qsimh_simulator",
+            ]
+        })
 
     doc_generator.build(output_dir=FLAGS.output_dir)
 


### PR DESCRIPTION
CC @lamberta - following up on #195. This PR hides internal APIs that should be invoked via their top-level qsimcirq equivalent.

Generated file structure:
```
/tmp/qsim_api/
├── qsimcirq
│   ├── all_symbols.md
│   ├── _api_cache.json
│   ├── qsim
│   │   ├── add_gate.md
│   │   ├── add_matrix1.md
│   │   ├── add_matrix2.md
│   │   ├── Circuit.md
│   │   ├── GateKind.md
│   │   ├── qsimh_simulate.md
│   │   ├── qsim_sample.md
│   │   ├── qsim_simulate_fullstate.md
│   │   └── qsim_simulate.md
│   ├── QSimCircuit.md
│   ├── QSimhSimulator.md
│   ├── qsim.md
│   ├── QSimSimulator.md
│   ├── QSimSimulatorState.md
│   ├── QSimSimulatorTrialResult.md
│   └── _toc.yaml
└── qsimcirq.md
```