### PR TITLE
Polish qsimcirq getting started guide.

### DIFF
--- a/docs/tutorials/qsimcirq.ipynb
+++ b/docs/tutorials/qsimcirq.ipynb
@@ -1,565 +1,587 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "8M2lhf2RBGZj"
-      },
-      "source": [
-        "##### Copyright 2020 Google"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
-        "id": "FMqHt2UBBJzR"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "vAx5g2rPnlzt"
-      },
-      "source": [
-        "# Get started with qsimcirq"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "5jqw8k0zBsb-"
-      },
-      "source": [
-        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.example.org/qsim/tutorials/qsimcirq\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on QuantumLib</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/qsim/blob/master/docs/tutorials/qsimcirq.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/quantumlib/qsim/blob/master/docs/tutorials/qsimcirq.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/qsim/docs/tutorials/qsimcirq.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
-        "  </td>\n",
-        "</table>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "VgdpPfgTCjQB"
-      },
-      "source": [
-        "The qsim library provides a Python interface to Cirq in the **qsimcirq** PyPI package."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "8vr-44j-Csxf"
-      },
-      "source": [
-        "## Setup\n",
-        "\n",
-        "Install the Cirq and qsimcirq packages:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "XcAhsIQdivnp"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install cirq\n",
-        "!pip install qsimcirq"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "7lYC4qxpDKMN"
-      },
-      "source": [
-        "Simulating Cirq circuits with qsim is easy: just define the circuit as you normally would, then create a **QSimSimulator** to perform the simulation. This object implements Cirq's [simulator.py](https://github.com/quantumlib/Cirq/blob/master/cirq/sim/simulator.py) interfaces, so you can drop it in anywhere the basic Cirq simulator is used."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "FXytmQlBoeTT"
-      },
-      "source": [
-        "## Full state-vector simulation\n",
-        "\n",
-        "qsim is optimized for computing the final state vector of a circuit. Try it by running the example below."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "jd8DaJMbjkCM"
-      },
-      "outputs": [],
-      "source": [
-        "import cirq\n",
-        "import qsimcirq\n",
-        "\n",
-        "states = ['00', '01', '10', '11']\n",
-        "\n",
-        "# Define qubits and a short circuit.\n",
-        "q0, q1 = cirq.LineQubit.range(2)\n",
-        "circuit = cirq.Circuit(cirq.H(q0), cirq.CX(q0, q1))\n",
-        "print(\"Circuit:\")\n",
-        "print(circuit)\n",
-        "print()\n",
-        "\n",
-        "# Simulate the circuit with Cirq and return the full state vector.\n",
-        "print('Cirq results:')\n",
-        "cirq_simulator = cirq.Simulator()\n",
-        "cirq_results = cirq_simulator.simulate(circuit)\n",
-        "print(cirq_results)\n",
-        "print()\n",
-        "\n",
-        "# Simulate the circuit with qsim and return the full state vector.\n",
-        "print('qsim results:')\n",
-        "qsim_simulator = qsimcirq.QSimSimulator()\n",
-        "qsim_results = qsim_simulator.simulate(circuit)\n",
-        "print(qsim_results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "-kyXlKujtZcp"
-      },
-      "source": [
-        "To sample from this state, you can invoke Cirq's `sample_state_vector` method:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "-m6uzQ6ms9I7"
-      },
-      "outputs": [],
-      "source": [
-        "samples = cirq.sample_state_vector(\n",
-        "    qsim_results.state_vector(), indices=[0, 1], repetitions=10)\n",
-        "print(samples)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "pOhybi46sHwI"
-      },
-      "source": [
-        "## Measurement sampling\n",
-        "\n",
-        "qsim also supports sampling from user-defined measurement gates. Note that since qsim and Cirq use different random number generators, identical runs on both simulators may give different results, even if they use the same seed."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "NRJvtqYrnylJ"
-      },
-      "outputs": [],
-      "source": [
-        "# Define a circuit with measurements.\n",
-        "q0, q1 = cirq.LineQubit.range(2)\n",
-        "circuit = cirq.Circuit(\n",
-        "    cirq.H(q0), cirq.X(q1), cirq.CX(q0, q1),\n",
-        "    cirq.measure(q0, key='qubit_0'),\n",
-        "    cirq.measure(q1, key='qubit_1'),\n",
-        ")\n",
-        "print(\"Circuit:\")\n",
-        "print(circuit)\n",
-        "print()\n",
-        "\n",
-        "# Simulate the circuit with Cirq and return just the measurement values.\n",
-        "print('Cirq results:')\n",
-        "cirq_simulator = cirq.Simulator()\n",
-        "cirq_results = cirq_simulator.run(circuit, repetitions=5)\n",
-        "print(cirq_results)\n",
-        "print()\n",
-        "\n",
-        "# Simulate the circuit with qsim and return just the measurement values.\n",
-        "print('qsim results:')\n",
-        "qsim_simulator = qsimcirq.QSimSimulator()\n",
-        "qsim_results = qsim_simulator.run(circuit, repetitions=5)\n",
-        "print(qsim_results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "6NoSr0E_wgR_"
-      },
-      "source": [
-        "The warning above highlights an important distinction between the `simulate` and `run` methods:\n",
-        "\n",
-        "*   `simulate` only executes the circuit once. Sampling from the resulting state is fast, but if there are intermediate measurements the final state vector depends on the results of those measurements.\n",
-        "*   `run` will execute the circuit once for each repetition requested. As a result, sampling is much slower, but intermediate measurements are re-sampled for each repetition. If there are no intermediate measurements, `run` redirects to `simulate` for faster execution.\n",
-        "\n",
-        "The warning goes away if intermediate measurements are present:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "hFrwYjWM0Hpa"
-      },
-      "outputs": [],
-      "source": [
-        "# Define a circuit with intermediate measurements.\n",
-        "q0 = cirq.LineQubit(0)\n",
-        "circuit = cirq.Circuit(\n",
-        "    cirq.X(q0)**0.5, cirq.measure(q0, key='m0'),\n",
-        "    cirq.X(q0)**0.5, cirq.measure(q0, key='m1'),\n",
-        "    cirq.X(q0)**0.5, cirq.measure(q0, key='m2'),\n",
-        ")\n",
-        "print(\"Circuit:\")\n",
-        "print(circuit)\n",
-        "print()\n",
-        "\n",
-        "# Simulate the circuit with qsim and return just the measurement values.\n",
-        "print('qsim results:')\n",
-        "qsim_simulator = qsimcirq.QSimSimulator()\n",
-        "qsim_results = qsim_simulator.run(circuit, repetitions=5)\n",
-        "print(qsim_results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "KhPHBKpi0lYE"
-      },
-      "source": [
-        "## Amplitude evaluation\n",
-        "\n",
-        "qsim can also calculate amplitudes for specific output bitstrings."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "aCbvXO6M1jWB"
-      },
-      "outputs": [],
-      "source": [
-        "# Define a simple circuit.\n",
-        "q0, q1 = cirq.LineQubit.range(2)\n",
-        "circuit = cirq.Circuit(cirq.H(q0), cirq.CX(q0, q1))\n",
-        "print(\"Circuit:\")\n",
-        "print(circuit)\n",
-        "print()\n",
-        "\n",
-        "# Simulate the circuit with qsim and return the amplitudes for |00) and |01).\n",
-        "print('Cirq results:')\n",
-        "cirq_simulator = cirq.Simulator()\n",
-        "cirq_results = cirq_simulator.compute_amplitudes(\n",
-        "    circuit, bitstrings=[0b00, 0b01])\n",
-        "print(cirq_results)\n",
-        "print()\n",
-        "\n",
-        "# Simulate the circuit with qsim and return the amplitudes for |00) and |01).\n",
-        "print('qsim results:')\n",
-        "qsim_simulator = qsimcirq.QSimSimulator()\n",
-        "qsim_results = qsim_simulator.compute_amplitudes(\n",
-        "    circuit, bitstrings=[0b00, 0b01])\n",
-        "print(qsim_results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "zy5XRdkm219l"
-      },
-      "source": [
-        "## Performance benchmark\n",
-        "\n",
-        "The code below generates a depth-16 circuit on a 4x5 qubit grid, then runs it against the basic Cirq simulator. For a circuit of this size, the difference in runtime can be significant - try it out!"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "SyRpm08R3qCy"
-      },
-      "outputs": [],
-      "source": [
-        "import time\n",
-        "\n",
-        "qubits = [cirq.GridQubit(i,j) for i in range(4) for j in range(5)]\n",
-        "\n",
-        "# Generates a random circuit on the provided qubits.\n",
-        "circuit = cirq.experiments.random_rotations_between_grid_interaction_layers_circuit(\n",
-        "    qubits=qubits, depth=16)\n",
-        "\n",
-        "# Simulate the circuit with Cirq and print the runtime.\n",
-        "cirq_simulator = cirq.Simulator()\n",
-        "cirq_start = time.time()\n",
-        "cirq_results = cirq_simulator.simulate(circuit)\n",
-        "cirq_elapsed = time.time() - cirq_start\n",
-        "print(f'Cirq runtime: {cirq_elapsed}')\n",
-        "print()\n",
-        "\n",
-        "# Simulate the circuit with qsim and print the runtime.\n",
-        "qsim_simulator = qsimcirq.QSimSimulator()\n",
-        "qsim_start = time.time()\n",
-        "qsim_results = qsim_simulator.simulate(circuit)\n",
-        "qsim_elapsed = time.time() - qsim_start\n",
-        "print(f'qsim runtime: {qsim_elapsed}')\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "OUjhKoRVZGKZ"
-      },
-      "source": [
-        "qsim performance can be tuned further by passing options to the simulator constructor. These options use the same format as the qsim_base binary - a full description can be found in the qsim [usage doc](https://github.com/quantumlib/qsim/blob/master/docs/usage.md)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "yE6ZXAKzZL5P"
-      },
-      "outputs": [],
-      "source": [
-        "# Use eight threads to parallelize simulation.\n",
-        "options = {'t': 8}\n",
-        "\n",
-        "qsim_simulator = qsimcirq.QSimSimulator(options)\n",
-        "qsim_start = time.time()\n",
-        "qsim_results = qsim_simulator.simulate(circuit)\n",
-        "qsim_elapsed = time.time() - qsim_start\n",
-        "print(f'qsim runtime: {qsim_elapsed}')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "LgWOEMLKutsq"
-      },
-      "source": [
-        "## Advanced applications: Distributed execution\n",
-        "\n",
-        "qsimh (qsim-hybrid) is a second library in the qsim repository that takes a slightly different approach to circuit simulation. When simulating a quantum circuit, it's possible to simplify the execution by decomposing a subset of two-qubit gates into pairs of one-qubit gates with shared indices. This operation is called \"slicing\" (or \"cutting\") the gates.\n",
-        "\n",
-        "qsimh takes advantage of the \"slicing\" operation by selecting a set of gates to \"slice\" and assigning each possible value of the shared indices across a set of executors running in parallel. By adding up the results afterwards, the total state can be recovered."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "t3OkT3FKuuhp"
-      },
-      "outputs": [],
-      "source": [
-        "# Pick a pair of qubits.\n",
-        "q0 = cirq.GridQubit(0, 0)\n",
-        "q1 = cirq.GridQubit(0, 1)\n",
-        "\n",
-        "# Create a circuit that entangles the pair.\n",
-        "circuit = cirq.Circuit(\n",
-        "    cirq.H(q0), cirq.CX(q0, q1), cirq.X(q1)\n",
-        ")\n",
-        "print(\"Circuit:\")\n",
-        "print(circuit)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "KUAwCOGeu0wA"
-      },
-      "source": [
-        "In order to let qsimh know how we want to split up the circuit, we need to pass it some additional options. More detail on these can be found in the qsim [usage doc](https://github.com/quantumlib/qsim/blob/master/docs/usage.md), but the fundamentals are explained below."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "VXc-A8e7u262"
-      },
-      "outputs": [],
-      "source": [
-        "options = {}\n",
-        "\n",
-        "# 'k' indicates the qubits on one side of the cut.\n",
-        "# We'll use qubit 0 for this.\n",
-        "options['k'] = [0]\n",
-        "\n",
-        "# 'p' and 'r' control when values are assigned to cut indices.\n",
-        "# There are some intricacies in choosing values for these options,\n",
-        "# but for now we'll set p=1 and r=0.\n",
-        "# This allows us to pre-assign the value of the CX indices\n",
-        "# and distribute its execution to multiple jobs.\n",
-        "options['p'] = 1\n",
-        "options['r'] = 0\n",
-        "\n",
-        "# 'w' indicates the value pre-assigned to the cut.\n",
-        "# This should change for each execution.\n",
-        "options['w'] = 0\n",
-        "\n",
-        "# Create the qsimh simulator with those options.\n",
-        "qsimh_simulator = qsimcirq.QSimhSimulator(options)\n",
-        "results_0 = qsimh_simulator.compute_amplitudes(\n",
-        "    circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])\n",
-        "print(results_0)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "eij3DsN4u5Om"
-      },
-      "source": [
-        "Now to run the other side of the cut..."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "py6I1omau6Gk"
-      },
-      "outputs": [],
-      "source": [
-        "options['w'] = 1\n",
-        "\n",
-        "qsimh_simulator = qsimcirq.QSimhSimulator(options)\n",
-        "results_1 = qsimh_simulator.compute_amplitudes(\n",
-        "    circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])\n",
-        "print(results_1)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "wnjmLDedu7j4"
-      },
-      "source": [
-        "...and add the two together. The results of a normal qsim simulation are shown for comparison."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "YQoyZ6ldu7--"
-      },
-      "outputs": [],
-      "source": [
-        "results = [r0 + r1 for r0, r1 in zip(results_0, results_1)]\n",
-        "print(\"qsimh results:\")\n",
-        "print(results)\n",
-        "\n",
-        "qsim_simulator = qsimcirq.QSimSimulator()\n",
-        "qsim_simulator.compute_amplitudes(circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])\n",
-        "print(\"qsim results:\")\n",
-        "print(results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "o11JcJJ8vEfW"
-      },
-      "source": [
-        "The key point to note here is that `results_0` and `results_1` are completely independent - they can be run in parallel on two separate machines, with no communication between the two. Getting the full result requires `2^p` executions, but each individual result is much cheaper to calculate than trying to do the whole circuit at once."
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [],
-      "name": "qsimcirq.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "8M2lhf2RBGZj"
+   },
+   "source": [
+    "##### Copyright 2020 Google"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {},
+    "colab_type": "code",
+    "id": "FMqHt2UBBJzR"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "vAx5g2rPnlzt"
+   },
+   "source": [
+    "# Get started with qsimcirq"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "5jqw8k0zBsb-"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://www.example.org/qsim/tutorials/qsimcirq\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on QuantumLib</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/qsim/blob/master/docs/tutorials/qsimcirq.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/qsim/blob/master/docs/tutorials/qsimcirq.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/qsim/docs/tutorials/qsimcirq.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "VgdpPfgTCjQB"
+   },
+   "source": [
+    "The qsim library provides a Python interface to Cirq in the **qsimcirq** PyPI package."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "8vr-44j-Csxf"
+   },
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install the Cirq and qsimcirq packages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "XcAhsIQdivnp"
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import cirq\n",
+    "except ImportError:\n",
+    "    !pip install cirq --quiet\n",
+    "    import cirq\n",
+    "\n",
+    "try:\n",
+    "    import qsimcirq\n",
+    "except ImportError:\n",
+    "    !pip install qsimcirq --quiet\n",
+    "    import qsimcirq"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "7lYC4qxpDKMN"
+   },
+   "source": [
+    "Simulating Cirq circuits with qsim is easy: just define the circuit as you normally would, then create a `QSimSimulator` to perform the simulation. This object implements Cirq's [simulator.py](https://github.com/quantumlib/Cirq/blob/master/cirq/sim/simulator.py) interfaces, so you can drop it in anywhere the basic Cirq simulator is used."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "FXytmQlBoeTT"
+   },
+   "source": [
+    "## Full state-vector simulation\n",
+    "\n",
+    "qsim is optimized for computing the final state vector of a circuit. Try it by running the example below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "jd8DaJMbjkCM"
+   },
+   "outputs": [],
+   "source": [
+    "# Define qubits and a short circuit.\n",
+    "q0, q1 = cirq.LineQubit.range(2)\n",
+    "circuit = cirq.Circuit(cirq.H(q0), cirq.CX(q0, q1))\n",
+    "print(\"Circuit:\")\n",
+    "print(circuit)\n",
+    "print()\n",
+    "\n",
+    "# Simulate the circuit with Cirq and return the full state vector.\n",
+    "print('Cirq results:')\n",
+    "cirq_simulator = cirq.Simulator()\n",
+    "cirq_results = cirq_simulator.simulate(circuit)\n",
+    "print(cirq_results)\n",
+    "print()\n",
+    "\n",
+    "# Simulate the circuit with qsim and return the full state vector.\n",
+    "print('qsim results:')\n",
+    "qsim_simulator = qsimcirq.QSimSimulator()\n",
+    "qsim_results = qsim_simulator.simulate(circuit)\n",
+    "print(qsim_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "-kyXlKujtZcp"
+   },
+   "source": [
+    "To sample from this state, you can invoke Cirq's `sample_state_vector` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "-m6uzQ6ms9I7"
+   },
+   "outputs": [],
+   "source": [
+    "samples = cirq.sample_state_vector(\n",
+    "    qsim_results.state_vector(), indices=[0, 1], repetitions=10)\n",
+    "print(samples)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "pOhybi46sHwI"
+   },
+   "source": [
+    "## Measurement sampling\n",
+    "\n",
+    "qsim also supports sampling from user-defined measurement gates. \n",
+    "\n",
+    "> *Note*: Since qsim and Cirq use different random number generators, identical runs on both simulators may give different results, even if they use the same seed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "NRJvtqYrnylJ"
+   },
+   "outputs": [],
+   "source": [
+    "# Define a circuit with measurements.\n",
+    "q0, q1 = cirq.LineQubit.range(2)\n",
+    "circuit = cirq.Circuit(\n",
+    "    cirq.H(q0), cirq.X(q1), cirq.CX(q0, q1),\n",
+    "    cirq.measure(q0, key='qubit_0'),\n",
+    "    cirq.measure(q1, key='qubit_1'),\n",
+    ")\n",
+    "print(\"Circuit:\")\n",
+    "print(circuit)\n",
+    "print()\n",
+    "\n",
+    "# Simulate the circuit with Cirq and return just the measurement values.\n",
+    "print('Cirq results:')\n",
+    "cirq_simulator = cirq.Simulator()\n",
+    "cirq_results = cirq_simulator.run(circuit, repetitions=5)\n",
+    "print(cirq_results)\n",
+    "print()\n",
+    "\n",
+    "# Simulate the circuit with qsim and return just the measurement values.\n",
+    "print('qsim results:')\n",
+    "qsim_simulator = qsimcirq.QSimSimulator()\n",
+    "qsim_results = qsim_simulator.run(circuit, repetitions=5)\n",
+    "print(qsim_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "6NoSr0E_wgR_"
+   },
+   "source": [
+    "The warning above highlights an important distinction between the `simulate` and `run` methods:\n",
+    "\n",
+    "* `simulate` only executes the circuit once. \n",
+    "  -  Sampling from the resulting state is fast, but if there are intermediate measurements the final state vector depends on the results of those measurements.\n",
+    "* `run` will execute the circuit once for each repetition requested. \n",
+    "  -  As a result, sampling is much slower, but intermediate measurements are re-sampled for each repetition. If there are no intermediate measurements, `run` redirects to `simulate` for faster execution.\n",
+    "\n",
+    "The warning goes away if intermediate measurements are present:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "hFrwYjWM0Hpa"
+   },
+   "outputs": [],
+   "source": [
+    "# Define a circuit with intermediate measurements.\n",
+    "q0 = cirq.LineQubit(0)\n",
+    "circuit = cirq.Circuit(\n",
+    "    cirq.X(q0)**0.5, cirq.measure(q0, key='m0'),\n",
+    "    cirq.X(q0)**0.5, cirq.measure(q0, key='m1'),\n",
+    "    cirq.X(q0)**0.5, cirq.measure(q0, key='m2'),\n",
+    ")\n",
+    "print(\"Circuit:\")\n",
+    "print(circuit)\n",
+    "print()\n",
+    "\n",
+    "# Simulate the circuit with qsim and return just the measurement values.\n",
+    "print('qsim results:')\n",
+    "qsim_simulator = qsimcirq.QSimSimulator()\n",
+    "qsim_results = qsim_simulator.run(circuit, repetitions=5)\n",
+    "print(qsim_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "KhPHBKpi0lYE"
+   },
+   "source": [
+    "## Amplitude evaluation\n",
+    "\n",
+    "qsim can also calculate amplitudes for specific output bitstrings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "aCbvXO6M1jWB"
+   },
+   "outputs": [],
+   "source": [
+    "# Define a simple circuit.\n",
+    "q0, q1 = cirq.LineQubit.range(2)\n",
+    "circuit = cirq.Circuit(cirq.H(q0), cirq.CX(q0, q1))\n",
+    "print(\"Circuit:\")\n",
+    "print(circuit)\n",
+    "print()\n",
+    "\n",
+    "# Simulate the circuit with qsim and return the amplitudes for |00) and |01).\n",
+    "print('Cirq results:')\n",
+    "cirq_simulator = cirq.Simulator()\n",
+    "cirq_results = cirq_simulator.compute_amplitudes(\n",
+    "    circuit, bitstrings=[0b00, 0b01])\n",
+    "print(cirq_results)\n",
+    "print()\n",
+    "\n",
+    "# Simulate the circuit with qsim and return the amplitudes for |00) and |01).\n",
+    "print('qsim results:')\n",
+    "qsim_simulator = qsimcirq.QSimSimulator()\n",
+    "qsim_results = qsim_simulator.compute_amplitudes(\n",
+    "    circuit, bitstrings=[0b00, 0b01])\n",
+    "print(qsim_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "zy5XRdkm219l"
+   },
+   "source": [
+    "## Performance benchmark\n",
+    "\n",
+    "The code below generates a depth-16 circuit on a 4x5 qubit grid, then runs it against the basic Cirq simulator. For a circuit of this size, the difference in runtime can be significant - try it out!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "SyRpm08R3qCy"
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "# Get a rectangular grid of qubits.\n",
+    "qubits = cirq.GridQubit.rect(4, 5)\n",
+    "\n",
+    "# Generates a random circuit on the provided qubits.\n",
+    "circuit = cirq.experiments.random_rotations_between_grid_interaction_layers_circuit(\n",
+    "    qubits=qubits, depth=16)\n",
+    "\n",
+    "# Simulate the circuit with Cirq and print the runtime.\n",
+    "cirq_simulator = cirq.Simulator()\n",
+    "cirq_start = time.time()\n",
+    "cirq_results = cirq_simulator.simulate(circuit)\n",
+    "cirq_elapsed = time.time() - cirq_start\n",
+    "print(f'Cirq runtime: {cirq_elapsed} seconds.')\n",
+    "print()\n",
+    "\n",
+    "# Simulate the circuit with qsim and print the runtime.\n",
+    "qsim_simulator = qsimcirq.QSimSimulator()\n",
+    "qsim_start = time.time()\n",
+    "qsim_results = qsim_simulator.simulate(circuit)\n",
+    "qsim_elapsed = time.time() - qsim_start\n",
+    "print(f'qsim runtime: {qsim_elapsed} seconds.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "OUjhKoRVZGKZ"
+   },
+   "source": [
+    "qsim performance can be tuned further by passing options to the simulator constructor. These options use the same format as the qsim_base binary - a full description can be found in the qsim [usage doc](https://github.com/quantumlib/qsim/blob/master/docs/usage.md)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "yE6ZXAKzZL5P"
+   },
+   "outputs": [],
+   "source": [
+    "# Use eight threads to parallelize simulation.\n",
+    "options = {'t': 8}\n",
+    "\n",
+    "qsim_simulator = qsimcirq.QSimSimulator(options)\n",
+    "qsim_start = time.time()\n",
+    "qsim_results = qsim_simulator.simulate(circuit)\n",
+    "qsim_elapsed = time.time() - qsim_start\n",
+    "print(f'qsim runtime: {qsim_elapsed} seconds.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "LgWOEMLKutsq"
+   },
+   "source": [
+    "## Advanced applications: Distributed execution\n",
+    "\n",
+    "qsimh (qsim-hybrid) is a second library in the qsim repository that takes a slightly different approach to circuit simulation. When simulating a quantum circuit, it's possible to simplify the execution by decomposing a subset of two-qubit gates into pairs of one-qubit gates with shared indices. This operation is called \"slicing\" (or \"cutting\") the gates.\n",
+    "\n",
+    "qsimh takes advantage of the \"slicing\" operation by selecting a set of gates to \"slice\" and assigning each possible value of the shared indices across a set of executors running in parallel. By adding up the results afterwards, the total state can be recovered."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "t3OkT3FKuuhp"
+   },
+   "outputs": [],
+   "source": [
+    "# Pick a pair of qubits.\n",
+    "q0 = cirq.GridQubit(0, 0)\n",
+    "q1 = cirq.GridQubit(0, 1)\n",
+    "\n",
+    "# Create a circuit that entangles the pair.\n",
+    "circuit = cirq.Circuit(\n",
+    "    cirq.H(q0), cirq.CX(q0, q1), cirq.X(q1)\n",
+    ")\n",
+    "print(\"Circuit:\")\n",
+    "print(circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "KUAwCOGeu0wA"
+   },
+   "source": [
+    "In order to let qsimh know how we want to split up the circuit, we need to pass it some additional options. More detail on these can be found in the qsim [usage doc](https://github.com/quantumlib/qsim/blob/master/docs/usage.md), but the fundamentals are explained below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "VXc-A8e7u262"
+   },
+   "outputs": [],
+   "source": [
+    "options = {}\n",
+    "\n",
+    "# 'k' indicates the qubits on one side of the cut.\n",
+    "# We'll use qubit 0 for this.\n",
+    "options['k'] = [0]\n",
+    "\n",
+    "# 'p' and 'r' control when values are assigned to cut indices.\n",
+    "# There are some intricacies in choosing values for these options,\n",
+    "# but for now we'll set p=1 and r=0.\n",
+    "# This allows us to pre-assign the value of the CX indices\n",
+    "# and distribute its execution to multiple jobs.\n",
+    "options['p'] = 1\n",
+    "options['r'] = 0\n",
+    "\n",
+    "# 'w' indicates the value pre-assigned to the cut.\n",
+    "# This should change for each execution.\n",
+    "options['w'] = 0\n",
+    "\n",
+    "# Create the qsimh simulator with those options.\n",
+    "qsimh_simulator = qsimcirq.QSimhSimulator(options)\n",
+    "results_0 = qsimh_simulator.compute_amplitudes(\n",
+    "    circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])\n",
+    "print(results_0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "eij3DsN4u5Om"
+   },
+   "source": [
+    "Now to run the other side of the cut..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "py6I1omau6Gk"
+   },
+   "outputs": [],
+   "source": [
+    "options['w'] = 1\n",
+    "\n",
+    "qsimh_simulator = qsimcirq.QSimhSimulator(options)\n",
+    "results_1 = qsimh_simulator.compute_amplitudes(\n",
+    "    circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])\n",
+    "print(results_1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "wnjmLDedu7j4"
+   },
+   "source": [
+    "...and add the two together. The results of a normal qsim simulation are shown for comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "YQoyZ6ldu7--"
+   },
+   "outputs": [],
+   "source": [
+    "results = [r0 + r1 for r0, r1 in zip(results_0, results_1)]\n",
+    "print(\"qsimh results:\")\n",
+    "print(results)\n",
+    "\n",
+    "qsim_simulator = qsimcirq.QSimSimulator()\n",
+    "qsim_simulator.compute_amplitudes(circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])\n",
+    "print(\"qsim results:\")\n",
+    "print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "o11JcJJ8vEfW"
+   },
+   "source": [
+    "The key point to note here is that `results_0` and `results_1` are completely independent - they can be run in parallel on two separate machines, with no communication between the two. Getting the full result requires `2^p` executions, but each individual result is much cheaper to calculate than trying to do the whole circuit at once."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "qsimcirq.ipynb",
+   "private_outputs": true,
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Removes unused `states` variable, standardizes package installation as per https://github.com/quantumlib/Cirq/pull/3431, and small formatting changes. 