### PR TITLE
Don't overwrite initial states in qtrajectory

### DIFF
--- a/lib/qtrajectory.h
+++ b/lib/qtrajectory.h
@@ -238,12 +238,11 @@ class QuantumTrajectorySimulator {
 
     if (state_space.IsNull(state)) {
       state = CreateState(num_qubits, state_space);
+      state_space.SetStateZero(state);
       if (state_space.IsNull(state)) {
         return false;
       }
     }
-
-    state_space.SetStateZero(state);
 
     gates.resize(0);
     stat.resize(0);


### PR DESCRIPTION
Came across this in testing for qsimcirq integration: if we `SetStateZero` for all states, users can't specify an input state.