### PR TITLE
Update Cirq gates.

### DIFF
--- a/lib/gates_cirq.h
+++ b/lib/gates_cirq.h
@@ -78,7 +78,7 @@ template <typename fp_type>
 using Matrix2q = std::array<std::array<std::complex<fp_type>, 4>, 4>;
 
 constexpr double h_double = 0.5;
-constexpr double pi_double = M_PI;
+constexpr double pi_double = 3.14159265358979323846264338327950288;
 constexpr double is2_double = 0.7071067811865475;
 
 // Gates from cirq/ops/identity.py:
@@ -1207,6 +1207,17 @@ struct MatrixGate1 {
         time, q0, {real(m[0][0]), imag(m[0][0]), real(m[0][1]), imag(m[0][1]),
                    real(m[1][0]), imag(m[1][0]), real(m[1][1]), imag(m[1][1])});
   }
+
+  static GateCirq<fp_type> Create(unsigned time, unsigned q0,
+                                  Matrix<fp_type>&& m) {
+    return CreateGate<GateCirq<fp_type>, MatrixGate1>(time, q0, std::move(m));
+  }
+
+  static GateCirq<fp_type> Create(unsigned time, unsigned q0,
+                                  const Matrix<fp_type>& m) {
+    auto m2 = m;
+    return CreateGate<GateCirq<fp_type>, MatrixGate1>(time, q0, std::move(m2));
+  }
 };
 
 /**
@@ -1222,16 +1233,33 @@ struct MatrixGate2 {
                                   const Matrix2q<fp_type>& m) {
     using std::real;
     using std::imag;
+
+    // Matrix is in this form because the simulator uses inverse qubit order.
     return CreateGate<GateCirq<fp_type>, MatrixGate2>(
         time, q0, q1,
-        {real(m[0][0]), imag(m[0][0]), real(m[0][1]), imag(m[0][1]),
-         real(m[0][2]), imag(m[0][2]), real(m[0][3]), imag(m[0][3]),
-         real(m[1][0]), imag(m[1][0]), real(m[1][1]), imag(m[1][1]),
-         real(m[1][2]), imag(m[1][2]), real(m[1][3]), imag(m[1][3]),
-         real(m[2][0]), imag(m[2][0]), real(m[2][1]), imag(m[2][1]),
-         real(m[2][2]), imag(m[2][2]), real(m[2][3]), imag(m[2][3]),
-         real(m[3][0]), imag(m[3][0]), real(m[3][1]), imag(m[3][1]),
-         real(m[3][2]), imag(m[3][2]), real(m[3][3]), imag(m[3][3])});
+        {real(m[0][0]), imag(m[0][0]), real(m[0][2]), imag(m[0][2]),
+         real(m[0][1]), imag(m[0][1]), real(m[0][3]), imag(m[0][3]),
+         real(m[2][0]), imag(m[2][0]), real(m[2][2]), imag(m[2][2]),
+         real(m[2][1]), imag(m[2][1]), real(m[2][3]), imag(m[2][3]),
+         real(m[1][0]), imag(m[1][0]), real(m[1][2]), imag(m[1][2]),
+         real(m[1][1]), imag(m[1][1]), real(m[1][3]), imag(m[1][3]),
+         real(m[3][0]), imag(m[3][0]), real(m[3][2]), imag(m[3][2]),
+         real(m[3][1]), imag(m[3][1]), real(m[3][3]), imag(m[3][3])});
+  }
+
+  static GateCirq<fp_type> Create(unsigned time, unsigned q0, unsigned q1,
+                                  Matrix<fp_type>&& m) {
+    MatrixShuffle({1, 0}, 2, m);
+    return
+        CreateGate<GateCirq<fp_type>, MatrixGate2>(time, q0, q1, std::move(m));
+  }
+
+  static GateCirq<fp_type> Create(unsigned time, unsigned q0, unsigned q1,
+                                  const Matrix<fp_type>& m) {
+    auto m2 = m;
+    MatrixShuffle({1, 0}, 2, m2);
+    return
+        CreateGate<GateCirq<fp_type>, MatrixGate2>(time, q0, q1, std::move(m2));
   }
 
   static schmidt_decomp_type<fp_type> SchmidtDecomp() {

--- a/tests/gates_cirq_testfixture.h
+++ b/tests/gates_cirq_testfixture.h
@@ -27,7 +27,7 @@ namespace qsim {
 namespace CirqCircuit1 {
 
 template <typename fp_type>
-Circuit<Cirq::GateCirq<fp_type>> GetCircuit() {
+Circuit<Cirq::GateCirq<fp_type>> GetCircuit(bool qsimh) {
   Circuit<Cirq::GateCirq<fp_type>> circuit{4, {}};
   circuit.gates.reserve(128);
 
@@ -116,28 +116,55 @@ Circuit<Cirq::GateCirq<fp_type>> GetCircuit() {
   circuit.gates.emplace_back(Cirq::ZZ<fp_type>::Create(17, 1, 3));
 
   using C = std::complex<fp_type>;
-  using A = std::array<C, 2>;
-  Cirq::Matrix1q<fp_type> m0 = {A{C{1, 0}, C{0, 0}}, A{C{0, 0}, C{0, 1}}};
-  Cirq::Matrix1q<fp_type> m1 = {A{C{0, 0}, C{0, -1}}, A{C{0, 1}, C{0, 0}}};
-  Cirq::Matrix1q<fp_type> m2 = {A{C{0, 0}, C{1, 0}}, A{C{1, 0}, C{0, 0}}};
-  Cirq::Matrix1q<fp_type> m3 = {A{C{1, 0}, C{0, 0}}, A{C{0, 0}, C{-1, 0}}};
-  circuit.gates.emplace_back(Cirq::MatrixGate1<fp_type>::Create(18, 0, m0));
-  circuit.gates.emplace_back(Cirq::MatrixGate1<fp_type>::Create(18, 1, m1));
-  circuit.gates.emplace_back(Cirq::MatrixGate1<fp_type>::Create(18, 2, m2));
-  circuit.gates.emplace_back(Cirq::MatrixGate1<fp_type>::Create(18, 3, m3));
 
-  circuit.gates.emplace_back(Cirq::riswap<fp_type>::Create(19, 0, 1, 0.7));
-  circuit.gates.emplace_back(Cirq::givens<fp_type>::Create(19, 2, 3, 1.2));
+  if (qsimh) {
+    circuit.gates.emplace_back(Cirq::ry<fp_type>::Create(18, 0, 1.3));
+    circuit.gates.emplace_back(Cirq::rz<fp_type>::Create(18, 1, 0.4));
+    circuit.gates.emplace_back(Cirq::rx<fp_type>::Create(18, 2, 0.7));
+    circuit.gates.emplace_back(Cirq::S<fp_type>::Create(18, 3));
 
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(20, 0));
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(20, 1));
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(20, 2));
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(20, 3));
+    using A4 = std::array<C, 4>;
+
+    Cirq::Matrix2q<fp_type> m40 =
+      {A4{C{0, 0}, C{-0.5, -0.5}, C{-0.5, -0.5}, C{0, 0}},
+       A4{C{0.5, -0.5}, C{0, 0}, C{0, 0}, C{-0.5, 0.5}},
+       A4{C{0.5, -0.5}, C{0, 0}, C{0, 0}, C{0.5, -0.5}},
+       A4{C{0, 0}, C{-0.5, -0.5}, C{0.5, 0.5}, C{0, 0}}};
+
+    Matrix<fp_type> m41 = {0.5, -0.5, 0, 0, 0, 0, -0.5, 0.5,
+                           0, 0, 0.5, -0.5, -0.5, 0.5, 0, 0,
+                           0, 0, -0.5, 0.5, -0.5, 0.5, 0, 0,
+                           0.5, -0.5, 0, 0, 0, 0, 0.5, -0.5};
+
+    circuit.gates.emplace_back(
+        Cirq::MatrixGate2<fp_type>::Create(19, 0, 1, m40));
+    circuit.gates.emplace_back(
+        Cirq::MatrixGate2<fp_type>::Create(19, 2, 3, m41));
+  }
+
+  using A2 = std::array<C, 2>;
+
+  Matrix<fp_type> m20 = {1, 0, 0, 0, 0, 0, 0, 1};
+  Cirq::Matrix1q<fp_type> m21 = {A2{C{0, 0}, C{0, -1}}, A2{C{0, 1}, C{0, 0}}};
+  Cirq::Matrix1q<fp_type> m22 = {A2{C{0, 0}, C{1, 0}}, A2{C{1, 0}, C{0, 0}}};
+  circuit.gates.emplace_back(Cirq::MatrixGate1<fp_type>::Create(20, 0, m20));
+  circuit.gates.emplace_back(Cirq::MatrixGate1<fp_type>::Create(20, 1, m21));
+  circuit.gates.emplace_back(Cirq::MatrixGate1<fp_type>::Create(20, 2, m22));
+  circuit.gates.emplace_back(Cirq::MatrixGate1<fp_type>::Create(
+      20, 3, {1, 0, 0, 0, 0, 0, -1, 0}));
+
+  circuit.gates.emplace_back(Cirq::riswap<fp_type>::Create(21, 0, 1, 0.7));
+  circuit.gates.emplace_back(Cirq::givens<fp_type>::Create(21, 2, 3, 1.2));
+
+  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(22, 0));
+  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(22, 1));
+  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(22, 2));
+  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(22, 3));
 
   return circuit;
 }
 
-std::vector<std::complex<double>> expected_results = {
+std::vector<std::complex<double>> expected_results0 = {
   {0.12549974, 0.21873295},
   {-0.09108202, 0.042387843},
   {0.11101487, -0.1457827},
@@ -156,6 +183,25 @@ std::vector<std::complex<double>> expected_results = {
   {-0.21426316, -0.074324496},
 };
 
+std::vector<std::complex<double>> expected_results1 = {
+ {-0.2793373, 0.04345847},
+ {0.011749804, 0.016165959},
+ {0.17934188, 0.14092307},
+ {0.048778597, -0.13790636},
+ {-0.03567368, 0.22674736},
+ {-0.059383754, -0.3467964},
+ {-0.1784511, 0.35632825},
+ {-0.04453452, -0.12378654},
+ {-0.07437507, 0.051441293},
+ {0.20011382, -0.025952503},
+ {-0.01476972, 0.03508006},
+ {0.03354645, -0.27887696},
+ {-0.22601734, -0.18618399},
+ {-0.060738925, -0.16348544},
+ {0.078519106, -0.4696969},
+ {0.14574647, -0.015134549},
+};
+
 /*
 
 These results were obtained by the following Cirq code, which simulates
@@ -165,131 +211,149 @@ import cirq
 import numpy as np
 
 def main():
-    q0 = cirq.GridQubit(1, 1) # 3
-    q1 = cirq.GridQubit(1, 0) # 2
-    q2 = cirq.GridQubit(0, 1) # 1
-    q3 = cirq.GridQubit(0, 0) # 0
+  q0 = cirq.GridQubit(1, 1) # 3
+  q1 = cirq.GridQubit(1, 0) # 2
+  q2 = cirq.GridQubit(0, 1) # 1
+  q3 = cirq.GridQubit(0, 0) # 0
 
-    circuit = cirq.Circuit(
-        cirq.Moment([
-            cirq.H(q0),
-            cirq.H(q1),
-            cirq.H(q2),
-            cirq.H(q3),
-        ]),
-        cirq.Moment([
-            cirq.T(q0),
-            cirq.T(q1),
-            cirq.T(q2),
-            cirq.T(q3),
-        ]),
-        cirq.Moment([
-            cirq.CZPowGate(exponent=0.7, global_shift=0.2)(q0, q1),
-            cirq.CXPowGate(exponent=1.2, global_shift=0.4)(q2, q3),
-        ]),
-        cirq.Moment([
-            cirq.XPowGate(exponent=0.3, global_shift=1.1)(q0),
-            cirq.YPowGate(exponent=0.4, global_shift=1)(q1),
-            cirq.ZPowGate(exponent=0.5, global_shift=0.9)(q2),
-            cirq.HPowGate(exponent=0.6, global_shift=0.8)(q3),
-        ]),
-        cirq.Moment([
-            cirq.CX(q0, q2),
-            cirq.CZ(q1, q3),
-        ]),
-        cirq.Moment([
-            cirq.X(q0),
-            cirq.Y(q1),
-            cirq.Z(q2),
-            cirq.S(q3),
-        ]),
-        cirq.Moment([
-            cirq.XXPowGate(exponent=0.4, global_shift=0.7)(q0, q1),
-            cirq.YYPowGate(exponent=0.8, global_shift=0.5)(q2, q3),
-        ]),
-        cirq.Moment([
-            cirq.I(q0),
-            cirq.I(q1),
-            cirq.IdentityGate(2)(q2, q3)
-        ]),
-        cirq.Moment([
-            cirq.rx(0.7)(q0),
-            cirq.ry(0.2)(q1),
-            cirq.rz(0.4)(q2),
-            cirq.PhasedXPowGate(
-                phase_exponent=0.8, exponent=0.6, global_shift=0.3)(q3),
-        ]),
-        cirq.Moment([
-            cirq.ZZPowGate(exponent=0.3, global_shift=1.3)(q0, q2),
-            cirq.ISwapPowGate(exponent=0.6, global_shift=1.2)(q1, q3),
-        ]),
-        cirq.Moment([
-            cirq.XPowGate(exponent=0.1, global_shift=0.9)(q0),
-            cirq.YPowGate(exponent=0.2, global_shift=1)(q1),
-            cirq.ZPowGate(exponent=0.3, global_shift=1.1)(q2),
-            cirq.HPowGate(exponent=0.4, global_shift=1.2)(q3),
-        ]),
-        cirq.Moment([
-            cirq.SwapPowGate(exponent=0.2, global_shift=0.9)(q0, q1),
-            cirq.PhasedISwapPowGate(phase_exponent = 0.8, exponent=0.6)(q2, q3),
-        ]),
-        cirq.Moment([
-            cirq.PhasedXZGate(
-                x_exponent=0.2, z_exponent=0.3, axis_phase_exponent=1.4)(q0),
-            cirq.T(q1),
-            cirq.H(q2),
-            cirq.S(q3),
-        ]),
-        cirq.Moment([
-            cirq.SWAP(q0, q2),
-            cirq.XX(q1, q3),
-        ]),
-        cirq.Moment([
-            cirq.rx(0.8)(q0),
-            cirq.ry(0.9)(q1),
-            cirq.rz(1.2)(q2),
-            cirq.T(q3),
-        ]),
-        cirq.Moment([
-            cirq.YY(q0, q1),
-            cirq.ISWAP(q2, q3),
-        ]),
-        cirq.Moment([
-            cirq.T(q0),
-            cirq.Z(q1),
-            cirq.Y(q2),
-            cirq.X(q3),
-        ]),
-        cirq.Moment([
-            cirq.FSimGate(0.3, 1.7)(q0, q2),
-            cirq.ZZ(q1, q3),
-        ]),
-        cirq.Moment([
-            cirq.MatrixGate(np.array([[1, 0], [0, 1j]]))(q0),
-            cirq.MatrixGate(np.array([[0, -1j], [1j, 0]]))(q1),
-            cirq.MatrixGate(np.array([[0, 1], [1, 0]]))(q2),
-            cirq.MatrixGate(np.array([[1, 0], [0, -1]]))(q3),
-        ]),
-        cirq.Moment([
-            cirq.riswap(0.7)(q0, q1),
-            cirq.givens(1.2)(q2, q3),
-        ]),
-        cirq.Moment([
-            cirq.H(q0),
-            cirq.H(q1),
-            cirq.H(q2),
-            cirq.H(q3),
-        ]),
-    )
+  circuit = cirq.Circuit(
+    cirq.Moment([
+        cirq.H(q0),
+        cirq.H(q1),
+        cirq.H(q2),
+        cirq.H(q3),
+    ]),
+    cirq.Moment([
+        cirq.T(q0),
+        cirq.T(q1),
+        cirq.T(q2),
+        cirq.T(q3),
+    ]),
+    cirq.Moment([
+        cirq.CZPowGate(exponent=0.7, global_shift=0.2)(q0, q1),
+        cirq.CXPowGate(exponent=1.2, global_shift=0.4)(q2, q3),
+    ]),
+    cirq.Moment([
+        cirq.XPowGate(exponent=0.3, global_shift=1.1)(q0),
+        cirq.YPowGate(exponent=0.4, global_shift=1)(q1),
+        cirq.ZPowGate(exponent=0.5, global_shift=0.9)(q2),
+        cirq.HPowGate(exponent=0.6, global_shift=0.8)(q3),
+    ]),
+    cirq.Moment([
+        cirq.CX(q0, q2),
+        cirq.CZ(q1, q3),
+    ]),
+    cirq.Moment([
+        cirq.X(q0),
+        cirq.Y(q1),
+        cirq.Z(q2),
+        cirq.S(q3),
+    ]),
+    cirq.Moment([
+        cirq.XXPowGate(exponent=0.4, global_shift=0.7)(q0, q1),
+        cirq.YYPowGate(exponent=0.8, global_shift=0.5)(q2, q3),
+    ]),
+    cirq.Moment([
+        cirq.I(q0),
+        cirq.I(q1),
+        cirq.IdentityGate(2)(q2, q3)
+    ]),
+    cirq.Moment([
+        cirq.rx(0.7)(q0),
+        cirq.ry(0.2)(q1),
+        cirq.rz(0.4)(q2),
+        cirq.PhasedXPowGate(
+            phase_exponent=0.8, exponent=0.6, global_shift=0.3)(q3),
+    ]),
+    cirq.Moment([
+        cirq.ZZPowGate(exponent=0.3, global_shift=1.3)(q0, q2),
+        cirq.ISwapPowGate(exponent=0.6, global_shift=1.2)(q1, q3),
+    ]),
+    cirq.Moment([
+        cirq.XPowGate(exponent=0.1, global_shift=0.9)(q0),
+        cirq.YPowGate(exponent=0.2, global_shift=1)(q1),
+        cirq.ZPowGate(exponent=0.3, global_shift=1.1)(q2),
+        cirq.HPowGate(exponent=0.4, global_shift=1.2)(q3),
+    ]),
+    cirq.Moment([
+        cirq.SwapPowGate(exponent=0.2, global_shift=0.9)(q0, q1),
+        cirq.PhasedISwapPowGate(phase_exponent = 0.8, exponent=0.6)(q2, q3),
+    ]),
+    cirq.Moment([
+        cirq.PhasedXZGate(
+            x_exponent=0.2, z_exponent=0.3, axis_phase_exponent=1.4)(q0),
+        cirq.T(q1),
+        cirq.H(q2),
+        cirq.S(q3),
+    ]),
+    cirq.Moment([
+        cirq.SWAP(q0, q2),
+        cirq.XX(q1, q3),
+    ]),
+    cirq.Moment([
+        cirq.rx(0.8)(q0),
+        cirq.ry(0.9)(q1),
+        cirq.rz(1.2)(q2),
+        cirq.T(q3),
+    ]),
+    cirq.Moment([
+        cirq.YY(q0, q1),
+        cirq.ISWAP(q2, q3),
+    ]),
+    cirq.Moment([
+        cirq.T(q0),
+        cirq.Z(q1),
+        cirq.Y(q2),
+        cirq.X(q3),
+    ]),
+    cirq.Moment([
+        cirq.FSimGate(0.3, 1.7)(q0, q2),
+        cirq.ZZ(q1, q3),
+    ]),
+    # The following moment should not be included if qsimh is false above.
+    cirq.Moment([
+        cirq.ry(1.3)(q0),
+        cirq.rz(0.4)(q1),
+        cirq.rx(0.7)(q2),
+        cirq.S(q3),
+    ]),
+    # The following moment should not be included if qsimh is false above.
+    cirq.Moment([
+        cirq.MatrixGate(np.array([[0, -0.5 - 0.5j, -0.5 - 0.5j, 0],
+                                  [0.5 - 0.5j, 0, 0, -0.5 + 0.5j],
+                                  [0.5 - 0.5j, 0, 0, 0.5 - 0.5j],
+                                  [0, -0.5 - 0.5j, 0.5 + 0.5j, 0]]))(q0, q1),
+        cirq.MatrixGate(np.array([[0.5 - 0.5j, 0, 0, -0.5 + 0.5j],
+                                  [0, 0.5 - 0.5j, -0.5 + 0.5j, 0],
+                                  [0, -0.5 + 0.5j, -0.5 + 0.5j, 0],
+                                  [0.5 - 0.5j, 0, 0, 0.5 - 0.5j]]))(q2, q3),
+    ]),
+    cirq.Moment([
+        cirq.MatrixGate(np.array([[1, 0], [0, 1j]]))(q0),
+        cirq.MatrixGate(np.array([[0, -1j], [1j, 0]]))(q1),
+        cirq.MatrixGate(np.array([[0, 1], [1, 0]]))(q2),
+        cirq.MatrixGate(np.array([[1, 0], [0, -1]]))(q3),
+    ]),
+    cirq.Moment([
+        cirq.riswap(0.7)(q0, q1),
+        cirq.givens(1.2)(q2, q3),
+    ]),
+    cirq.Moment([
+        cirq.H(q0),
+        cirq.H(q1),
+        cirq.H(q2),
+        cirq.H(q3),
+    ]),
+  )
 
-    simulator = cirq.Simulator()
-    result = simulator.simulate(circuit)
+  simulator = cirq.Simulator()
+  result = simulator.simulate(circuit)
 
-    for i in range(len(result.state_vector())):
-        print(result.state_vector()[i])
+  for i in range(len(result.state_vector())):
+      print(result.state_vector()[i])
 
 if __name__ == '__main__':
-    main()
+  main()
 
 */
 

