### PR TITLE
bump cirq to 0.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements for the python 3 version of cirq.
 
-cirq==0.8.2
+cirq==0.9.1
 numpy~=1.16
 typing_extensions
 absl-py


### PR DESCRIPTION
Bumps the cirq version in requirements.txt to 0.9.1.