### PR TITLE
Make gate_appl dependency explicit

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -175,7 +175,10 @@ cc_library(
 
 cc_library(
     name = "gate_appl",
-    hdrs = ["gate_appl.h"],
+    hdrs = [
+        "gate.h",
+        "gate_appl.h",
+    ],
     deps = [":matrix"],
 )
 

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -175,11 +175,11 @@ cc_library(
 
 cc_library(
     name = "gate_appl",
-    hdrs = [
-        "gate.h",
-        "gate_appl.h",
+    hdrs = ["gate_appl.h"],
+    deps = [
+        ":gate",
+        ":matrix",
     ],
-    deps = [":matrix"],
 )
 
 cc_library(


### PR DESCRIPTION
Required for internal Bazel build process. I'm surprised this worked on external Bazel, actually - I don't see how gate_appl.h was able to resolve its dependency on gate.h when its only deps item was `:matrix`, which has no dependency on gate.h...