### PR TITLE
Pass through max fused qubits from Python

### DIFF
--- a/docs/tutorials/qsimcirq.ipynb
+++ b/docs/tutorials/qsimcirq.ipynb
@@ -376,6 +376,33 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "metadata": {
+      "id": "HVkTbqfH4zls"
+    },
+    "source": [
+      "Another option is to adjust the maximum number of qubits over which to fuse gates. Increasing this value (as demonstrated below) increases arithmetic intensity, which may improve performance with the right environment settings."
+    ]
+  },
+  {
+    "cell_type": "code",
+    "metadata": {
+      "id": "kkQ5ARpI5phJ"
+    },
+    "source": [
+      "# Increase maximum fused gate size to three qubits.\n",
+      "options = {'f': 3}\n",
+      "\n",
+      "qsim_simulator = qsimcirq.QSimSimulator(options)\n",
+      "qsim_start = time.time()\n",
+      "qsim_results = qsim_simulator.simulate(circuit)\n",
+      "qsim_elapsed = time.time() - qsim_start\n",
+      "print(f'qsim runtime: {qsim_elapsed} seconds.')"
+    ],
+    "execution_count": null,
+    "outputs": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "id": "LgWOEMLKutsq"

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -23,7 +23,6 @@
 
 #include "../lib/bitstring.h"
 #include "../lib/formux.h"
-#include "../lib/fuser_basic.h"
 #include "../lib/fuser_mqubit.h"
 #include "../lib/gates_qsim.h"
 #include "../lib/io.h"

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -24,6 +24,7 @@
 #include "../lib/bitstring.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_basic.h"
+#include "../lib/fuser_mqubit.h"
 #include "../lib/gates_qsim.h"
 #include "../lib/io.h"
 #include "../lib/run_qsim.h"
@@ -358,12 +359,13 @@ std::vector<std::complex<float>> qsim_simulate(const py::dict &options) {
     }
   };
 
-  using Runner = QSimRunner<IO, BasicGateFuser<IO, Cirq::GateCirq<float>>,
+  using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Cirq::GateCirq<float>>,
                             Simulator>;
 
   Runner::Parameter param;
   try {
     param.num_threads = parseOptions<unsigned>(options, "t\0");
+    param.max_fused_size = parseOptions<unsigned>(options, "f\0");
     param.verbosity = parseOptions<unsigned>(options, "v\0");
     param.seed = parseOptions<unsigned>(options, "s\0");
   } catch (const std::invalid_argument &exp) {
@@ -386,12 +388,13 @@ py::array_t<float> qsim_simulate_fullstate(const py::dict &options) {
   using Simulator = qsim::Simulator<For>;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
-  using Runner = QSimRunner<IO, BasicGateFuser<IO, Cirq::GateCirq<float>>,
+  using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Cirq::GateCirq<float>>,
                             Simulator>;
 
   Runner::Parameter param;
   try {
     param.num_threads = parseOptions<unsigned>(options, "t\0");
+    param.max_fused_size = parseOptions<unsigned>(options, "f\0");
     param.verbosity = parseOptions<unsigned>(options, "v\0");
     param.seed = parseOptions<unsigned>(options, "s\0");
   } catch (const std::invalid_argument &exp) {
@@ -437,12 +440,13 @@ std::vector<unsigned> qsim_sample(const py::dict &options) {
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
   using MeasurementResult = StateSpace::MeasurementResult;
-  using Runner = QSimRunner<IO, BasicGateFuser<IO, Cirq::GateCirq<float>>,
+  using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Cirq::GateCirq<float>>,
                             Simulator>;
 
   Runner::Parameter param;
   try {
     param.num_threads = parseOptions<unsigned>(options, "t\0");
+    param.max_fused_size = parseOptions<unsigned>(options, "f\0");
     param.verbosity = parseOptions<unsigned>(options, "v\0");
     param.seed = parseOptions<unsigned>(options, "s\0");
   } catch (const std::invalid_argument &exp) {
@@ -479,7 +483,7 @@ std::vector<unsigned> qsim_sample(const py::dict &options) {
 std::vector<std::complex<float>> qsimh_simulate(const py::dict &options) {
   using Simulator = qsim::Simulator<For>;
   using HybridSimulator = HybridSimulator<IO, Cirq::GateCirq<float>,
-                                          BasicGateFuser, Simulator, For>;
+                                          MultiQubitGateFuser, Simulator, For>;
   using Runner = QSimHRunner<IO, HybridSimulator>;
 
   Circuit<Cirq::GateCirq<float>> circuit;
@@ -495,6 +499,7 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options) {
     param.num_prefix_gatexs = parseOptions<unsigned>(options, "p\0");
     param.num_root_gatexs = parseOptions<unsigned>(options, "r\0");
     param.num_threads = parseOptions<unsigned>(options, "t\0");
+    param.max_fused_size = parseOptions<unsigned>(options, "f\0");
     param.verbosity = parseOptions<unsigned>(options, "v\0");
   } catch (const std::invalid_argument &exp) {
     IO::errorf(exp.what());

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -62,7 +62,7 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
           'Keys "c" & "i" are reserved for internal use and cannot be used in QSimCircuit instantiation.'
       )
     self._prng = value.parse_random_state(seed)
-    self.qsim_options = {'t': 1, 'v': 0}
+    self.qsim_options = {'t': 1, 'f': 2, 'v': 0}
     self.qsim_options.update(qsim_options)
 
   def get_seed(self):

--- a/qsimcirq/qsimh_simulator.py
+++ b/qsimcirq/qsimh_simulator.py
@@ -23,7 +23,7 @@ import qsimcirq.qsim_circuit as qsimc
 class QSimhSimulator(SimulatesAmplitudes):
 
   def __init__(self, qsimh_options: dict = {}):
-    self.qsimh_options = {'t': 1, 'v': 0}
+    self.qsimh_options = {'t': 1, 'f': 2, 'v': 0}
     self.qsimh_options.update(qsimh_options)
 
   def compute_amplitudes_sweep(

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -405,6 +405,26 @@ class MainTest(unittest.TestCase):
         result.state_vector(), cirq_result.state_vector())
 
 
+  def test_multi_qubit_fusion(self):
+    q0, q1, q2, q3 = cirq.LineQubit.range(4)
+    qubits = [q0, q1, q2, q3]
+    cirq_circuit = cirq.Circuit(
+      cirq.CX(q0, q1), cirq.X(q2)**0.5, cirq.Y(q3)**0.5,
+      cirq.CX(q0, q2), cirq.T(q1), cirq.T(q3),
+      cirq.CX(q1, q2), cirq.X(q3)**0.5, cirq.Y(q0)**0.5,
+      cirq.CX(q1, q3), cirq.T(q0), cirq.T(q2),
+      cirq.CX(q2, q3), cirq.X(q0)**0.5, cirq.Y(q1)**0.5,
+    )
+
+    qsimSim = qsimcirq.QSimSimulator(qsim_options={'f': 2})
+    result_2q_fusion = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+
+    qsimSim = qsimcirq.QSimSimulator(qsim_options={'f': 4})
+    result_4q_fusion = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result_2q_fusion.state_vector(), result_4q_fusion.state_vector())
+
+
   def test_cirq_qsim_simulate_random_unitary(self):
 
     q0, q1 = cirq.LineQubit.range(2)


### PR DESCRIPTION
Allows Python users to pipe in the `max_fused_size` parameter with option `f`.