### PR TITLE
Polish docs

### DIFF
--- a/docs/cirq_interface.md
+++ b/docs/cirq_interface.md
@@ -60,17 +60,18 @@ objects, which it wraps as `QSimCircuit` to enforce architectural constraints
 
 ### Usage procedure
 
-A QSimCircuit can be created from a Cirq circuit.
+We begin by defining a Cirq circuit which we want to simulate.
+
 ```
 my_circuit = cirq.Circuit()
 ```
 
-This circuit can then be simulated using either QSimSimulator or
-QSimhSimulator, depending on the output required:
+This circuit can then be simulated using either `QSimSimulator` or
+`QSimhSimulator`, depending on the desired output.
 
 #### QSimSimulator
 
-QSimSimulator uses a Schrödinger full state-vector simulator, suitable for
+`QSimSimulator` uses a Schrödinger full state-vector simulator, suitable for
 acquiring the complete state of a reasonably-sized circuit (~35 qubits).
 Options for the simulator, including number of threads and verbosity, can be
 set with the `qsim_options` field using the `qsim_base` flag format defined in
@@ -79,24 +80,25 @@ the [usage docs](/docs/usage.md).
 ```
 qsim_options = {'t': 8, 'v': 0}
 my_sim = qsimcirq.QSimSimulator(qsim_options)
-myres = my_sim.simulate(program = my_circuit)
+myres = my_sim.simulate(program=my_circuit)
 ```
 
-Alternatively, by using the `compute_amplitudes` method QSimSimulator can
+Alternatively, by using the `compute_amplitudes` method `QSimSimulator` can
 produce amplitudes for specific output bitstrings:
 ```
 my_sim = qsimcirq.QSimSimulator()
-myres = my_sim.compute_amplitudes(program = my_circuit,
-                                  bitstrings=['00', '01', '10', '11'])
+myres = my_sim.compute_amplitudes(program=my_circuit,
+                                  bitstrings=[0b00, 0b01, 0b10, 0b11])
 ```
 In the above example, the simulation is performed for the specified bitstrings
 of length 2. All the bitstring lengths should be equal to the number of qubits
 in `qsim_circuit`. Otherwise, BitstringsFromStream will raise an error.
 
-Finally, to retrieve sample measurements the `run` method can be used:
+Finally, to retrieve sample measurements the `run` method can be used. This requires
+the circuit to have measurements to sample from, else an error will be raised.
 ```
 my_sim = qsimcirq.QSimSimulator()
-myres = my_sim.run(program = my_circuit)
+myres = my_sim.run(program=my_circuit)
 ```
 
 This method may be more efficient if the final state vector is very large, as
@@ -110,7 +112,7 @@ reflected in the results.
 
 #### QSimhSimulator
 
-QSimhSimulator uses a hybrid Schrödinger-Feynman simulator. This limits it to
+`QSimhSimulator` uses a hybrid Schrödinger-Feynman simulator. This limits it to
 returning amplitudes for specific output bitstrings, but raises its upper
 bound on number of qubits simulated (50+ qubits, depending on depth).
 
@@ -123,11 +125,11 @@ qsimh_options = {
     'r': 2
 }
 my_sim = qsimcirq.QSimhSimulator(qsimh_options)
-myres = my_sim.compute_amplitudes(program = my_circuit,
-                                  bitstrings=['00', '01', '10', '11'])
+myres = my_sim.compute_amplitudes(program=my_circuit,
+                                  bitstrings=[0b00, 0b01, 0b10, 0b11])
 ```
 
-As with QSimSimulator, the options follow the flag format for `qsimh_base`
+As with `QSimSimulator`, the options follow the flag format for `qsimh_base`
 outlined in the [usage docs](/docs/usage.md).
 
 ## Additional features
@@ -142,8 +144,8 @@ gate set if possible. This uses the Cirq `decompose` operation.
 
 Known gates with no decomposition:
 
-- ControlledGate (i.e. gates constructed using the `controlled_by()` method)
-- Matrix gates on 3 or more qubits
+- Cirq `ControlledGate`s (i.e. gates constructed using the `cirq.ControlledGate` method).
+- Cirq `MatrixGate`s on 3 or more qubits.
 
 ### Parametrized circuits
 

--- a/docs/input_format.md
+++ b/docs/input_format.md
@@ -12,7 +12,7 @@ gates with one gate per line. The format for a gate is
 time gate_name qubits parameters
 ```
 
