### PR TITLE
Allow control passthrough from Cirq.

### DIFF
--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -267,6 +267,12 @@ void add_matrix2(const unsigned time, const std::vector<unsigned>& qubits,
     Cirq::MatrixGate2<float>::Create(time, qubits[0], qubits[1], matrix));
 }
 
+void control_last_gate(const std::vector<unsigned>& qubits,
+                       const std::vector<unsigned>& values,
+                       Circuit<Cirq::GateCirq<float>>* circuit) {
+  MakeControlledGate(qubits, values, circuit->gates.back());
+}
+
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options) {
   Circuit<Cirq::GateCirq<float>> circuit;
   std::vector<Bitstring> bitstrings;

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -39,6 +39,10 @@ void add_matrix2(const unsigned time, const std::vector<unsigned>& qubits,
                  const qsim::Cirq::Matrix2q<float>& matrix,
                  qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit);
 
+void control_last_gate(const std::vector<unsigned>& qubits,
+                       const std::vector<unsigned>& values,
+                       qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit);
+
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options);
 
 py::array_t<float> qsim_simulate_fullstate(const py::dict &options);
@@ -111,6 +115,8 @@ PYBIND11_MODULE(qsim, m) {
         "Adds a one-qubit matrix-defined gate to the given circuit.");
   m.def("add_matrix2", &add_matrix2,
         "Adds a two-qubit matrix-defined gate to the given circuit.");
+  m.def("control_last_gate", &control_last_gate,
+        "Applies controls to the final gate of a circuit.");
 }
 
 #endif

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -284,7 +284,9 @@ class MainTest(unittest.TestCase):
       cirq.X(qubits[2]).controlled_by(*qubits[:2], control_values=[1, 2]),
     )
     qsimSim = qsimcirq.QSimSimulator()
-    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    with self.assertWarnsRegex(RuntimeWarning,
+                               'Gate has no valid control value'):
+      result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
     assert result.state_vector()[0] == 1
 
 

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -218,6 +218,76 @@ class MainTest(unittest.TestCase):
         result.state_vector(), cirq_result.state_vector())
 
 
+  def test_basic_controlled_gate(self):
+    qubits = cirq.LineQubit.range(3)
+
+    cirq_circuit = cirq.Circuit(
+      cirq.H(qubits[1]), cirq.Y(qubits[2]),
+      cirq.X(qubits[0]).controlled_by(qubits[1]),
+      cirq.CX(*qubits[1:]).controlled_by(qubits[0]),
+      cirq.H(qubits[1]).controlled_by(qubits[0], qubits[2]),
+    )
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (8,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector())
+
+
+  def test_controlled_matrix_gates(self):
+    qubits = cirq.LineQubit.range(4)
+    m1 = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
+    m2 = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+
+    cirq_circuit = cirq.Circuit(
+      cirq.MatrixGate(m1).on(qubits[0]).controlled_by(qubits[3]),
+      cirq.MatrixGate(m2).on(*qubits[1:3]).controlled_by(qubits[0]),
+      cirq.MatrixGate(m1).on(qubits[2]).controlled_by(qubits[0], qubits[1],
+                                                      qubits[3]),
+      cirq.MatrixGate(m2).on(qubits[0], qubits[3]).controlled_by(*qubits[1:3]),
+    )
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (16,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector())
+
+
+  def test_control_values(self):
+    qubits = cirq.LineQubit.range(3)
+
+    cirq_circuit = cirq.Circuit(
+      # Controlled by |01) state on qubits 1 and 2
+      cirq.X(qubits[0]).controlled_by(*qubits[1:], control_values=[0, 1]),
+      # Controlled by either |0) or |1) on qubit 0 (i.e., uncontrolled)
+      cirq.X(qubits[1]).controlled_by(qubits[0], control_values=[(0, 1)]),
+      # Controlled by |10) state on qubits 0 and 1
+      cirq.X(qubits[2]).controlled_by(qubits[1], qubits[0],
+                                      control_values=[0, 1]),
+    )
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (8,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector())
+
+    qubits = cirq.LineQid.for_qid_shape([2, 3, 2])
+    cirq_circuit = cirq.Circuit(
+      # Controlled by |12) state on qubits 0 and 1
+      # Since qsim does not support qudits (yet), this gate is omitted.
+      cirq.X(qubits[2]).controlled_by(*qubits[:2], control_values=[1, 2]),
+    )
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector()[0] == 1
+
+
   def test_decomposable_gate(self):
     qubits = cirq.LineQubit.range(4)
 
@@ -243,21 +313,21 @@ class MainTest(unittest.TestCase):
         result.state_vector(), cirq_result.state_vector())
 
 
-  def test_cirq_irreconcilable_gate(self):
-    a, b, c, d = [
-        cirq.GridQubit(0, 0),
-        cirq.GridQubit(0, 1),
-        cirq.GridQubit(1, 1),
-        cirq.GridQubit(1, 0)
-    ]
+  def test_complicated_decomposition(self):
+    qubits = cirq.LineQubit.range(4)
 
-    # The QFT gate does not decompose cleanly into the qsim gateset.
+    # The QFT gate decomposes cleanly into the qsim gateset.
     cirq_circuit = cirq.Circuit(
-        cirq.QuantumFourierTransformGate(4).on(a, b, c, d))
+        cirq.QuantumFourierTransformGate(4).on(*qubits))
 
     qsimSim = qsimcirq.QSimSimulator()
-    with self.assertRaises(ValueError):
-      qsimSim.simulate(cirq_circuit)
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (16,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    # Decomposition may result in gates which add a global phase.
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector())
 
 
   def test_cirq_qsim_simulate_random_unitary(self):


### PR DESCRIPTION
This PR is part of issue #163.

With this change, the qsim-core support for controlled gates is made available to Cirq users. Any number of control qubits can be requested, but the gates being controlled must still be 1- or 2-qubit gates. Passthrough for larger gates will be supported in a future PR.