### PR TITLE
Add single qubit gate control support.

### DIFF
--- a/tests/unitary_calculator_basic_test.cc
+++ b/tests/unitary_calculator_basic_test.cc
@@ -29,6 +29,10 @@ TEST(UnitaryCalculatorTest, ApplyGate1) {
   TestApplyGate1<UnitaryCalculatorBasic<For, float>>();
 }
 
+TEST(UnitaryCalculatorTest, ApplyControlledGate1) {
+  TestApplyControlledGate1<UnitaryCalculatorBasic<For, float>>();
+}
+
 TEST(UnitaryCalculatorTest, ApplyGate2) {
   TestApplyGate2<UnitaryCalculatorBasic<For, float>>();
 }


### PR DESCRIPTION
Adds support for single qubit controlled gates in the unitary calculator. Tries to follow as closely as possible with the code generation style used in the rest of the library.