-Here `time` is a gate application "time". Gates with the same time can be
+Here `time` refers to when the gate is applied in the circuit. Gates with the same time can be
 applied independently and they may be reordered for performance. Trailing
 spaces or characters are not allowed. A number of sample circuits are provided
 in [circuits](/circuits).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,8 +22,8 @@ or try the runnable
 This repository includes two top-level libraries for simulation:
 
 -   **qsim** is a Schrödinger state-vector simulator designed to run on a
-    single machine. It produces the full state vector as output, for instance,
-    allowing users to sample repeatedly from a single execution.
+    single machine. It produces the full state vector as output which, 
+    for instance, allows users to sample repeatedly from a single execution.
 -   **qsimh** is a hybrid Schrödinger-Feynman simulator built for parallel
     execution on a cluster of machines. It produces amplitudes for user-
     specified output bitstrings.

--- a/docs/release-qsimcirq.md
+++ b/docs/release-qsimcirq.md
@@ -17,9 +17,9 @@ Version numbering follows the semantic versioning guidelines at
 >   1. MAJOR version when you make incompatible API changes,
 >   2. MINOR version when you add functionality in a backwards compatible manner, and
 >   3. PATCH version when you make backwards compatible bug fixes.
-
-Additional labels for pre-release and build metadata are available
-as extensions to the MAJOR.MINOR.PATCH format.
+> 
+> Additional labels for pre-release and build metadata are available
+> as extensions to the MAJOR.MINOR.PATCH format.
 
 Note that this behavior is altered for MAJOR version zero (0.y.z):
 

--- a/docs/release-qsimcirq.md
+++ b/docs/release-qsimcirq.md
@@ -12,20 +12,16 @@ Google-internal fork of qsim.
 Version numbering follows the semantic versioning guidelines at
 [semver.org](https://semver.org/), whose summary is copied below:
 
-```
-Given a version number MAJOR.MINOR.PATCH, increment the:
-
-  1. MAJOR version when you make incompatible API changes,
-  2. MINOR version when you add functionality in a backwards compatible manner, and
-  3. PATCH version when you make backwards compatible bug fixes.
+> Given a version number MAJOR.MINOR.PATCH, increment the:
+> 
+>   1. MAJOR version when you make incompatible API changes,
+>   2. MINOR version when you add functionality in a backwards compatible manner, and
+>   3. PATCH version when you make backwards compatible bug fixes.
 
 Additional labels for pre-release and build metadata are available
 as extensions to the MAJOR.MINOR.PATCH format.
-```
 
 Note that this behavior is altered for MAJOR version zero (0.y.z):
 
-```
-Major version zero (0.y.z) is for initial development. Anything MAY change at
-any time. The public API SHOULD NOT be considered stable.
-```
+> Major version zero (0.y.z) is for initial development. Anything MAY change at
+> any time. The public API SHOULD NOT be considered stable.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -153,7 +153,7 @@ reasonably well in most cases.
 
 The runtime of an execution is heavily influenced by **-p**, as there is no
 summation over the "prefix" gates. The unique "prefix" path is specified by
-**-w**; see the `Distributed execution` section below for details on this.
+**-w**; see the "Distributed execution" section below for details on this.
 
 **-r** implicitly specifies the number of the "suffix" gates: the total number
 of gates on the cut minus the values specified by **-p** and **-r**. For


### PR DESCRIPTION
Biggest changes are to `cirq_interface.md`:

- Update bitstrings from strings to ints. 
- Clarify creating a Cirq circuit vs. QSimCircuit.
- Replace reference to `cirq.controlled_by` (removed AFAIK) with `cirq.ControlledGate`. 

Other changes are minor formatting/wording updates. Note that block quotes are used in `release-qsimcirq.md` to prevent syntax highlighting in the plaintext. 