### PR TITLE
Fallback on unitary() in gate decomposition.

### DIFF
--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -228,14 +228,17 @@ class MainTest(unittest.TestCase):
       [1, 0, 0, 0, 0, 0, 0, 0],
       [0, 1, 0, 0, 0, 0, 0, 0],
       [0, 0, 1, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 1],
+      [0, 0, 0, 1, 0, 0, 0, 0],
       [0, 0, 0, 0, 1, 0, 0, 0],
       [0, 0, 0, 0, 0, 1, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 1],
       [0, 0, 0, 0, 0, 0, 1, 0],
-      [0, 0, 0, 1, 0, 0, 0, 0],
     ])
 
-    cirq_circuit = cirq.Circuit(cirq.MatrixGate(m).on(*qubits))
+    cirq_circuit = cirq.Circuit(
+      cirq.X(qubits[0]), cirq.X(qubits[1]),
+      cirq.MatrixGate(m).on(*qubits),
+    )
     qsimSim = qsimcirq.QSimSimulator()
     result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
     assert result.state_vector().shape == (8,)
@@ -267,15 +270,18 @@ class MainTest(unittest.TestCase):
           [1, 0, 0, 0, 0, 0, 0, 0],
           [0, 1, 0, 0, 0, 0, 0, 0],
           [0, 0, 1, 0, 0, 0, 0, 0],
-          [0, 0, 0, 0, 0, 0, 0, 1],
+          [0, 0, 0, 1, 0, 0, 0, 0],
           [0, 0, 0, 0, 1, 0, 0, 0],
           [0, 0, 0, 0, 0, 1, 0, 0],
+          [0, 0, 0, 0, 0, 0, 0, 1],
           [0, 0, 0, 0, 0, 0, 1, 0],
-          [0, 0, 0, 1, 0, 0, 0, 0],
         ])
 
     qubits = cirq.LineQubit.range(3)
-    cirq_circuit = cirq.Circuit(UnknownThreeQubitGate().on(*qubits))
+    cirq_circuit = cirq.Circuit(
+      cirq.X(qubits[0]), cirq.X(qubits[1]),
+      UnknownThreeQubitGate().on(*qubits),
+    )
     qsimSim = qsimcirq.QSimSimulator()
     result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
     assert result.state_vector().shape == (8,)

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -221,6 +221,70 @@ class MainTest(unittest.TestCase):
         result.state_vector(), cirq_result.state_vector())
 
 
+  def test_big_matrix_gates(self):
+    qubits = cirq.LineQubit.range(3)
+    # Toffoli gate as a matrix.
+    m = np.array([
+      [1, 0, 0, 0, 0, 0, 0, 0],
+      [0, 1, 0, 0, 0, 0, 0, 0],
+      [0, 0, 1, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 1],
+      [0, 0, 0, 0, 1, 0, 0, 0],
+      [0, 0, 0, 0, 0, 1, 0, 0],
+      [0, 0, 0, 0, 0, 0, 1, 0],
+      [0, 0, 0, 1, 0, 0, 0, 0],
+    ])
+
+    cirq_circuit = cirq.Circuit(cirq.MatrixGate(m).on(*qubits))
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (8,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector())
+
+
+  def test_decompose_to_matrix_gates(self):
+
+    class UnknownThreeQubitGate(cirq.ops.Gate):
+      """This gate is not recognized by qsim, and cannot be decomposed.
+      
+      qsim should attempt to convert it to a MatrixGate to resolve the issue.
+      """
+      def __init__(self):
+        pass
+
+      def _num_qubits_(self):
+        return 3
+
+      def _qid_shape_(self):
+        return (2, 2, 2)
+
+      def _unitary_(self):
+        # Toffoli gate as a matrix.
+        return np.array([
+          [1, 0, 0, 0, 0, 0, 0, 0],
+          [0, 1, 0, 0, 0, 0, 0, 0],
+          [0, 0, 1, 0, 0, 0, 0, 0],
+          [0, 0, 0, 0, 0, 0, 0, 1],
+          [0, 0, 0, 0, 1, 0, 0, 0],
+          [0, 0, 0, 0, 0, 1, 0, 0],
+          [0, 0, 0, 0, 0, 0, 1, 0],
+          [0, 0, 0, 1, 0, 0, 0, 0],
+        ])
+
+    qubits = cirq.LineQubit.range(3)
+    cirq_circuit = cirq.Circuit(UnknownThreeQubitGate().on(*qubits))
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (8,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector())
+
+
   def test_basic_controlled_gate(self):
     qubits = cirq.LineQubit.range(3)
 

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -236,7 +236,7 @@ class MainTest(unittest.TestCase):
     ])
 
     cirq_circuit = cirq.Circuit(
-      cirq.X(qubits[0]), cirq.X(qubits[1]),
+      cirq.H(qubits[0]), cirq.H(qubits[1]),
       cirq.MatrixGate(m).on(*qubits),
     )
     qsimSim = qsimcirq.QSimSimulator()
@@ -279,7 +279,7 @@ class MainTest(unittest.TestCase):
 
     qubits = cirq.LineQubit.range(3)
     cirq_circuit = cirq.Circuit(
-      cirq.X(qubits[0]), cirq.X(qubits[1]),
+      cirq.H(qubits[0]), cirq.H(qubits[1]),
       UnknownThreeQubitGate().on(*qubits),
     )
     qsimSim = qsimcirq.QSimSimulator()


### PR DESCRIPTION
Follow-up to #234. This PR ensures that 3+ qubit gates with no path for decomposing into known 1- and 2-qubit gates can be handled by qsim by converting to MatrixGates.