### PR TITLE
Remove COPY .git from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update
 RUN apt-get install -y g++ make
 
 # Copy relevant files for simulation
-COPY ./.git/ /qsim/.git/
 COPY ./Makefile /qsim/Makefile
 COPY ./apps/ /qsim/apps/
 COPY ./circuits/ /qsim/circuits/


### PR DESCRIPTION
The .git directory no longer exists, and is not required for the Docker image.