### PR TITLE
Don't call private method of superclass.

### DIFF
--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -167,7 +167,7 @@ class QSimCircuit(cirq.Circuit):
 
   def _resolve_parameters_(self, param_resolver: cirq.study.ParamResolver):
     return QSimCircuit(
-      super()._resolve_parameters_(param_resolver), device=self.device)
+      cirq.resolve_parameters(super(), param_resolver), device=self.device)
 
   def translate_cirq_to_qsim(
       self,


### PR DESCRIPTION
`_resolve_parameters_` is a private method, indicated by the leading underscore. `cirq.resolve_parameters` invokes this method with compatibility checks for https://github.com/quantumlib/Cirq/issues/3714, so we should use it instead.