### PR TITLE
Support initial state in qsimcirq.

### DIFF
--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -466,8 +466,7 @@ py::array_t<float> qsim_simulate_fullstate(
     IO::errorf("Memory allocation failed.\n");
     return {};
   }
-  py::buffer_info buf = input_vector.request();
-  float* ptr = (float*)buf.ptr;
+  const float* ptr = input_vector.data();
   for (int i = 0; i < input_vector.size(); ++i) {
     fsv[i] = ptr[i];
   }

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -46,6 +46,8 @@ void control_last_gate(const std::vector<unsigned>& qubits,
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options);
 
 py::array_t<float> qsim_simulate_fullstate(const py::dict &options);
+py::array_t<float> qsim_simulate_fullstate(
+      const py::dict &options, const py::array_t<float> &input_vector);
 
 std::vector<unsigned> qsim_sample(const py::dict &options);
 
@@ -55,7 +57,14 @@ PYBIND11_MODULE(qsim, m) {
   m.doc() = "pybind11 plugin";  // optional module docstring
 
   m.def("qsim_simulate", &qsim_simulate, "Call the qsim simulator");
-  m.def("qsim_simulate_fullstate", &qsim_simulate_fullstate,
+  m.def("qsim_simulate_fullstate",
+        static_cast<py::array_t<float>(*)(const py::dict&)>(
+            &qsim_simulate_fullstate),
+        "Call the qsim simulator for full state vector simulation");
+  m.def("qsim_simulate_fullstate",
+        static_cast<py::array_t<float>(*)(const py::dict&,
+                                          const py::array_t<float>&)>(
+            &qsim_simulate_fullstate),
         "Call the qsim simulator for full state vector simulation");
   m.def("qsim_sample", &qsim_sample, "Call the qsim sampler");
   m.def("qsimh_simulate", &qsimh_simulate, "Call the qsimh simulator");

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -45,7 +45,8 @@ void control_last_gate(const std::vector<unsigned>& qubits,
 
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options);
 
-py::array_t<float> qsim_simulate_fullstate(const py::dict &options);
+py::array_t<float> qsim_simulate_fullstate(
+      const py::dict &options, int64_t input_state);
 py::array_t<float> qsim_simulate_fullstate(
       const py::dict &options, const py::array_t<float> &input_vector);
 
@@ -58,7 +59,7 @@ PYBIND11_MODULE(qsim, m) {
 
   m.def("qsim_simulate", &qsim_simulate, "Call the qsim simulator");
   m.def("qsim_simulate_fullstate",
-        static_cast<py::array_t<float>(*)(const py::dict&)>(
+        static_cast<py::array_t<float>(*)(const py::dict&, int64_t)>(
             &qsim_simulate_fullstate),
         "Call the qsim simulator for full state vector simulation");
   m.def("qsim_simulate_fullstate",

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -46,7 +46,7 @@ void control_last_gate(const std::vector<unsigned>& qubits,
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options);
 
 py::array_t<float> qsim_simulate_fullstate(
-      const py::dict &options, int64_t input_state);
+      const py::dict &options, uint64_t input_state);
 py::array_t<float> qsim_simulate_fullstate(
       const py::dict &options, const py::array_t<float> &input_vector);
 
@@ -59,7 +59,7 @@ PYBIND11_MODULE(qsim, m) {
 
   m.def("qsim_simulate", &qsim_simulate, "Call the qsim simulator");
   m.def("qsim_simulate_fullstate",
-        static_cast<py::array_t<float>(*)(const py::dict&, int64_t)>(
+        static_cast<py::array_t<float>(*)(const py::dict&, uint64_t)>(
             &qsim_simulate_fullstate),
         "Call the qsim simulator for full state vector simulation");
   m.def("qsim_simulate_fullstate",

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -169,7 +169,7 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
         )
       options['c'] = program.translate_cirq_to_qsim(ops.QubitOrder.DEFAULT)
       options['s'] = self.get_seed()
-      final_state = qsim.qsim_simulate_fullstate(options)
+      final_state = qsim.qsim_simulate_fullstate(options, 0)
       full_results = sim.sample_state_vector(
         final_state.view(np.complex64), range(len(ordered_qubits)),
         repetitions=repetitions, seed=self._prng)
@@ -273,7 +273,9 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
       Raises:
           TypeError: if an invalid initial_state is provided.
       """
-    if not isinstance(initial_state, (type(None), int, np.ndarray)):
+    if initial_state is None:
+      initial_state = 0
+    if not isinstance(initial_state, (int, np.ndarray)):
       raise TypeError('initial_state must be an int or state vector.')
     if not isinstance(program, qsimc.QSimCircuit):
       program = qsimc.QSimCircuit(program, device=program.device)
@@ -305,10 +307,7 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
         qubit: index for index, qubit in enumerate(ordered_qubits)
       }
 
-      if initial_state is None:
-        qsim_state = qsim.qsim_simulate_fullstate(options)
-      else:
-        qsim_state = qsim.qsim_simulate_fullstate(options, input_vector)
+      qsim_state = qsim.qsim_simulate_fullstate(options, input_vector)
       assert qsim_state.dtype == np.float32
       assert qsim_state.ndim == 1
       final_state = QSimSimulatorState(qsim_state, qubit_map)

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -135,20 +135,38 @@ class MainTest(unittest.TestCase):
     # initial_state supports bitstrings.
     qsim_result = qsimSim.simulate_sweep(cirq_circuit, params,
                                          initial_state=0b01)
-    cirq_result = qsimSim.simulate_sweep(cirq_circuit, params,
+    cirq_result = cirqSim.simulate_sweep(cirq_circuit, params,
                                          initial_state=0b01)
     for i in range(len(qsim_result)):
       assert cirq.linalg.allclose_up_to_global_phase(
         qsim_result[i].state_vector(), cirq_result[i].state_vector())
 
     # initial_state supports state vectors.
+    initial_state = np.asarray([0.5j, 0.5, -0.5j, -0.5], dtype=np.complex64)
     qsim_result = qsimSim.simulate_sweep(
-      cirq_circuit, params, initial_state=np.asarray([0.5j, 0.5, -0.5j, -0.5]))
-    cirq_result = qsimSim.simulate_sweep(
-      cirq_circuit, params, initial_state=np.asarray([0.5j, 0.5, -0.5j, -0.5]))
+      cirq_circuit, params, initial_state=initial_state)
+    cirq_result = cirqSim.simulate_sweep(
+      cirq_circuit, params, initial_state=initial_state)
     for i in range(len(qsim_result)):
       assert cirq.linalg.allclose_up_to_global_phase(
         qsim_result[i].state_vector(), cirq_result[i].state_vector())
+
+  def test_input_vector_validation(self):
+    cirq_circuit = cirq.Circuit(
+      cirq.X(cirq.LineQubit(0)), cirq.X(cirq.LineQubit(1))
+    )
+    params = [{}]
+    qsimSim = qsimcirq.QSimSimulator()
+
+    with self.assertRaises(ValueError):
+      initial_state = np.asarray([0.25]*16, dtype=np.complex64)
+      qsim_result = qsimSim.simulate_sweep(
+        cirq_circuit, params, initial_state=initial_state)
+
+    with self.assertRaises(TypeError):
+      initial_state = np.asarray([0.5]*4)
+      qsim_result = qsimSim.simulate_sweep(
+        cirq_circuit, params, initial_state=initial_state)
 
 
   def test_cirq_qsim_run(self):

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -132,9 +132,23 @@ class MainTest(unittest.TestCase):
       assert cirq.linalg.allclose_up_to_global_phase(
         qsim_result[i].state_vector(), cirq_result[i].state_vector())
 
-    # initial_state is not supported.
-    with self.assertRaisesRegex(ValueError, 'initial_state'):
-      qsimSim.simulate_sweep(cirq_circuit, params, initial_state=0b01)
+    # initial_state supports bitstrings.
+    qsim_result = qsimSim.simulate_sweep(cirq_circuit, params,
+                                         initial_state=0b01)
+    cirq_result = qsimSim.simulate_sweep(cirq_circuit, params,
+                                         initial_state=0b01)
+    for i in range(len(qsim_result)):
+      assert cirq.linalg.allclose_up_to_global_phase(
+        qsim_result[i].state_vector(), cirq_result[i].state_vector())
+
+    # initial_state supports state vectors.
+    qsim_result = qsimSim.simulate_sweep(
+      cirq_circuit, params, initial_state=np.asarray([0.5j, 0.5, -0.5j, -0.5]))
+    cirq_result = qsimSim.simulate_sweep(
+      cirq_circuit, params, initial_state=np.asarray([0.5j, 0.5, -0.5j, -0.5]))
+    for i in range(len(qsim_result)):
+      assert cirq.linalg.allclose_up_to_global_phase(
+        qsim_result[i].state_vector(), cirq_result[i].state_vector())
 
 
   def test_cirq_qsim_run(self):


### PR DESCRIPTION
Fixes #41. Initial states can be provided as an integer (representing a computational basis state) or a numpy array containing the full state vector. If no initial state is given, the zero state is used.

I encountered difficulties with pybind when trying to mutate Python objects in C++; as a result, there is extra memory overhead when providing the initial state as an input vector. Integer and omitted input states are unaffected by this overhead cost.