### PR TITLE
Fix link to parameterized gates docs.

### DIFF
--- a/docs/cirq_interface.md
+++ b/docs/cirq_interface.md
@@ -148,6 +148,6 @@ Known gates with no decomposition:
 ### Parametrized circuits
 
 QSimCircuit objects can also contain
-[parameterized gates](https://cirq.readthedocs.io/en/stable/tutorial.html#parameterizing-the-ansatz)
+[parameterized gates](https://cirq.readthedocs.io/en/stable/docs/tutorials/variational_algorithm.html#Parameterizing-the-Ansatz)
 which have values assigned by Cirq's `ParamResolver`. See the link above for
 details on how to use this feature.

--- a/docs/cirq_interface.md
+++ b/docs/cirq_interface.md
@@ -148,6 +148,6 @@ Known gates with no decomposition:
 ### Parametrized circuits
 
 QSimCircuit objects can also contain
-[parameterized gates](https://cirq.readthedocs.io/en/stable/docs/tutorials/variational_algorithm.html#Parameterizing-the-Ansatz)
+[parameterized gates](https://cirq.readthedocs.io/en/stable/docs/tutorials/basics.html#Using-parameter-sweeps)
 which have values assigned by Cirq's `ParamResolver`. See the link above for
 details on how to use this feature.


### PR DESCRIPTION
Previous link was broken due to changes in Cirq docs. 

Another possible spot to link to in the Cirq docs is here: https://cirq.readthedocs.io/en/stable/docs/simulation.html#Parameterized-Values-and-Studies