--- a/tests/run_qsim_test.cc
+++ b/tests/run_qsim_test.cc
@@ -204,8 +204,8 @@ TEST(RunQSimTest, QSimSampler) {
 }
 
 TEST(RunQSimTest, CirqGates) {
-  auto circuit = CirqCircuit1::GetCircuit<float>();
-  const auto& expected_results = CirqCircuit1::expected_results;
+  auto circuit = CirqCircuit1::GetCircuit<float>(true);
+  const auto& expected_results = CirqCircuit1::expected_results1;
 
   using Simulator = Simulator<For>;
   using StateSpace = Simulator::StateSpace;

--- a/tests/run_qsimh_test.cc
+++ b/tests/run_qsimh_test.cc
@@ -162,8 +162,8 @@ TEST(RunQSimHTest, QSimHRunner) {
 }
 
 TEST(RunQSimHTest, CirqGates) {
-  auto circuit = CirqCircuit1::GetCircuit<float>();
-  const auto& expected_results = CirqCircuit1::expected_results;
+  auto circuit = CirqCircuit1::GetCircuit<float>(false);
+  const auto& expected_results = CirqCircuit1::expected_results0;
 
   using Simulator = Simulator<For>;
   using HybridSimulator = HybridSimulator<IO, Cirq::GateCirq<float>,


### PR DESCRIPTION
Fix pi constant (M_PI is not portable). Fix 2-qubit matrix gates (add matrix reshuffling to conform with the standard qubit ordering). Add more functions to create matrix gates.