### PR TITLE
Use latest Cirq version in qsim

### DIFF
--- a/docs/cirq_interface.md
+++ b/docs/cirq_interface.md
@@ -3,9 +3,9 @@
 This file provides examples of how to use qsim with the
 [Cirq](https://github.com/quantumlib/cirq) Python library.
 
-qsim is currently built to work with Cirq version 0.8.2; if you have a later
-version of Cirq installed, you may need to downgrade (or run in a virtualenv)
-when working with qsim until support for the latest Cirq version is available.
+qsim is kept up-to-date with the latest version of Cirq. If you experience
+compatibility issues, please file an issue in the qsim or Cirq repository
+as appropriate.
 
 
 ## Setting up

--- a/docs/tutorials/qsimcirq.ipynb
+++ b/docs/tutorials/qsimcirq.ipynb
@@ -99,8 +99,8 @@
       },
       "outputs": [],
       "source": [
-        "!pip install cirq==0.8.2\n",
-        "!pip install qsimcirq==0.3.0"
+        "!pip install cirq\n",
+        "!pip install qsimcirq"
       ]
     },
     {

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -33,7 +33,7 @@ from qsimcirq import qsim
 import qsimcirq.qsim_circuit as qsimc
 
 
-class QSimSimulatorState(sim.WaveFunctionSimulatorState):
+class QSimSimulatorState(sim.StateVectorSimulatorState):
 
     def __init__(self,
                  qsim_data: np.ndarray,
@@ -42,7 +42,7 @@ class QSimSimulatorState(sim.WaveFunctionSimulatorState):
       super().__init__(state_vector=state_vector, qubit_map=qubit_map)
 
 
-class QSimSimulatorTrialResult(sim.WaveFunctionTrialResult):
+class QSimSimulatorTrialResult(sim.StateVectorTrialResult):
 
     def __init__(self,
                  params: study.ParamResolver,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements for the python 3 version of cirq.
 
-cirq==0.9.1
+cirq
 numpy~=1.16
 typing_extensions
 absl-py


### PR DESCRIPTION
Thanks to the Cirq backwards-compatibility policies, we can safely use the latest version of Cirq as long as any Cirq deprecations are reflected in qsim before the next Cirq release (~3 months).