### PR TITLE
Docstrings for qsim[h]_options

### DIFF
--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -57,6 +57,20 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
 
   def __init__(self, qsim_options: dict = {},
                seed: value.RANDOM_STATE_OR_SEED_LIKE = None):
+    """Creates a new QSimSimulator using the given options and seed.
+    
+    Args:
+        qsim_options: A map of circuit options for the simulator. These will be
+            applied to all circuits run using this simulator. Accepted keys and
+            their behavior are as follows:
+                - 'f': int (> 0). Maximum size of fused gates. Default: 2.
+                - 't': int (> 0). Number of threads to run on. Default: 1.
+                - 'v': int (>= 0). Log verbosity. Default: 0.
+        seed: A random state or seed object, as defined in cirq.value.
+    
+    Raises:
+        ValueError if internal keys 'c' or 'i' are included in 'qsim_options'.
+    """
     if any(k in qsim_options for k in ('c', 'i')):
       raise ValueError(
           'Keys "c" & "i" are reserved for internal use and cannot be used in QSimCircuit instantiation.'

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -66,6 +66,7 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
                 - 'f': int (> 0). Maximum size of fused gates. Default: 2.
                 - 't': int (> 0). Number of threads to run on. Default: 1.
                 - 'v': int (>= 0). Log verbosity. Default: 0.
+            See qsim/docs/usage.md for more details on these options.
         seed: A random state or seed object, as defined in cirq.value.
     
     Raises:

--- a/qsimcirq/qsimh_simulator.py
+++ b/qsimcirq/qsimh_simulator.py
@@ -23,6 +23,20 @@ import qsimcirq.qsim_circuit as qsimc
 class QSimhSimulator(SimulatesAmplitudes):
 
   def __init__(self, qsimh_options: dict = {}):
+    """Creates a new QSimhSimulator using the given options.
+    
+    Args:
+        qsim_options: A map of circuit options for the simulator. These will be
+            applied to all circuits run using this simulator. Accepted keys and
+            their behavior are as follows:
+                - 'k': Comma-separated list of ints. Indices of "part 1" qubits.
+                - 'p': int (>= 0). Number of "prefix" gates.
+                - 'r': int (>= 0). Number of "root" gates.
+                - 't': int (> 0). Number of threads to run on. Default: 1.
+                - 'v': int (>= 0). Log verbosity. Default: 0.
+                - 'w': int (>= 0). Prefix value.
+            See qsim/docs/usage.md for more details on these options.
+    """
     self.qsimh_options = {'t': 1, 'f': 2, 'v': 0}
     self.qsimh_options.update(qsimh_options)
 


### PR DESCRIPTION
Details pulled from qsim/docs/usage.md. Fixes #276.