### PR TITLE
Enable trajectory simulation via qsimcirq

### DIFF
--- a/lib/qtrajectory.h
+++ b/lib/qtrajectory.h
@@ -68,6 +68,21 @@ using Channel = std::vector<KrausOperator<Gate>>;
 template <typename Gate>
 using NoisyCircuit = std::vector<Channel<Gate>>;
 
+template <typename Gate>
+unsigned count_qubits(const NoisyCircuit<Gate>& ncircuit) {
+  std::set<int> qubit_set;
+  for (const Channel<Gate>& channel : ncircuit) {
+    for (const KrausOperator<Gate>& kop : channel) {
+      for (const Gate& gate : kop.ops) {
+        for (const unsigned& qidx : gate.qubits) {
+          qubit_set.insert(qidx);
+        }
+      }
+    }
+  }
+  return qubit_set.size();
+}
+
 /**
  * Quantum trajectory simulator.
  */

--- a/lib/qtrajectory.h
+++ b/lib/qtrajectory.h
@@ -68,21 +68,6 @@ using Channel = std::vector<KrausOperator<Gate>>;
 template <typename Gate>
 using NoisyCircuit = std::vector<Channel<Gate>>;
 
-template <typename Gate>
-unsigned count_qubits(const NoisyCircuit<Gate>& ncircuit) {
-  std::set<int> qubit_set;
-  for (const Channel<Gate>& channel : ncircuit) {
-    for (const KrausOperator<Gate>& kop : channel) {
-      for (const Gate& gate : kop.ops) {
-        for (const unsigned& qidx : gate.qubits) {
-          qubit_set.insert(qidx);
-        }
-      }
-    }
-  }
-  return qubit_set.size();
-}
-
 /**
  * Quantum trajectory simulator.
  */

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -73,256 +73,190 @@ std::vector<Bitstring> getBitstrings(const py::dict &options, int num_qubits) {
 
 }  // namespace
 
-void add_gate(const qsim::Cirq::GateKind gate_kind, const unsigned time,
-              const std::vector<unsigned>& qubits,
-              const std::map<std::string, float>& params,
-              Circuit<Cirq::GateCirq<float>>* circuit) {
+Cirq::GateCirq<float> create_gate(const qsim::Cirq::GateKind gate_kind,
+                                  const unsigned time,
+                                  const std::vector<unsigned>& qubits,
+                                  const std::map<std::string, float>& params) {
   switch (gate_kind) {
     case Cirq::kI1:
-      circuit->gates.push_back(Cirq::I1<float>::Create(time, qubits[0]));
-      break;
+      return Cirq::I1<float>::Create(time, qubits[0]);
     case Cirq::kI2:
-      circuit->gates.push_back(
-        Cirq::I2<float>::Create(time, qubits[0], qubits[1]));
-      break;
+      return Cirq::I2<float>::Create(time, qubits[0], qubits[1]);
     case Cirq::kI:
-      circuit->gates.push_back(Cirq::I<float>::Create(time, qubits));
-      break;
+      return Cirq::I<float>::Create(time, qubits);
     case Cirq::kXPowGate:
-      circuit->gates.push_back(
-        Cirq::XPowGate<float>::Create(time, qubits[0], params.at("exponent"),
-                                      params.at("global_shift")));
-      break;
+      return Cirq::XPowGate<float>::Create(
+        time, qubits[0], params.at("exponent"), params.at("global_shift"));
     case Cirq::kYPowGate:
-      circuit->gates.push_back(
-        Cirq::YPowGate<float>::Create(time, qubits[0], params.at("exponent"),
-                                      params.at("global_shift")));
-      break;
+      return Cirq::YPowGate<float>::Create(
+        time, qubits[0], params.at("exponent"), params.at("global_shift"));
     case Cirq::kZPowGate:
-      circuit->gates.push_back(
-        Cirq::ZPowGate<float>::Create(time, qubits[0], params.at("exponent"),
-                                      params.at("global_shift")));
-      break;
+      return Cirq::ZPowGate<float>::Create(
+        time, qubits[0], params.at("exponent"), params.at("global_shift"));
     case Cirq::kHPowGate:
-      circuit->gates.push_back(
-        Cirq::HPowGate<float>::Create(time, qubits[0], params.at("exponent"),
-                                      params.at("global_shift")));
-      break;
+      return Cirq::HPowGate<float>::Create(
+        time, qubits[0], params.at("exponent"), params.at("global_shift"));
     case Cirq::kCZPowGate:
-      circuit->gates.push_back(
-        Cirq::CZPowGate<float>::Create(time, qubits[0], qubits[1],
-                                       params.at("exponent"),
-                                       params.at("global_shift")));
-      break;
+      return Cirq::CZPowGate<float>::Create(
+        time, qubits[0], qubits[1],
+        params.at("exponent"), params.at("global_shift"));
     case Cirq::kCXPowGate:
-      circuit->gates.push_back(
-        Cirq::CXPowGate<float>::Create(time, qubits[0], qubits[1],
-                                       params.at("exponent"),
-                                       params.at("global_shift")));
-      break;
+      return Cirq::CXPowGate<float>::Create(
+        time, qubits[0], qubits[1],
+        params.at("exponent"), params.at("global_shift"));
     case Cirq::krx:
-      circuit->gates.push_back(
-        Cirq::rx<float>::Create(time, qubits[0], params.at("phi")));
-      break;
+      return Cirq::rx<float>::Create(time, qubits[0], params.at("phi"));
     case Cirq::kry:
-      circuit->gates.push_back(
-        Cirq::ry<float>::Create(time, qubits[0], params.at("phi")));
-      break;
+      return Cirq::ry<float>::Create(time, qubits[0], params.at("phi"));
     case Cirq::krz:
-      circuit->gates.push_back(
-        Cirq::rz<float>::Create(time, qubits[0], params.at("phi")));
-      break;
+      return Cirq::rz<float>::Create(time, qubits[0], params.at("phi"));
     case Cirq::kH:
-      circuit->gates.push_back(Cirq::H<float>::Create(time, qubits[0]));
-      break;
+      return Cirq::H<float>::Create(time, qubits[0]);
     case Cirq::kS:
-      circuit->gates.push_back(Cirq::S<float>::Create(time, qubits[0]));
-      break;
+      return Cirq::S<float>::Create(time, qubits[0]);
     case Cirq::kCZ:
-      circuit->gates.push_back(
-        Cirq::CZ<float>::Create(time, qubits[0], qubits[1]));
-      break;
+      return Cirq::CZ<float>::Create(time, qubits[0], qubits[1]);
     case Cirq::kCX:
-      circuit->gates.push_back(
-        Cirq::CX<float>::Create(time, qubits[0], qubits[1]));
-      break;
+      return Cirq::CX<float>::Create(time, qubits[0], qubits[1]);
     case Cirq::kT:
-      circuit->gates.push_back(Cirq::T<float>::Create(time, qubits[0]));
-      break;
+      return Cirq::T<float>::Create(time, qubits[0]);
     case Cirq::kX:
-      circuit->gates.push_back(Cirq::X<float>::Create(time, qubits[0]));
-      break;
+      return Cirq::X<float>::Create(time, qubits[0]);
     case Cirq::kY:
-      circuit->gates.push_back(Cirq::Y<float>::Create(time, qubits[0]));
-      break;
+      return Cirq::Y<float>::Create(time, qubits[0]);
     case Cirq::kZ:
-      circuit->gates.push_back(Cirq::Z<float>::Create(time, qubits[0]));
-      break;
+      return Cirq::Z<float>::Create(time, qubits[0]);
     case Cirq::kPhasedXPowGate:
-      circuit->gates.push_back(
-        Cirq::PhasedXPowGate<float>::Create(time, qubits[0],
-                                            params.at("phase_exponent"),
-                                            params.at("exponent"),
-                                            params.at("global_shift")));
-      break;
+      return Cirq::PhasedXPowGate<float>::Create(
+        time, qubits[0], params.at("phase_exponent"), params.at("exponent"),
+        params.at("global_shift"));
     case Cirq::kPhasedXZGate:
-      circuit->gates.push_back(
-        Cirq::PhasedXZGate<float>::Create(time, qubits[0],
-                                          params.at("x_exponent"),
-                                          params.at("z_exponent"),
-                                          params.at("axis_phase_exponent")));
-      break;
+      return Cirq::PhasedXZGate<float>::Create(
+        time, qubits[0], params.at("x_exponent"), params.at("z_exponent"),
+        params.at("axis_phase_exponent"));
     case Cirq::kXXPowGate:
-      circuit->gates.push_back(
-        Cirq::XXPowGate<float>::Create(time, qubits[0], qubits[1],
-                                       params.at("exponent"),
-                                       params.at("global_shift")));
-      break;
+      return Cirq::XXPowGate<float>::Create(
+        time, qubits[0], qubits[1], params.at("exponent"),
+        params.at("global_shift"));
     case Cirq::kYYPowGate:
-      circuit->gates.push_back(
-        Cirq::YYPowGate<float>::Create(time, qubits[0], qubits[1],
-                                       params.at("exponent"),
-                                       params.at("global_shift")));
-      break;
+      return Cirq::YYPowGate<float>::Create(
+        time, qubits[0], qubits[1],
+        params.at("exponent"), params.at("global_shift"));
     case Cirq::kZZPowGate:
-      circuit->gates.push_back(
-        Cirq::ZZPowGate<float>::Create(time, qubits[0], qubits[1],
-                                       params.at("exponent"),
-                                       params.at("global_shift")));
-      break;
+      return Cirq::ZZPowGate<float>::Create(
+        time, qubits[0], qubits[1],
+        params.at("exponent"), params.at("global_shift"));
     case Cirq::kXX:
-      circuit->gates.push_back(
-        Cirq::XX<float>::Create(time, qubits[0], qubits[1]));
-      break;
+      return Cirq::XX<float>::Create(time, qubits[0], qubits[1]);
     case Cirq::kYY:
-      circuit->gates.push_back(
-        Cirq::YY<float>::Create(time, qubits[0], qubits[1]));
-      break;
+      return Cirq::YY<float>::Create(time, qubits[0], qubits[1]);
     case Cirq::kZZ:
-      circuit->gates.push_back(
-        Cirq::ZZ<float>::Create(time, qubits[0], qubits[1]));
+      return Cirq::ZZ<float>::Create(time, qubits[0], qubits[1]);
       break;
     case Cirq::kSwapPowGate:
-      circuit->gates.push_back(
-        Cirq::SwapPowGate<float>::Create(time, qubits[0], qubits[1],
-                                         params.at("exponent"),
-                                         params.at("global_shift")));
-      break;
+      return Cirq::SwapPowGate<float>::Create(
+        time, qubits[0], qubits[1],
+        params.at("exponent"), params.at("global_shift"));
     case Cirq::kISwapPowGate:
-      circuit->gates.push_back(
-        Cirq::ISwapPowGate<float>::Create(time, qubits[0], qubits[1],
-                                          params.at("exponent"),
-                                          params.at("global_shift")));
-      break;
+      return Cirq::ISwapPowGate<float>::Create(
+        time, qubits[0], qubits[1],
+        params.at("exponent"), params.at("global_shift"));
     case Cirq::kriswap:
-      circuit->gates.push_back(
-        Cirq::riswap<float>::Create(time, qubits[0], qubits[1],
-                                    params.at("phi")));
-      break;
+      return Cirq::riswap<float>::Create(time, qubits[0], qubits[1],
+                                    params.at("phi"));
     case Cirq::kSWAP:
-      circuit->gates.push_back(
-        Cirq::SWAP<float>::Create(time, qubits[0], qubits[1]));
-      break;
+      return Cirq::SWAP<float>::Create(time, qubits[0], qubits[1]);
     case Cirq::kISWAP:
-      circuit->gates.push_back(
-        Cirq::ISWAP<float>::Create(time, qubits[0], qubits[1]));
-      break;
+      return Cirq::ISWAP<float>::Create(time, qubits[0], qubits[1]);
     case Cirq::kPhasedISwapPowGate:
-      circuit->gates.push_back(
-        Cirq::PhasedISwapPowGate<float>::Create(time, qubits[0], qubits[1],
-                                                params.at("phase_exponent"),
-                                                params.at("exponent")));
-      break;
+      return Cirq::PhasedISwapPowGate<float>::Create(
+        time, qubits[0], qubits[1],
+        params.at("phase_exponent"), params.at("exponent"));
     case Cirq::kgivens:
-      circuit->gates.push_back(
-        Cirq::givens<float>::Create(time, qubits[0], qubits[1],
-                                    params.at("phi")));
-      break;
+      return Cirq::givens<float>::Create(
+        time, qubits[0], qubits[1], params.at("phi"));
     case Cirq::kFSimGate:
-      circuit->gates.push_back(
-        Cirq::FSimGate<float>::Create(time, qubits[0], qubits[1],
-                                      params.at("theta"), params.at("phi")));
-      break;
+      return Cirq::FSimGate<float>::Create(
+        time, qubits[0], qubits[1], params.at("theta"), params.at("phi"));
     case Cirq::kCCZPowGate:
-      circuit->gates.push_back(
-        Cirq::CCZPowGate<float>::Create(time, qubits[0], qubits[1], qubits[2],
-                                        params.at("exponent"),
-                                        params.at("global_shift")));
-      break;
+      return Cirq::CCZPowGate<float>::Create(
+        time, qubits[0], qubits[1], qubits[2],
+        params.at("exponent"), params.at("global_shift"));
     case Cirq::kCCXPowGate:
-      circuit->gates.push_back(
-        Cirq::CCXPowGate<float>::Create(time, qubits[0], qubits[1], qubits[2],
-                                        params.at("exponent"),
-                                        params.at("global_shift")));
-      break;
+      return Cirq::CCXPowGate<float>::Create(
+        time, qubits[0], qubits[1], qubits[2],
+        params.at("exponent"), params.at("global_shift"));
     case Cirq::kCSwapGate:
-      circuit->gates.push_back(
-        Cirq::CSwapGate<float>::Create(time, qubits[0], qubits[1], qubits[2]));
-      break;
+      return Cirq::CSwapGate<float>::Create(
+        time, qubits[0], qubits[1], qubits[2]);
     case Cirq::kCCZ:
-      circuit->gates.push_back(
-        Cirq::CCZ<float>::Create(time, qubits[0], qubits[1], qubits[2]));
-      break;
+      return Cirq::CCZ<float>::Create(time, qubits[0], qubits[1], qubits[2]);
     case Cirq::kCCX:
-      circuit->gates.push_back(
-        Cirq::CCX<float>::Create(time, qubits[0], qubits[1], qubits[2]));
-      break;
+      return Cirq::CCX<float>::Create(time, qubits[0], qubits[1], qubits[2]);
     case Cirq::kMeasurement: {
       std::vector<unsigned> qubits_ = qubits;
-      circuit->gates.push_back(
-        gate::Measurement<Cirq::GateCirq<float>>::Create(time,
-                                                         std::move(qubits_)));
+      return gate::Measurement<Cirq::GateCirq<float>>::Create(
+        time, std::move(qubits_));
       }
-      break;
     // Matrix gates are handled in the add_matrix methods below.
     default:
       throw std::invalid_argument("GateKind not supported.");
   }
 }
 
-void add_diagonal_gate(const unsigned time, const std::vector<unsigned>& qubits,
-                       const std::vector<float>& angles,
-                       Circuit<Cirq::GateCirq<float>>* circuit) {
+Cirq::GateCirq<float> create_diagonal_gate(const unsigned time,
+                                           const std::vector<unsigned>& qubits,
+                                           const std::vector<float>& angles) {
   switch (qubits.size()) {
   case 2:
-    circuit->gates.push_back(
-        Cirq::TwoQubitDiagonalGate<float>::Create(time, qubits[0], qubits[1],
-                                                  angles));
-    break;
+    return Cirq::TwoQubitDiagonalGate<float>::Create(
+      time, qubits[0], qubits[1], angles);
   case 3:
-    circuit->gates.push_back(
-        Cirq::ThreeQubitDiagonalGate<float>::Create(time, qubits[0], qubits[1],
-                                                    qubits[2], angles));
-    break;
+    return Cirq::ThreeQubitDiagonalGate<float>::Create(
+      time, qubits[0], qubits[1], qubits[2], angles);
   default:
     throw std::invalid_argument(
         "Only 2- or 3-qubit diagonal gates sre supported.");
   }
 }
 
-void add_matrix_gate(const unsigned time, const std::vector<unsigned>& qubits,
-                     const std::vector<float>& matrix,
-                     Circuit<Cirq::GateCirq<float>>* circuit) {
+Cirq::GateCirq<float> create_matrix_gate(const unsigned time,
+                                         const std::vector<unsigned>& qubits,
+                                         const std::vector<float>& matrix) {
   switch (qubits.size()) {
   case 1:
-    circuit->gates.push_back(
-        Cirq::MatrixGate1<float>::Create(time, qubits[0], matrix));
-    break;
+    return Cirq::MatrixGate1<float>::Create(time, qubits[0], matrix);
   case 2:
-    circuit->gates.push_back(
-        Cirq::MatrixGate2<float>::Create(time, qubits[0], qubits[1], matrix));
-    break;
+    return Cirq::MatrixGate2<float>::Create(time, qubits[0], qubits[1], matrix);
   case 3:
   case 4:
   case 5:
   case 6:
-    circuit->gates.push_back(
-        Cirq::MatrixGate<float>::Create(time, qubits, matrix));
-    break;
+    return Cirq::MatrixGate<float>::Create(time, qubits, matrix);
   default:
     throw std::invalid_argument(
-        "Only up to 6-qubit matrix gates sre supported.");
+        "Only up to 6-qubit matrix gates are supported.");
   }
+}
+
+void add_gate(const qsim::Cirq::GateKind gate_kind, const unsigned time,
+              const std::vector<unsigned>& qubits,
+              const std::map<std::string, float>& params,
+              Circuit<Cirq::GateCirq<float>>* circuit) {
+  circuit->gates.push_back(create_gate(gate_kind, time, qubits, params));
+}
+
+void add_diagonal_gate(const unsigned time, const std::vector<unsigned>& qubits,
+                       const std::vector<float>& angles,
+                       Circuit<Cirq::GateCirq<float>>* circuit) {
+  circuit->gates.push_back(create_diagonal_gate(time, qubits, angles));
+}
+
+void add_matrix_gate(const unsigned time,
+                     const std::vector<unsigned>& qubits,
+                     const std::vector<float>& matrix,
+                     Circuit<Cirq::GateCirq<float>>* circuit) {
+  circuit->gates.push_back(create_matrix_gate(time, qubits, matrix));
 }
 
 void control_last_gate(const std::vector<unsigned>& qubits,

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -395,7 +395,7 @@ std::vector<std::complex<float>> qtrajectory_simulate(const py::dict &options) {
   std::vector<Bitstring> bitstrings;
   try {
     ncircuit = getNoisyCircuit(options);
-    num_qubits = qsim::count_qubits(ncircuit);
+    num_qubits = parseOptions<unsigned>(options, "n\0");
     bitstrings = getBitstrings(options, num_qubits);
   } catch (const std::invalid_argument &exp) {
     IO::errorf(exp.what());
@@ -562,7 +562,7 @@ py::array_t<float> qtrajectory_simulate_fullstate(const py::dict &options,
   unsigned num_qubits;
   try {
     ncircuit = getNoisyCircuit(options);
-    num_qubits = qsim::count_qubits(ncircuit);
+    num_qubits = parseOptions<unsigned>(options, "n\0");
   } catch (const std::invalid_argument &exp) {
     IO::errorf(exp.what());
     return {};
@@ -622,7 +622,7 @@ py::array_t<float> qtrajectory_simulate_fullstate(
   unsigned num_qubits;
   try {
     ncircuit = getNoisyCircuit(options);
-    num_qubits = qsim::count_qubits(ncircuit);
+    num_qubits = parseOptions<unsigned>(options, "n\0");
   } catch (const std::invalid_argument &exp) {
     IO::errorf(exp.what());
     return {};
@@ -740,7 +740,7 @@ std::vector<unsigned> qtrajectory_sample(const py::dict &options) {
   unsigned num_qubits;
   try {
     ncircuit = getNoisyCircuit(options);
-    num_qubits = qsim::count_qubits(ncircuit);
+    num_qubits = parseOptions<unsigned>(options, "n\0");
   } catch (const std::invalid_argument &exp) {
     IO::errorf(exp.what());
     return {};

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -319,17 +319,16 @@ void control_last_gate_channel(const std::vector<unsigned>& qubits,
   }
 }
 
-void add_mixture(const unsigned time,
+void add_channel(const unsigned time,
                  const std::vector<unsigned>& qubits,
                  const std::vector<std::tuple<float, std::vector<float>, bool>>&
                      prob_matrix_unitary_triples,
                  NoisyCircuit<Cirq::GateCirq<float>>* ncircuit) {
-  // Adds a Cirq mixture to the noisy circuit. Cirq mixtures are probabilistic
-  // combinations of matrix gates, which may or may not be unitary.
+  // Adds a channel to the noisy circuit.
   using Gate = Cirq::GateCirq<float>;
   Channel<Gate> channel;
   // prob_matrix_unitary_triples contains triples with these elements:
-  //   0. The probability of applying the matrix.
+  //   0. The lower-bound probability of applying the matrix.
   //   1. The matrix to be applied.
   //   2. Whether the matrix is unitary.
   for (const auto &triple : prob_matrix_unitary_triples) {
@@ -421,7 +420,6 @@ std::vector<std::complex<float>> qtrajectory_simulate(const py::dict &options) {
     param.num_threads = parseOptions<unsigned>(options, "t\0");
     param.max_fused_size = parseOptions<unsigned>(options, "f\0");
     param.verbosity = parseOptions<unsigned>(options, "v\0");
-    // TODO: check with Sergei (move from method argument?)
     seed = parseOptions<unsigned>(options, "s\0");
   } catch (const std::invalid_argument &exp) {
     IO::errorf(exp.what());
@@ -583,7 +581,6 @@ py::array_t<float> qtrajectory_simulate_fullstate(const py::dict &options,
     param.num_threads = parseOptions<unsigned>(options, "t\0");
     param.max_fused_size = parseOptions<unsigned>(options, "f\0");
     param.verbosity = parseOptions<unsigned>(options, "v\0");
-    // TODO: check with Sergei (move from method argument?)
     seed = parseOptions<unsigned>(options, "s\0");
   } catch (const std::invalid_argument &exp) {
     IO::errorf(exp.what());
@@ -644,7 +641,6 @@ py::array_t<float> qtrajectory_simulate_fullstate(
     param.num_threads = parseOptions<unsigned>(options, "t\0");
     param.max_fused_size = parseOptions<unsigned>(options, "f\0");
     param.verbosity = parseOptions<unsigned>(options, "v\0");
-    // TODO: check with Sergei (move from method argument?)
     seed = parseOptions<unsigned>(options, "s\0");
   } catch (const std::invalid_argument &exp) {
     IO::errorf(exp.what());
@@ -763,7 +759,6 @@ std::vector<unsigned> qtrajectory_sample(const py::dict &options) {
     param.num_threads = parseOptions<unsigned>(options, "t\0");
     param.max_fused_size = parseOptions<unsigned>(options, "f\0");
     param.verbosity = parseOptions<unsigned>(options, "v\0");
-    // TODO: check with Sergei (move from method argument?)
     seed = parseOptions<unsigned>(options, "s\0");
     param.collect_mea_stat = true;
   } catch (const std::invalid_argument &exp) {

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -375,6 +375,10 @@ std::vector<std::complex<float>> qsim_simulate(const py::dict &options) {
   return amplitudes;
 }
 
+std::vector<std::complex<float>> qtrajectory_simulate(const py::dict &options) {
+  return {};
+}
+
 // Simulate from a "pure" starting state.
 py::array_t<float> qsim_simulate_fullstate(const py::dict &options,
                                            uint64_t input_state) {
@@ -427,6 +431,16 @@ py::array_t<float> qsim_simulate_fullstate(const py::dict &options,
   auto capsule = py::capsule(
       fsv, [](void *data) { delete reinterpret_cast<float *>(data); });
   return py::array_t<float>(fsv_size, fsv, capsule);
+}
+
+py::array_t<float> qtrajectory_simulate_fullstate(const py::dict &options,
+                                                  uint64_t input_state) {
+  return {};
+}
+
+py::array_t<float> qtrajectory_simulate_fullstate(
+    const py::dict &options, const py::array_t<float> &input_vector) {
+  return {};
 }
 
 // Simulate from an initial state vector.
@@ -540,6 +554,10 @@ std::vector<unsigned> qsim_sample(const py::dict &options) {
                        result.bitstring.end());
   }
   return result_bits;
+}
+
+std::vector<unsigned> qtrajectory_sample(const py::dict &options) {
+  return {};
 }
 
 std::vector<std::complex<float>> qsimh_simulate(const py::dict &options) {

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -331,6 +331,8 @@ void control_last_gate(const std::vector<unsigned>& qubits,
   MakeControlledGate(qubits, values, circuit->gates.back());
 }
 
+// TODO: need methods for creating Kraus ops and channels
+
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options) {
   Circuit<Cirq::GateCirq<float>> circuit;
   std::vector<Bitstring> bitstrings;
@@ -376,6 +378,7 @@ std::vector<std::complex<float>> qsim_simulate(const py::dict &options) {
 }
 
 std::vector<std::complex<float>> qtrajectory_simulate(const py::dict &options) {
+  // TODO: implement
   return {};
 }
 
@@ -431,16 +434,6 @@ py::array_t<float> qsim_simulate_fullstate(const py::dict &options,
   auto capsule = py::capsule(
       fsv, [](void *data) { delete reinterpret_cast<float *>(data); });
   return py::array_t<float>(fsv_size, fsv, capsule);
-}
-
-py::array_t<float> qtrajectory_simulate_fullstate(const py::dict &options,
-                                                  uint64_t input_state) {
-  return {};
-}
-
-py::array_t<float> qtrajectory_simulate_fullstate(
-    const py::dict &options, const py::array_t<float> &input_vector) {
-  return {};
 }
 
 // Simulate from an initial state vector.
@@ -503,6 +496,18 @@ py::array_t<float> qsim_simulate_fullstate(
   return py::array_t<float>(fsv_size, fsv, capsule);
 }
 
+py::array_t<float> qtrajectory_simulate_fullstate(const py::dict &options,
+                                                  uint64_t input_state) {
+  // TODO: implement
+  return {};
+}
+
+py::array_t<float> qtrajectory_simulate_fullstate(
+    const py::dict &options, const py::array_t<float> &input_vector) {
+  // TODO: implement
+  return {};
+}
+
 std::vector<unsigned> qsim_sample(const py::dict &options) {
   Circuit<Cirq::GateCirq<float>> circuit;
   try {
@@ -557,6 +562,7 @@ std::vector<unsigned> qsim_sample(const py::dict &options) {
 }
 
 std::vector<unsigned> qtrajectory_sample(const py::dict &options) {
+  // TODO: implement
   return {};
 }
 

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -25,6 +25,7 @@ namespace py = pybind11;
 
 #include "../lib/circuit.h"
 #include "../lib/gates_cirq.h"
+#include "../lib/qtrajectory.h"
 
 void add_gate(const qsim::Cirq::GateKind gate_kind, const unsigned time,
               const std::vector<unsigned>& qubits,
@@ -52,6 +53,15 @@ py::array_t<float> qsim_simulate_fullstate(
 
 std::vector<unsigned> qsim_sample(const py::dict &options);
 
+std::vector<std::complex<float>> qtrajectory_simulate(const py::dict &options);
+
+py::array_t<float> qtrajectory_simulate_fullstate(
+      const py::dict &options, uint64_t input_state);
+py::array_t<float> qtrajectory_simulate_fullstate(
+      const py::dict &options, const py::array_t<float> &input_vector);
+
+std::vector<unsigned> qtrajectory_sample(const py::dict &options);
+
 std::vector<std::complex<float>> qsimh_simulate(const py::dict &options);
 
 PYBIND11_MODULE(qsim, m) {
@@ -68,16 +78,34 @@ PYBIND11_MODULE(qsim, m) {
             &qsim_simulate_fullstate),
         "Call the qsim simulator for full state vector simulation");
   m.def("qsim_sample", &qsim_sample, "Call the qsim sampler");
+
+  m.def("qtrajectory_simulate", &qtrajectory_simulate,
+        "Call the qtrajectory simulator");
+  m.def("qtrajectory_simulate_fullstate",
+        static_cast<py::array_t<float>(*)(const py::dict&, uint64_t)>(
+            &qtrajectory_simulate_fullstate),
+        "Call the qtrajectory simulator for full state vector simulation");
+  m.def("qtrajectory_simulate_fullstate",
+        static_cast<py::array_t<float>(*)(const py::dict&,
+                                          const py::array_t<float>&)>(
+            &qtrajectory_simulate_fullstate),
+        "Call the qtrajectory simulator for full state vector simulation");
+  m.def("qtrajectory_sample", &qtrajectory_sample,
+        "Call the qtrajectory sampler");
+
   m.def("qsimh_simulate", &qsimh_simulate, "Call the qsimh simulator");
 
   using GateCirq = qsim::Cirq::GateCirq<float>;
   using GateKind = qsim::Cirq::GateKind;
   using Circuit = qsim::Circuit<GateCirq>;
+  using NoisyCircuit = qsim::NoisyCircuit<GateCirq>;
 
   py::class_<Circuit>(m, "Circuit")
     .def(py::init<>())
     .def_readwrite("num_qubits", &Circuit::num_qubits)
     .def_readwrite("gates", &Circuit::gates);
+
+  py::class_<NoisyCircuit>(m, "NoisyCircuit").def(py::init<>());
 
   py::enum_<GateKind>(m, "GateKind")
     .value("kI1", GateKind::kI1)

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -70,6 +70,12 @@ void control_last_gate_channel(
     const std::vector<unsigned>& qubits, const std::vector<unsigned>& values,
     qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* ncircuit);
 
+void add_mixture(const unsigned time,
+                 const std::vector<unsigned>& qubits,
+                 const std::vector<std::tuple<float, std::vector<float>, bool>>&
+                     prob_matrix_unitary_triples,
+                 qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* ncircuit);
+
 // Methods for simulating noiseless circuits.
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options);
 
@@ -200,6 +206,9 @@ PYBIND11_MODULE(qsim, m) {
         "Adds a matrix-defined gate to the given noisy circuit.");
   m.def("control_last_gate_channel", &control_last_gate_channel,
         "Applies controls to the final channel of a noisy circuit.");
+
+  m.def("add_mixture", &add_mixture,
+        "Adds a mixture to the given noisy circuit.");
 }
 
 #endif

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -70,9 +70,6 @@ void control_last_gate_channel(
     const std::vector<unsigned>& qubits, const std::vector<unsigned>& values,
     qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* ncircuit);
 
-// TODO: remove when full tests are available.
-int count_gates(qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>> ncircuit);
-
 // Methods for simulating noiseless circuits.
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options);
 
@@ -138,10 +135,6 @@ PYBIND11_MODULE(qsim, m) {
     .def_readwrite("gates", &Circuit::gates);
 
   py::bind_vector<NoisyCircuit>(m, "NoisyCircuit");
-
-  // TODO: remove when full tests are available.
-  m.def("count_gates", &count_gates,
-        "Test method that returns the number of gates in a noisy circuit.");
 
   py::enum_<GateKind>(m, "GateKind")
     .value("kI1", GateKind::kI1)

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -70,7 +70,7 @@ void control_last_gate_channel(
     const std::vector<unsigned>& qubits, const std::vector<unsigned>& values,
     qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* ncircuit);
 
-void add_mixture(const unsigned time,
+void add_channel(const unsigned time,
                  const std::vector<unsigned>& qubits,
                  const std::vector<std::tuple<float, std::vector<float>, bool>>&
                      prob_matrix_unitary_triples,
@@ -207,8 +207,8 @@ PYBIND11_MODULE(qsim, m) {
   m.def("control_last_gate_channel", &control_last_gate_channel,
         "Applies controls to the final channel of a noisy circuit.");
 
-  m.def("add_mixture", &add_mixture,
-        "Adds a mixture to the given noisy circuit.");
+  m.def("add_channel", &add_channel,
+        "Adds a channel to the given noisy circuit.");
 }
 
 #endif

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -351,8 +351,10 @@ class QSimCircuit(cirq.Circuit):
         for mixture in ops_by_mix:
           mixdata = []
           for prob, mat in cirq.mixture(mixture):
-            square_mat = np.reshape(mat, (int(np.sqrt(len(mat))), -1))
+            square_mat = np.reshape(mat, (int(np.sqrt(mat.size)), -1))
             unitary = cirq.is_unitary(square_mat)
+            # Package matrix into a qsim-friendly format.
+            mat = np.reshape(mat, (-1,)).astype(np.complex64, copy=False)
             mixdata.append((prob, mat.view(np.float32), unitary))
           qubits = [qubit_to_index_dict[q] for q in mixture.qubits]
           qsim.add_mixture(time_offset, qubits, mixdata, qsim_ncircuit)

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -254,3 +254,14 @@ class QSimCircuit(cirq.Circuit):
       time_offset += moment_length
 
     return qsim_circuit
+
+
+  def translate_cirq_to_qtrajectory(
+      self,
+      qubit_order: cirq.ops.QubitOrderOrList = cirq.ops.QubitOrder.DEFAULT
+  ) -> qsim.NoisyCircuit:
+    """
+        Translates this noisy Cirq circuit to the qsim representation.
+        :qubit_order: Ordering of qubits
+        :return: a C++ qsim NoisyCircuit object
+        """

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -242,9 +242,10 @@ class QSimCircuit(cirq.Circuit):
         """
 
     qsim_circuit = qsim.Circuit()
-    qsim_circuit.num_qubits = len(self.all_qubits())
+    qubits = self.all_qubits()
+    qsim_circuit.num_qubits = len(qubits)
     ordered_qubits = cirq.ops.QubitOrder.as_qubit_order(qubit_order).order_for(
-        self.all_qubits())
+      qubits)
 
     # qsim numbers qubits in reverse order from cirq
     ordered_qubits = list(reversed(ordered_qubits))

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -173,38 +173,36 @@ def add_op_to_circuit(
 
   if (gate_kind == qsim.kTwoQubitDiagonalGate or
       gate_kind == qsim.kThreeQubitDiagonalGate):
-    op = (
-      qsim.add_diagonal_gate if isinstance(circuit, qsim.Circuit)
-      else qsim.add_diagonal_gate_channel
-    )
-    op(time, qsim_qubits, qsim_gate._diag_angles_radians, circuit)
+    if isinstance(circuit, qsim.Circuit):
+      qsim.add_diagonal_gate(
+        time, qsim_qubits, qsim_gate._diag_angles_radians, circuit)
+    else:
+      qsim.add_diagonal_gate_channel(
+        time, qsim_qubits, qsim_gate._diag_angles_radians, circuit)
   elif gate_kind == qsim.kMatrixGate:
-    op = (
-      qsim.add_matrix_gate if isinstance(circuit, qsim.Circuit)
-      else qsim.add_matrix_gate_channel
-    )
     m = [
       val for i in list(cirq.unitary(qsim_gate).flat)
       for val in [i.real, i.imag]
     ]
-    op(time, qsim_qubits, m, circuit)
+    if isinstance(circuit, qsim.Circuit):
+      qsim.add_matrix_gate(time, qsim_qubits, m, circuit)
+    else:
+      qsim.add_matrix_gate_channel(time, qsim_qubits, m, circuit)
   else:
     params = {
       p.strip('_'): val for p, val in vars(qsim_gate).items()
       if isinstance(val, float) or isinstance(val, int)
     }
-    op = (
-      qsim.add_gate if isinstance(circuit, qsim.Circuit)
-      else qsim.add_gate_channel
-    )
-    op(gate_kind, time, qsim_qubits, params, circuit)
+    if isinstance(circuit, qsim.Circuit):
+      qsim.add_gate(gate_kind, time, qsim_qubits, params, circuit)
+    else:
+      qsim.add_gate_channel(gate_kind, time, qsim_qubits, params, circuit)
 
   if is_controlled:
-    op = (
-      qsim.control_last_gate if isinstance(circuit, qsim.Circuit)
-      else qsim.control_last_gate_channel
-    )
-    op(control_qubits, control_values, circuit)
+    if isinstance(circuit, qsim.Circuit):
+      qsim.control_last_gate(control_qubits, control_values, circuit)
+    else:
+      qsim.control_last_gate_channel(control_qubits, control_values, circuit)
 
 
 class QSimCircuit(cirq.Circuit):

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -88,9 +88,10 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
     Raises:
         ValueError if internal keys 'c' or 'i' are included in 'qsim_options'.
     """
-    if any(k in qsim_options for k in ('c', 'i')):
+    if any(k in qsim_options for k in ('c', 'i', 'n')):
       raise ValueError(
-          'Keys "c" & "i" are reserved for internal use and cannot be used in QSimCircuit instantiation.'
+          'Keys {"c", "i", "n"} are reserved for internal use and cannot be '
+          'used in QSimCircuit instantiation.'
       )
     self._prng = value.parse_random_state(seed)
     self.qsim_options = {'t': 1, 'f': 2, 'v': 0}
@@ -208,6 +209,7 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
         )
       options['c'] = program.translate_cirq_to_qsim(ops.QubitOrder.DEFAULT)
       options['s'] = self.get_seed()
+      options['n'] = protocols.num_qubits(program)
       final_state = qsim.qsim_simulate_fullstate(options, 0)
       full_results = sim.sample_state_vector(
         final_state.view(np.complex64), range(len(ordered_qubits)),
@@ -223,6 +225,7 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
       options['c'] = translator_fn(ops.QubitOrder.DEFAULT)
       for i in range(repetitions):
         options['s'] = self.get_seed()
+        options['n'] = protocols.num_qubits(program)
         measurements = sampler_fn(options)
         for key, bound in bounds.items():
           for j in range(bound[1]-bound[0]):
@@ -282,6 +285,7 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
       translator_fn = getattr(solved_circuit, translator_fn_name)
       options['c'] = translator_fn(qubit_order)
       options['s'] = self.get_seed()
+      options['n'] = protocols.num_qubits(solved_circuit)
       amplitudes = simulator_fn(options)
       trials_results.append(amplitudes)
 
@@ -351,6 +355,7 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
       translator_fn = getattr(solved_circuit, translator_fn_name)
       options['c'] = translator_fn(qubit_order)
       options['s'] = self.get_seed()
+      options['n'] = protocols.num_qubits(solved_circuit)
       ordered_qubits = ops.QubitOrder.as_qubit_order(qubit_order).order_for(
         solved_circuit.all_qubits())
       # qsim numbers qubits in reverse order from cirq

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -55,7 +55,6 @@ class QSimSimulatorTrialResult(sim.StateVectorTrialResult):
 
 # This should probably live in Cirq...
 # TODO: update to support CircuitOperations.
-# TODO(now): parameterized gates have no unitary
 def _needs_trajectories(circuit: circuits.Circuit) -> bool:
   """Checks if the circuit requires trajectory simulation."""
   for op in circuit.all_operations():

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -191,7 +191,8 @@ def test_input_vector_validation():
       cirq_circuit, params, initial_state=initial_state)
 
 
-def test_cirq_qsim_run():
+@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+def test_cirq_qsim_run(mode: str):
   # Pick qubits.
   a, b, c, d = [
       cirq.GridQubit(0, 0),
@@ -211,6 +212,9 @@ def test_cirq_qsim_run():
       cirq.measure(c, key='mc'),
       cirq.measure(d, key='md'),
   )
+  if mode == 'noisy':
+    cirq_circuit.append(NoiseTrigger().on(a))
+
   qsimSim = qsimcirq.QSimSimulator()
   assert isinstance(qsimSim, cirq.SimulatesSamples)
 
@@ -219,7 +223,8 @@ def test_cirq_qsim_run():
     assert(value.shape == (5, 1))
 
 
-def test_qsim_run_vs_cirq_run():
+@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+def test_qsim_run_vs_cirq_run(mode: str):
   # Simple circuit, want to check mapping of qubit(s) to their measurements
   a, b, c, d = [
     cirq.GridQubit(0, 0),
@@ -234,6 +239,9 @@ def test_qsim_run_vs_cirq_run():
       cirq.measure(d, key='md'),
   )
 
+  if mode == 'noisy':
+    circuit.append(NoiseTrigger().on(a))
+
   # run in cirq
   simulator = cirq.Simulator()
   cirq_result = simulator.run(circuit, repetitions=20)
@@ -246,7 +254,8 @@ def test_qsim_run_vs_cirq_run():
   assert(qsim_result == cirq_result)
 
 
-def test_intermediate_measure():
+@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+def test_intermediate_measure(mode: str):
   # Demonstrate that intermediate measurement is possible.
   a, b = [
     cirq.GridQubit(0, 0),
@@ -260,6 +269,9 @@ def test_intermediate_measure():
     cirq.H(a), cirq.H(b),
   )
 
+  if mode == 'noisy':
+    circuit.append(NoiseTrigger().on(a))
+
   simulator = cirq.Simulator()
   cirq_result = simulator.run(circuit, repetitions=20)
 
@@ -269,10 +281,14 @@ def test_intermediate_measure():
   assert(qsim_result == cirq_result)
 
 
-def test_sampling_nondeterminism():
+@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+def test_sampling_nondeterminism(mode: str):
   # Ensure that reusing a QSimSimulator doesn't reuse the original seed.
   q = cirq.GridQubit(0, 0)
   circuit = cirq.Circuit(cirq.H(q), cirq.measure(q, key='m'))
+  if mode == 'noisy':
+    circuit.append(NoiseTrigger().on(q))
+
   qsim_simulator = qsimcirq.QSimSimulator()
   qsim_result = qsim_simulator.run(circuit, repetitions=100)
 

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -14,860 +14,858 @@
 
 import numpy as np
 import sympy
-import unittest
 import cirq
+import pytest
 import qsimcirq
 
 
-class MainTest(unittest.TestCase):
+# TODO: update to full circuit-translation tests
+# Parameterize all with a "noisy" trailing gate?
+# Plus explicit testing for noise-only behaviors:
+#   - channels
+#   - mixtures
+#   - gates-as-channels
+def test_noisy_circuit_placeholder():
+  from qsimcirq import qsim
+  nc = qsim.NoisyCircuit()
+  assert qsim.count_gates(nc) == 0
 
-  # TODO: update to full circuit-translation tests
-  def test_noisy_circuit_placeholder(self):
-    from qsimcirq import qsim
-    nc = qsim.NoisyCircuit()
-    assert qsim.count_gates(nc) == 0
+  a, b, c = cirq.LineQubit.range(3)
+  gate_to_add = cirq.X(a)
 
-    a, b, c = cirq.LineQubit.range(3)
-    gate_to_add = cirq.X(a)
+  gkind = qsim.kX
+  time = 0
+  qubits = [0]
+  params = {}
+  qsim.add_gate_channel(gkind, time, qubits, params, nc)
+  assert qsim.count_gates(nc) == 1
 
-    gkind = qsim.kX
-    time = 0
-    qubits = [0]
-    params = {}
-    qsim.add_gate_channel(gkind, time, qubits, params, nc)
-    assert qsim.count_gates(nc) == 1
+  time = 1
+  qubits = [0, 1]
+  angles = [0.25, 0.5, 0.75]
+  qsim.add_diagonal_gate_channel(time, qubits, angles, nc)
+  assert qsim.count_gates(nc) == 2
 
-    time = 1
-    qubits = [0, 1]
-    angles = [0.25, 0.5, 0.75]
-    qsim.add_diagonal_gate_channel(time, qubits, angles, nc)
-    assert qsim.count_gates(nc) == 2
+  time = 2
+  qubits = [2]
+  matrix = [0, 1, 1, 0]
+  qsim.add_matrix_gate_channel(time, qubits, matrix, nc)
+  assert qsim.count_gates(nc) == 3
 
-    time = 2
-    qubits = [2]
-    matrix = [0, 1, 1, 0]
-    qsim.add_matrix_gate_channel(time, qubits, matrix, nc)
-    assert qsim.count_gates(nc) == 3
-
-    control_qubits = [0]
-    control_values = [1]
-    qsim.control_last_gate_channel(control_qubits, control_values, nc)
-    assert qsim.count_gates(nc) == 3
-
-
-  def test_cirq_too_big_gate(self):
-    # Pick qubits.
-    a, b, c, d, e, f, g = [
-        cirq.GridQubit(0, 0),
-        cirq.GridQubit(0, 1),
-        cirq.GridQubit(0, 2),
-        cirq.GridQubit(1, 0),
-        cirq.GridQubit(1, 1),
-        cirq.GridQubit(1, 2),
-        cirq.GridQubit(2, 0),
-    ]
-
-    # Create a circuit with a gate larger than 6 qubits.
-    cirq_circuit = cirq.Circuit(cirq.IdentityGate(7).on(a, b, c, d, e, f, g))
-
-    qsimSim = qsimcirq.QSimSimulator()
-    with self.assertRaises(NotImplementedError):
-      qsimSim.compute_amplitudes(cirq_circuit, bitstrings=[0b0, 0b1])
+  control_qubits = [0]
+  control_values = [1]
+  qsim.control_last_gate_channel(control_qubits, control_values, nc)
+  assert qsim.count_gates(nc) == 3
 
 
-  def test_cirq_qsim_simulate(self):
-    # Pick qubits.
-    a, b, c, d = [
-        cirq.GridQubit(0, 0),
-        cirq.GridQubit(0, 1),
-        cirq.GridQubit(1, 1),
-        cirq.GridQubit(1, 0)
-    ]
-
-    # Create a circuit
-    cirq_circuit = cirq.Circuit(
-        cirq.X(a)**0.5,  # Square root of X.
-        cirq.Y(b)**0.5,  # Square root of Y.
-        cirq.Z(c),  # Z.
-        cirq.CZ(a, d)  # ControlZ.
-    )
-
-    qsimSim = qsimcirq.QSimSimulator()
-    result = qsimSim.compute_amplitudes(
-        cirq_circuit, bitstrings=[0b0100, 0b1011])
-    assert np.allclose(result, [0.5j, 0j])
-
-
-  def test_cirq_qsim_simulate_fullstate(self):
-    # Pick qubits.
-    a, b, c, d = [
-        cirq.GridQubit(0, 0),
-        cirq.GridQubit(0, 1),
-        cirq.GridQubit(1, 1),
-        cirq.GridQubit(1, 0)
-    ]
-
-    # Create a circuit.
-    cirq_circuit = cirq.Circuit(
-        cirq.Moment([
-            cirq.X(a)**0.5,  # Square root of X.
-            cirq.H(b),       # Hadamard.
-            cirq.X(c),       # X.
-            cirq.H(d),       # Hadamard.
-        ]),
-        cirq.Moment([
-            cirq.X(a)**0.5,  # Square root of X.
-            cirq.CX(b, c),   # ControlX.
-            cirq.S(d),       # S (square root of Z).
-        ]),
-        cirq.Moment([
-            cirq.I(a),
-            cirq.ISWAP(b, c),
-        ])
-    )
-
-    qsimSim = qsimcirq.QSimSimulator()
-    result = qsimSim.simulate(cirq_circuit, qubit_order=[a, b, c, d])
-    assert result.state_vector().shape == (16,)
-    cirqSim = cirq.Simulator()
-    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=[a, b, c, d])
-    # When using rotation gates such as S, qsim may add a global phase relative
-    # to other simulators. This is fine, as the result is equivalent.
-    assert cirq.linalg.allclose_up_to_global_phase(
-        result.state_vector(), cirq_result.state_vector())
-
-
-  def test_cirq_qsim_simulate_sweep(self):
-    # Pick qubits.
-    a, b = [
-        cirq.GridQubit(0, 0),
-        cirq.GridQubit(0, 1),
-    ]
-    x = sympy.Symbol('x')
-
-    # Create a circuit.
-    cirq_circuit = cirq.Circuit(
-        cirq.Moment([
-            cirq.X(a)**x,
-            cirq.H(b),       # Hadamard.
-        ]),
-        cirq.Moment([
-            cirq.CX(a, b),   # ControlX.
-        ]),
-    )
-
-    params = [{x: 0.25}, {x: 0.5}, {x: 0.75}]
-    qsimSim = qsimcirq.QSimSimulator()
-    qsim_result = qsimSim.simulate_sweep(cirq_circuit, params)
-    cirqSim = cirq.Simulator()
-    cirq_result = cirqSim.simulate_sweep(cirq_circuit, params)
-
-    for i in range(len(qsim_result)):
-      assert cirq.linalg.allclose_up_to_global_phase(
-        qsim_result[i].state_vector(), cirq_result[i].state_vector())
-
-    # initial_state supports bitstrings.
-    qsim_result = qsimSim.simulate_sweep(cirq_circuit, params,
-                                         initial_state=0b01)
-    cirq_result = cirqSim.simulate_sweep(cirq_circuit, params,
-                                         initial_state=0b01)
-    for i in range(len(qsim_result)):
-      assert cirq.linalg.allclose_up_to_global_phase(
-        qsim_result[i].state_vector(), cirq_result[i].state_vector())
-
-    # initial_state supports state vectors.
-    initial_state = np.asarray([0.5j, 0.5, -0.5j, -0.5], dtype=np.complex64)
-    qsim_result = qsimSim.simulate_sweep(
-      cirq_circuit, params, initial_state=initial_state)
-    cirq_result = cirqSim.simulate_sweep(
-      cirq_circuit, params, initial_state=initial_state)
-    for i in range(len(qsim_result)):
-      assert cirq.linalg.allclose_up_to_global_phase(
-        qsim_result[i].state_vector(), cirq_result[i].state_vector())
-
-  def test_input_vector_validation(self):
-    cirq_circuit = cirq.Circuit(
-      cirq.X(cirq.LineQubit(0)), cirq.X(cirq.LineQubit(1))
-    )
-    params = [{}]
-    qsimSim = qsimcirq.QSimSimulator()
-
-    with self.assertRaises(ValueError):
-      initial_state = np.asarray([0.25]*16, dtype=np.complex64)
-      qsim_result = qsimSim.simulate_sweep(
-        cirq_circuit, params, initial_state=initial_state)
-
-    with self.assertRaises(TypeError):
-      initial_state = np.asarray([0.5]*4)
-      qsim_result = qsimSim.simulate_sweep(
-        cirq_circuit, params, initial_state=initial_state)
-
-
-  def test_cirq_qsim_run(self):
-    # Pick qubits.
-    a, b, c, d = [
-        cirq.GridQubit(0, 0),
-        cirq.GridQubit(0, 1),
-        cirq.GridQubit(1, 1),
-        cirq.GridQubit(1, 0)
-    ]
-    # Create a circuit
-    cirq_circuit = cirq.Circuit(
-        cirq.X(a)**0.5,  # Square root of X.
-        cirq.Y(b)**0.5,  # Square root of Y.
-        cirq.Z(c),  # Z.
-        cirq.CZ(a, d),  # ControlZ.
-        # measure qubits
-        cirq.measure(a, key='ma'),
-        cirq.measure(b, key='mb'),
-        cirq.measure(c, key='mc'),
-        cirq.measure(d, key='md'),
-    )
-    qsimSim = qsimcirq.QSimSimulator()
-    assert isinstance(qsimSim, cirq.SimulatesSamples)
-
-    result = qsimSim.run(cirq_circuit, repetitions=5)
-    for key, value in result.measurements.items():
-      assert(value.shape == (5, 1))
-
-
-  def test_qsim_run_vs_cirq_run(self):
-    # Simple circuit, want to check mapping of qubit(s) to their measurements
-    a, b, c, d = [
+def test_cirq_too_big_gate():
+  # Pick qubits.
+  a, b, c, d, e, f, g = [
       cirq.GridQubit(0, 0),
       cirq.GridQubit(0, 1),
+      cirq.GridQubit(0, 2),
       cirq.GridQubit(1, 0),
       cirq.GridQubit(1, 1),
-    ]
-    circuit = cirq.Circuit(
-        cirq.X(b),
-        cirq.CX(b, d),
-        cirq.measure(a, b, c, key='mabc'),
-        cirq.measure(d, key='md'),
-    )
+      cirq.GridQubit(1, 2),
+      cirq.GridQubit(2, 0),
+  ]
 
-    # run in cirq
-    simulator = cirq.Simulator()
-    cirq_result = simulator.run(circuit, repetitions=20)
+  # Create a circuit with a gate larger than 6 qubits.
+  cirq_circuit = cirq.Circuit(cirq.IdentityGate(7).on(a, b, c, d, e, f, g))
 
-    # run in qsim
-    qsim_simulator = qsimcirq.QSimSimulator()
-    qsim_result = qsim_simulator.run(circuit, repetitions=20)
-
-    # are they the same?
-    assert(qsim_result == cirq_result)
+  qsimSim = qsimcirq.QSimSimulator()
+  with pytest.raises(NotImplementedError):
+    qsimSim.compute_amplitudes(cirq_circuit, bitstrings=[0b0, 0b1])
 
 
-  def test_intermediate_measure(self):
-    # Demonstrate that intermediate measurement is possible.
-    a, b = [
+def test_cirq_qsim_simulate():
+  # Pick qubits.
+  a, b, c, d = [
       cirq.GridQubit(0, 0),
       cirq.GridQubit(0, 1),
-    ]
-    circuit = cirq.Circuit(
-      cirq.X(a), cirq.CX(a, b), cirq.measure(a, b, key='m1'),
-      cirq.CZ(a, b), cirq.measure(a, b, key='m2'),
-      cirq.X(a), cirq.CX(a, b), cirq.measure(a, b, key='m3'),
-      # Trailing gates with no measurement do not affect results.
-      cirq.H(a), cirq.H(b),
-    )
+      cirq.GridQubit(1, 1),
+      cirq.GridQubit(1, 0)
+  ]
 
-    simulator = cirq.Simulator()
-    cirq_result = simulator.run(circuit, repetitions=20)
+  # Create a circuit
+  cirq_circuit = cirq.Circuit(
+      cirq.X(a)**0.5,  # Square root of X.
+      cirq.Y(b)**0.5,  # Square root of Y.
+      cirq.Z(c),  # Z.
+      cirq.CZ(a, d)  # ControlZ.
+  )
 
-    qsim_simulator = qsimcirq.QSimSimulator()
-    qsim_result = qsim_simulator.run(circuit, repetitions=20)
-
-    assert(qsim_result == cirq_result)
-
-
-  def test_sampling_nondeterminism(self):
-    # Ensure that reusing a QSimSimulator doesn't reuse the original seed.
-    q = cirq.GridQubit(0, 0)
-    circuit = cirq.Circuit(cirq.H(q), cirq.measure(q, key='m'))
-    qsim_simulator = qsimcirq.QSimSimulator()
-    qsim_result = qsim_simulator.run(circuit, repetitions=100)
-
-    result_counts = qsim_result.histogram(key='m')
-    assert(result_counts[0] > 1)
-    assert(result_counts[1] > 1)
+  qsimSim = qsimcirq.QSimSimulator()
+  result = qsimSim.compute_amplitudes(
+      cirq_circuit, bitstrings=[0b0100, 0b1011])
+  assert np.allclose(result, [0.5j, 0j])
 
 
-  def test_matrix1_gate(self):
-    q = cirq.LineQubit(0)
-    m = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
+def test_cirq_qsim_simulate_fullstate():
+  # Pick qubits.
+  a, b, c, d = [
+      cirq.GridQubit(0, 0),
+      cirq.GridQubit(0, 1),
+      cirq.GridQubit(1, 1),
+      cirq.GridQubit(1, 0)
+  ]
 
-    cirq_circuit = cirq.Circuit(cirq.MatrixGate(m).on(q))
-    qsimSim = qsimcirq.QSimSimulator()
-    result = qsimSim.simulate(cirq_circuit)
-    assert result.state_vector().shape == (2,)
-    cirqSim = cirq.Simulator()
-    cirq_result = cirqSim.simulate(cirq_circuit)
+  # Create a circuit.
+  cirq_circuit = cirq.Circuit(
+      cirq.Moment([
+          cirq.X(a)**0.5,  # Square root of X.
+          cirq.H(b),       # Hadamard.
+          cirq.X(c),       # X.
+          cirq.H(d),       # Hadamard.
+      ]),
+      cirq.Moment([
+          cirq.X(a)**0.5,  # Square root of X.
+          cirq.CX(b, c),   # ControlX.
+          cirq.S(d),       # S (square root of Z).
+      ]),
+      cirq.Moment([
+          cirq.I(a),
+          cirq.ISWAP(b, c),
+      ])
+  )
+
+  qsimSim = qsimcirq.QSimSimulator()
+  result = qsimSim.simulate(cirq_circuit, qubit_order=[a, b, c, d])
+  assert result.state_vector().shape == (16,)
+  cirqSim = cirq.Simulator()
+  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=[a, b, c, d])
+  # When using rotation gates such as S, qsim may add a global phase relative
+  # to other simulators. This is fine, as the result is equivalent.
+  assert cirq.linalg.allclose_up_to_global_phase(
+      result.state_vector(), cirq_result.state_vector())
+
+
+def test_cirq_qsim_simulate_sweep():
+  # Pick qubits.
+  a, b = [
+      cirq.GridQubit(0, 0),
+      cirq.GridQubit(0, 1),
+  ]
+  x = sympy.Symbol('x')
+
+  # Create a circuit.
+  cirq_circuit = cirq.Circuit(
+      cirq.Moment([
+          cirq.X(a)**x,
+          cirq.H(b),       # Hadamard.
+      ]),
+      cirq.Moment([
+          cirq.CX(a, b),   # ControlX.
+      ]),
+  )
+
+  params = [{x: 0.25}, {x: 0.5}, {x: 0.75}]
+  qsimSim = qsimcirq.QSimSimulator()
+  qsim_result = qsimSim.simulate_sweep(cirq_circuit, params)
+  cirqSim = cirq.Simulator()
+  cirq_result = cirqSim.simulate_sweep(cirq_circuit, params)
+
+  for i in range(len(qsim_result)):
     assert cirq.linalg.allclose_up_to_global_phase(
-        result.state_vector(), cirq_result.state_vector())
+      qsim_result[i].state_vector(), cirq_result[i].state_vector())
+
+  # initial_state supports bitstrings.
+  qsim_result = qsimSim.simulate_sweep(cirq_circuit, params,
+                                        initial_state=0b01)
+  cirq_result = cirqSim.simulate_sweep(cirq_circuit, params,
+                                        initial_state=0b01)
+  for i in range(len(qsim_result)):
+    assert cirq.linalg.allclose_up_to_global_phase(
+      qsim_result[i].state_vector(), cirq_result[i].state_vector())
+
+  # initial_state supports state vectors.
+  initial_state = np.asarray([0.5j, 0.5, -0.5j, -0.5], dtype=np.complex64)
+  qsim_result = qsimSim.simulate_sweep(
+    cirq_circuit, params, initial_state=initial_state)
+  cirq_result = cirqSim.simulate_sweep(
+    cirq_circuit, params, initial_state=initial_state)
+  for i in range(len(qsim_result)):
+    assert cirq.linalg.allclose_up_to_global_phase(
+      qsim_result[i].state_vector(), cirq_result[i].state_vector())
+
+def test_input_vector_validation():
+  cirq_circuit = cirq.Circuit(
+    cirq.X(cirq.LineQubit(0)), cirq.X(cirq.LineQubit(1))
+  )
+  params = [{}]
+  qsimSim = qsimcirq.QSimSimulator()
+
+  with pytest.raises(ValueError):
+    initial_state = np.asarray([0.25]*16, dtype=np.complex64)
+    qsim_result = qsimSim.simulate_sweep(
+      cirq_circuit, params, initial_state=initial_state)
+
+  with pytest.raises(TypeError):
+    initial_state = np.asarray([0.5]*4)
+    qsim_result = qsimSim.simulate_sweep(
+      cirq_circuit, params, initial_state=initial_state)
 
 
-  def test_matrix2_gate(self):
-    qubits = cirq.LineQubit.range(2)
-    m = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+def test_cirq_qsim_run():
+  # Pick qubits.
+  a, b, c, d = [
+      cirq.GridQubit(0, 0),
+      cirq.GridQubit(0, 1),
+      cirq.GridQubit(1, 1),
+      cirq.GridQubit(1, 0)
+  ]
+  # Create a circuit
+  cirq_circuit = cirq.Circuit(
+      cirq.X(a)**0.5,  # Square root of X.
+      cirq.Y(b)**0.5,  # Square root of Y.
+      cirq.Z(c),  # Z.
+      cirq.CZ(a, d),  # ControlZ.
+      # measure qubits
+      cirq.measure(a, key='ma'),
+      cirq.measure(b, key='mb'),
+      cirq.measure(c, key='mc'),
+      cirq.measure(d, key='md'),
+  )
+  qsimSim = qsimcirq.QSimSimulator()
+  assert isinstance(qsimSim, cirq.SimulatesSamples)
 
-    cirq_circuit = cirq.Circuit(cirq.MatrixGate(m).on(*qubits))
-    qsimSim = qsimcirq.QSimSimulator()
+  result = qsimSim.run(cirq_circuit, repetitions=5)
+  for key, value in result.measurements.items():
+    assert(value.shape == (5, 1))
+
+
+def test_qsim_run_vs_cirq_run():
+  # Simple circuit, want to check mapping of qubit(s) to their measurements
+  a, b, c, d = [
+    cirq.GridQubit(0, 0),
+    cirq.GridQubit(0, 1),
+    cirq.GridQubit(1, 0),
+    cirq.GridQubit(1, 1),
+  ]
+  circuit = cirq.Circuit(
+      cirq.X(b),
+      cirq.CX(b, d),
+      cirq.measure(a, b, c, key='mabc'),
+      cirq.measure(d, key='md'),
+  )
+
+  # run in cirq
+  simulator = cirq.Simulator()
+  cirq_result = simulator.run(circuit, repetitions=20)
+
+  # run in qsim
+  qsim_simulator = qsimcirq.QSimSimulator()
+  qsim_result = qsim_simulator.run(circuit, repetitions=20)
+
+  # are they the same?
+  assert(qsim_result == cirq_result)
+
+
+def test_intermediate_measure():
+  # Demonstrate that intermediate measurement is possible.
+  a, b = [
+    cirq.GridQubit(0, 0),
+    cirq.GridQubit(0, 1),
+  ]
+  circuit = cirq.Circuit(
+    cirq.X(a), cirq.CX(a, b), cirq.measure(a, b, key='m1'),
+    cirq.CZ(a, b), cirq.measure(a, b, key='m2'),
+    cirq.X(a), cirq.CX(a, b), cirq.measure(a, b, key='m3'),
+    # Trailing gates with no measurement do not affect results.
+    cirq.H(a), cirq.H(b),
+  )
+
+  simulator = cirq.Simulator()
+  cirq_result = simulator.run(circuit, repetitions=20)
+
+  qsim_simulator = qsimcirq.QSimSimulator()
+  qsim_result = qsim_simulator.run(circuit, repetitions=20)
+
+  assert(qsim_result == cirq_result)
+
+
+def test_sampling_nondeterminism():
+  # Ensure that reusing a QSimSimulator doesn't reuse the original seed.
+  q = cirq.GridQubit(0, 0)
+  circuit = cirq.Circuit(cirq.H(q), cirq.measure(q, key='m'))
+  qsim_simulator = qsimcirq.QSimSimulator()
+  qsim_result = qsim_simulator.run(circuit, repetitions=100)
+
+  result_counts = qsim_result.histogram(key='m')
+  assert(result_counts[0] > 1)
+  assert(result_counts[1] > 1)
+
+
+def test_matrix1_gate():
+  q = cirq.LineQubit(0)
+  m = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
+
+  cirq_circuit = cirq.Circuit(cirq.MatrixGate(m).on(q))
+  qsimSim = qsimcirq.QSimSimulator()
+  result = qsimSim.simulate(cirq_circuit)
+  assert result.state_vector().shape == (2,)
+  cirqSim = cirq.Simulator()
+  cirq_result = cirqSim.simulate(cirq_circuit)
+  assert cirq.linalg.allclose_up_to_global_phase(
+      result.state_vector(), cirq_result.state_vector())
+
+
+def test_matrix2_gate():
+  qubits = cirq.LineQubit.range(2)
+  m = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+
+  cirq_circuit = cirq.Circuit(cirq.MatrixGate(m).on(*qubits))
+  qsimSim = qsimcirq.QSimSimulator()
+  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert result.state_vector().shape == (4,)
+  cirqSim = cirq.Simulator()
+  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert cirq.linalg.allclose_up_to_global_phase(
+      result.state_vector(), cirq_result.state_vector())
+
+
+def test_big_matrix_gates():
+  qubits = cirq.LineQubit.range(3)
+  # Toffoli gate as a matrix.
+  m = np.array([
+    [1, 0, 0, 0, 0, 0, 0, 0],
+    [0, 1, 0, 0, 0, 0, 0, 0],
+    [0, 0, 1, 0, 0, 0, 0, 0],
+    [0, 0, 0, 1, 0, 0, 0, 0],
+    [0, 0, 0, 0, 1, 0, 0, 0],
+    [0, 0, 0, 0, 0, 1, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 1],
+    [0, 0, 0, 0, 0, 0, 1, 0],
+  ])
+
+  cirq_circuit = cirq.Circuit(
+    cirq.H(qubits[0]), cirq.H(qubits[1]),
+    cirq.MatrixGate(m).on(*qubits),
+  )
+  qsimSim = qsimcirq.QSimSimulator()
+  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert result.state_vector().shape == (8,)
+  cirqSim = cirq.Simulator()
+  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert cirq.linalg.allclose_up_to_global_phase(
+      result.state_vector(), cirq_result.state_vector())
+
+
+def test_decompose_to_matrix_gates():
+
+  class UnknownThreeQubitGate(cirq.ops.Gate):
+    """This gate is not recognized by qsim, and cannot be decomposed.
+    
+    qsim should attempt to convert it to a MatrixGate to resolve the issue.
+    """
+    def __init__(self):
+      pass
+
+    def _num_qubits_(self):
+      return 3
+
+    def _qid_shape_(self):
+      return (2, 2, 2)
+
+    def _unitary_(self):
+      # Toffoli gate as a matrix.
+      return np.array([
+        [1, 0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0, 0, 0],
+        [0, 0, 1, 0, 0, 0, 0, 0],
+        [0, 0, 0, 1, 0, 0, 0, 0],
+        [0, 0, 0, 0, 1, 0, 0, 0],
+        [0, 0, 0, 0, 0, 1, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 1],
+        [0, 0, 0, 0, 0, 0, 1, 0],
+      ])
+
+  qubits = cirq.LineQubit.range(3)
+  cirq_circuit = cirq.Circuit(
+    cirq.H(qubits[0]), cirq.H(qubits[1]),
+    UnknownThreeQubitGate().on(*qubits),
+  )
+  qsimSim = qsimcirq.QSimSimulator()
+  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert result.state_vector().shape == (8,)
+  cirqSim = cirq.Simulator()
+  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert cirq.linalg.allclose_up_to_global_phase(
+      result.state_vector(), cirq_result.state_vector())
+
+
+def test_basic_controlled_gate():
+  qubits = cirq.LineQubit.range(3)
+
+  cirq_circuit = cirq.Circuit(
+    cirq.H(qubits[1]), cirq.Y(qubits[2]),
+    cirq.X(qubits[0]).controlled_by(qubits[1]),
+    cirq.CX(*qubits[1:]).controlled_by(qubits[0]),
+    cirq.H(qubits[1]).controlled_by(qubits[0], qubits[2]),
+  )
+  qsimSim = qsimcirq.QSimSimulator()
+  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert result.state_vector().shape == (8,)
+  cirqSim = cirq.Simulator()
+  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert cirq.linalg.allclose_up_to_global_phase(
+      result.state_vector(), cirq_result.state_vector())
+
+
+def test_controlled_matrix_gates():
+  qubits = cirq.LineQubit.range(4)
+  m1 = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
+  m2 = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+
+  cirq_circuit = cirq.Circuit(
+    cirq.MatrixGate(m1).on(qubits[0]).controlled_by(qubits[3]),
+    cirq.MatrixGate(m2).on(*qubits[1:3]).controlled_by(qubits[0]),
+    cirq.MatrixGate(m1).on(qubits[2]).controlled_by(qubits[0], qubits[1],
+                                                    qubits[3]),
+    cirq.MatrixGate(m2).on(qubits[0], qubits[3]).controlled_by(*qubits[1:3]),
+  )
+  qsimSim = qsimcirq.QSimSimulator()
+  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert result.state_vector().shape == (16,)
+  cirqSim = cirq.Simulator()
+  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert cirq.linalg.allclose_up_to_global_phase(
+      result.state_vector(), cirq_result.state_vector())
+
+
+def test_control_values():
+  qubits = cirq.LineQubit.range(3)
+
+  cirq_circuit = cirq.Circuit(
+    # Controlled by |01) state on qubits 1 and 2
+    cirq.X(qubits[0]).controlled_by(*qubits[1:], control_values=[0, 1]),
+    # Controlled by either |0) or |1) on qubit 0 (i.e., uncontrolled)
+    cirq.X(qubits[1]).controlled_by(qubits[0], control_values=[(0, 1)]),
+    # Controlled by |10) state on qubits 0 and 1
+    cirq.X(qubits[2]).controlled_by(qubits[1], qubits[0],
+                                    control_values=[0, 1]),
+  )
+  qsimSim = qsimcirq.QSimSimulator()
+  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert result.state_vector().shape == (8,)
+  cirqSim = cirq.Simulator()
+  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert cirq.linalg.allclose_up_to_global_phase(
+      result.state_vector(), cirq_result.state_vector())
+
+  qubits = cirq.LineQid.for_qid_shape([2, 3, 2])
+  cirq_circuit = cirq.Circuit(
+    # Controlled by |12) state on qubits 0 and 1
+    # Since qsim does not support qudits (yet), this gate is omitted.
+    cirq.X(qubits[2]).controlled_by(*qubits[:2], control_values=[1, 2]),
+  )
+  qsimSim = qsimcirq.QSimSimulator()
+  with pytest.warns(RuntimeWarning, match='Gate has no valid control value'):
     result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert result.state_vector().shape == (4,)
-    cirqSim = cirq.Simulator()
-    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert cirq.linalg.allclose_up_to_global_phase(
-        result.state_vector(), cirq_result.state_vector())
+  assert result.state_vector()[0] == 1
 
 
-  def test_big_matrix_gates(self):
-    qubits = cirq.LineQubit.range(3)
-    # Toffoli gate as a matrix.
-    m = np.array([
-      [1, 0, 0, 0, 0, 0, 0, 0],
-      [0, 1, 0, 0, 0, 0, 0, 0],
-      [0, 0, 1, 0, 0, 0, 0, 0],
-      [0, 0, 0, 1, 0, 0, 0, 0],
-      [0, 0, 0, 0, 1, 0, 0, 0],
-      [0, 0, 0, 0, 0, 1, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 1],
-      [0, 0, 0, 0, 0, 0, 1, 0],
-    ])
+def test_decomposable_gate():
+  qubits = cirq.LineQubit.range(4)
 
-    cirq_circuit = cirq.Circuit(
-      cirq.H(qubits[0]), cirq.H(qubits[1]),
-      cirq.MatrixGate(m).on(*qubits),
-    )
-    qsimSim = qsimcirq.QSimSimulator()
-    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert result.state_vector().shape == (8,)
-    cirqSim = cirq.Simulator()
-    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert cirq.linalg.allclose_up_to_global_phase(
-        result.state_vector(), cirq_result.state_vector())
-
-
-  def test_decompose_to_matrix_gates(self):
-
-    class UnknownThreeQubitGate(cirq.ops.Gate):
-      """This gate is not recognized by qsim, and cannot be decomposed.
-      
-      qsim should attempt to convert it to a MatrixGate to resolve the issue.
-      """
-      def __init__(self):
-        pass
-
-      def _num_qubits_(self):
-        return 3
-
-      def _qid_shape_(self):
-        return (2, 2, 2)
-
-      def _unitary_(self):
-        # Toffoli gate as a matrix.
-        return np.array([
-          [1, 0, 0, 0, 0, 0, 0, 0],
-          [0, 1, 0, 0, 0, 0, 0, 0],
-          [0, 0, 1, 0, 0, 0, 0, 0],
-          [0, 0, 0, 1, 0, 0, 0, 0],
-          [0, 0, 0, 0, 1, 0, 0, 0],
-          [0, 0, 0, 0, 0, 1, 0, 0],
-          [0, 0, 0, 0, 0, 0, 0, 1],
-          [0, 0, 0, 0, 0, 0, 1, 0],
-        ])
-
-    qubits = cirq.LineQubit.range(3)
-    cirq_circuit = cirq.Circuit(
-      cirq.H(qubits[0]), cirq.H(qubits[1]),
-      UnknownThreeQubitGate().on(*qubits),
-    )
-    qsimSim = qsimcirq.QSimSimulator()
-    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert result.state_vector().shape == (8,)
-    cirqSim = cirq.Simulator()
-    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert cirq.linalg.allclose_up_to_global_phase(
-        result.state_vector(), cirq_result.state_vector())
-
-
-  def test_basic_controlled_gate(self):
-    qubits = cirq.LineQubit.range(3)
-
-    cirq_circuit = cirq.Circuit(
-      cirq.H(qubits[1]), cirq.Y(qubits[2]),
-      cirq.X(qubits[0]).controlled_by(qubits[1]),
-      cirq.CX(*qubits[1:]).controlled_by(qubits[0]),
-      cirq.H(qubits[1]).controlled_by(qubits[0], qubits[2]),
-    )
-    qsimSim = qsimcirq.QSimSimulator()
-    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert result.state_vector().shape == (8,)
-    cirqSim = cirq.Simulator()
-    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert cirq.linalg.allclose_up_to_global_phase(
-        result.state_vector(), cirq_result.state_vector())
-
-
-  def test_controlled_matrix_gates(self):
-    qubits = cirq.LineQubit.range(4)
-    m1 = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
-    m2 = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
-
-    cirq_circuit = cirq.Circuit(
-      cirq.MatrixGate(m1).on(qubits[0]).controlled_by(qubits[3]),
-      cirq.MatrixGate(m2).on(*qubits[1:3]).controlled_by(qubits[0]),
-      cirq.MatrixGate(m1).on(qubits[2]).controlled_by(qubits[0], qubits[1],
-                                                      qubits[3]),
-      cirq.MatrixGate(m2).on(qubits[0], qubits[3]).controlled_by(*qubits[1:3]),
-    )
-    qsimSim = qsimcirq.QSimSimulator()
-    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert result.state_vector().shape == (16,)
-    cirqSim = cirq.Simulator()
-    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert cirq.linalg.allclose_up_to_global_phase(
-        result.state_vector(), cirq_result.state_vector())
-
-
-  def test_control_values(self):
-    qubits = cirq.LineQubit.range(3)
-
-    cirq_circuit = cirq.Circuit(
-      # Controlled by |01) state on qubits 1 and 2
-      cirq.X(qubits[0]).controlled_by(*qubits[1:], control_values=[0, 1]),
-      # Controlled by either |0) or |1) on qubit 0 (i.e., uncontrolled)
-      cirq.X(qubits[1]).controlled_by(qubits[0], control_values=[(0, 1)]),
-      # Controlled by |10) state on qubits 0 and 1
-      cirq.X(qubits[2]).controlled_by(qubits[1], qubits[0],
-                                      control_values=[0, 1]),
-    )
-    qsimSim = qsimcirq.QSimSimulator()
-    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert result.state_vector().shape == (8,)
-    cirqSim = cirq.Simulator()
-    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert cirq.linalg.allclose_up_to_global_phase(
-        result.state_vector(), cirq_result.state_vector())
-
-    qubits = cirq.LineQid.for_qid_shape([2, 3, 2])
-    cirq_circuit = cirq.Circuit(
-      # Controlled by |12) state on qubits 0 and 1
-      # Since qsim does not support qudits (yet), this gate is omitted.
-      cirq.X(qubits[2]).controlled_by(*qubits[:2], control_values=[1, 2]),
-    )
-    qsimSim = qsimcirq.QSimSimulator()
-    with self.assertWarnsRegex(RuntimeWarning,
-                               'Gate has no valid control value'):
-      result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert result.state_vector()[0] == 1
-
-
-  def test_decomposable_gate(self):
-    qubits = cirq.LineQubit.range(4)
-
-    # The Toffoli gate (CCX) decomposes into multiple qsim-supported gates.
-    cirq_circuit = cirq.Circuit(
-        cirq.H(qubits[0]),
-        cirq.H(qubits[1]),
-        cirq.Moment(
-          cirq.CCX(*qubits[:3]),
-          cirq.H(qubits[3]),
-        ),
-        cirq.H(qubits[2]),
+  # The Toffoli gate (CCX) decomposes into multiple qsim-supported gates.
+  cirq_circuit = cirq.Circuit(
+      cirq.H(qubits[0]),
+      cirq.H(qubits[1]),
+      cirq.Moment(
+        cirq.CCX(*qubits[:3]),
         cirq.H(qubits[3]),
-    )
+      ),
+      cirq.H(qubits[2]),
+      cirq.H(qubits[3]),
+  )
 
-    qsimSim = qsimcirq.QSimSimulator()
-    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert result.state_vector().shape == (16,)
-    cirqSim = cirq.Simulator()
-    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-    # Decomposition may result in gates which add a global phase.
-    assert cirq.linalg.allclose_up_to_global_phase(
-        result.state_vector(), cirq_result.state_vector())
-
-
-  def test_complicated_decomposition(self):
-    qubits = cirq.LineQubit.range(4)
-
-    # The QFT gate decomposes cleanly into the qsim gateset.
-    cirq_circuit = cirq.Circuit(
-        cirq.QuantumFourierTransformGate(4).on(*qubits))
-
-    qsimSim = qsimcirq.QSimSimulator()
-    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert result.state_vector().shape == (16,)
-    cirqSim = cirq.Simulator()
-    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-    # Decomposition may result in gates which add a global phase.
-    assert cirq.linalg.allclose_up_to_global_phase(
-        result.state_vector(), cirq_result.state_vector())
+  qsimSim = qsimcirq.QSimSimulator()
+  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert result.state_vector().shape == (16,)
+  cirqSim = cirq.Simulator()
+  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+  # Decomposition may result in gates which add a global phase.
+  assert cirq.linalg.allclose_up_to_global_phase(
+      result.state_vector(), cirq_result.state_vector())
 
 
-  def test_multi_qubit_fusion(self):
-    q0, q1, q2, q3 = cirq.LineQubit.range(4)
-    qubits = [q0, q1, q2, q3]
-    cirq_circuit = cirq.Circuit(
-      cirq.CX(q0, q1), cirq.X(q2)**0.5, cirq.Y(q3)**0.5,
-      cirq.CX(q0, q2), cirq.T(q1), cirq.T(q3),
-      cirq.CX(q1, q2), cirq.X(q3)**0.5, cirq.Y(q0)**0.5,
-      cirq.CX(q1, q3), cirq.T(q0), cirq.T(q2),
-      cirq.CX(q2, q3), cirq.X(q0)**0.5, cirq.Y(q1)**0.5,
-    )
+def test_complicated_decomposition():
+  qubits = cirq.LineQubit.range(4)
 
-    qsimSim = qsimcirq.QSimSimulator(qsim_options={'f': 2})
-    result_2q_fusion = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+  # The QFT gate decomposes cleanly into the qsim gateset.
+  cirq_circuit = cirq.Circuit(
+      cirq.QuantumFourierTransformGate(4).on(*qubits))
 
-    qsimSim = qsimcirq.QSimSimulator(qsim_options={'f': 4})
-    result_4q_fusion = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-    assert cirq.linalg.allclose_up_to_global_phase(
-        result_2q_fusion.state_vector(), result_4q_fusion.state_vector())
+  qsimSim = qsimcirq.QSimSimulator()
+  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert result.state_vector().shape == (16,)
+  cirqSim = cirq.Simulator()
+  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+  # Decomposition may result in gates which add a global phase.
+  assert cirq.linalg.allclose_up_to_global_phase(
+      result.state_vector(), cirq_result.state_vector())
 
 
-  def test_cirq_qsim_simulate_random_unitary(self):
+def test_multi_qubit_fusion():
+  q0, q1, q2, q3 = cirq.LineQubit.range(4)
+  qubits = [q0, q1, q2, q3]
+  cirq_circuit = cirq.Circuit(
+    cirq.CX(q0, q1), cirq.X(q2)**0.5, cirq.Y(q3)**0.5,
+    cirq.CX(q0, q2), cirq.T(q1), cirq.T(q3),
+    cirq.CX(q1, q2), cirq.X(q3)**0.5, cirq.Y(q0)**0.5,
+    cirq.CX(q1, q3), cirq.T(q0), cirq.T(q2),
+    cirq.CX(q2, q3), cirq.X(q0)**0.5, cirq.Y(q1)**0.5,
+  )
 
-    q0, q1 = cirq.LineQubit.range(2)
-    qsimSim = qsimcirq.QSimSimulator(qsim_options={'t': 16, 'v': 0})
-    for iter in range(10):
-        random_circuit = cirq.testing.random_circuit(qubits=[q0, q1],
-                                                     n_moments=8,
-                                                     op_density=0.99,
-                                                     random_state=iter)
+  qsimSim = qsimcirq.QSimSimulator(qsim_options={'f': 2})
+  result_2q_fusion = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
 
-        cirq.ConvertToCzAndSingleGates().optimize_circuit(random_circuit) # cannot work with params
-        cirq.ExpandComposite().optimize_circuit(random_circuit)
-
-        result = qsimSim.simulate(random_circuit, qubit_order=[q0, q1])
-        assert result.state_vector().shape == (4,)
-
-        cirqSim = cirq.Simulator()
-        cirq_result = cirqSim.simulate(random_circuit, qubit_order=[q0, q1])
-        # When using rotation gates such as S, qsim may add a global phase relative
-        # to other simulators. This is fine, as the result is equivalent.
-        assert cirq.linalg.allclose_up_to_global_phase(
-            result.state_vector(),
-            cirq_result.state_vector(),
-            atol = 1.e-6
-        )
+  qsimSim = qsimcirq.QSimSimulator(qsim_options={'f': 4})
+  result_4q_fusion = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+  assert cirq.linalg.allclose_up_to_global_phase(
+      result_2q_fusion.state_vector(), result_4q_fusion.state_vector())
 
 
-  def test_cirq_qsimh_simulate(self):
-    # Pick qubits.
-    a, b = [cirq.GridQubit(0, 0), cirq.GridQubit(0, 1)]
+def test_cirq_qsim_simulate_random_unitary():
 
-    # Create a circuit
-    cirq_circuit = cirq.Circuit(cirq.CNOT(a, b), cirq.CNOT(b, a), cirq.X(a))
+  q0, q1 = cirq.LineQubit.range(2)
+  qsimSim = qsimcirq.QSimSimulator(qsim_options={'t': 16, 'v': 0})
+  for iter in range(10):
+      random_circuit = cirq.testing.random_circuit(qubits=[q0, q1],
+                                                    n_moments=8,
+                                                    op_density=0.99,
+                                                    random_state=iter)
 
-    qsimh_options = {'k': [0], 'w': 0, 'p': 1, 'r': 1}
-    qsimhSim = qsimcirq.QSimhSimulator(qsimh_options)
-    result = qsimhSim.compute_amplitudes(
-        cirq_circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])
-    assert np.allclose(result, [0j, 0j, (1 + 0j), 0j])
+      cirq.ConvertToCzAndSingleGates().optimize_circuit(random_circuit) # cannot work with params
+      cirq.ExpandComposite().optimize_circuit(random_circuit)
 
+      result = qsimSim.simulate(random_circuit, qubit_order=[q0, q1])
+      assert result.state_vector().shape == (4,)
 
-  def test_cirq_qsim_params(self):
-    qubit = cirq.GridQubit(0,0)
-
-    circuit = cirq.Circuit(cirq.X(qubit)**sympy.Symbol("beta"))
-    params = cirq.ParamResolver({'beta': 0.5})
-
-    simulator = cirq.Simulator()
-    cirq_result = simulator.simulate(circuit, param_resolver = params)
-
-    qsim_simulator = qsimcirq.QSimSimulator()
-    qsim_result = qsim_simulator.simulate(circuit, param_resolver = params)
-
-    assert cirq.linalg.allclose_up_to_global_phase(
-        qsim_result.state_vector(), cirq_result.state_vector())
+      cirqSim = cirq.Simulator()
+      cirq_result = cirqSim.simulate(random_circuit, qubit_order=[q0, q1])
+      # When using rotation gates such as S, qsim may add a global phase relative
+      # to other simulators. This is fine, as the result is equivalent.
+      assert cirq.linalg.allclose_up_to_global_phase(
+          result.state_vector(),
+          cirq_result.state_vector(),
+          atol = 1.e-6
+      )
 
 
-  def test_cirq_qsim_all_supported_gates(self):
-    q0 = cirq.GridQubit(1, 1)
-    q1 = cirq.GridQubit(1, 0)
-    q2 = cirq.GridQubit(0, 1)
-    q3 = cirq.GridQubit(0, 0)
+def test_cirq_qsimh_simulate():
+  # Pick qubits.
+  a, b = [cirq.GridQubit(0, 0), cirq.GridQubit(0, 1)]
 
-    circuit = cirq.Circuit(
-      cirq.Moment([
-        cirq.H(q0),
-        cirq.H(q1),
-        cirq.H(q2),
-        cirq.H(q3),
-      ]),
-      cirq.Moment([
-        cirq.T(q0),
-        cirq.T(q1),
-        cirq.T(q2),
-        cirq.T(q3),
-      ]),
-      cirq.Moment([
-        cirq.CZPowGate(exponent=0.7, global_shift=0.2)(q0, q1),
-        cirq.CXPowGate(exponent=1.2, global_shift=0.4)(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.XPowGate(exponent=0.3, global_shift=1.1)(q0),
-        cirq.YPowGate(exponent=0.4, global_shift=1)(q1),
-        cirq.ZPowGate(exponent=0.5, global_shift=0.9)(q2),
-        cirq.HPowGate(exponent=0.6, global_shift=0.8)(q3),
-      ]),
-      cirq.Moment([
-        cirq.CX(q0, q2),
-        cirq.CZ(q1, q3),
-      ]),
-      cirq.Moment([
-        cirq.X(q0),
-        cirq.Y(q1),
-        cirq.Z(q2),
-        cirq.S(q3),
-      ]),
-      cirq.Moment([
-        cirq.XXPowGate(exponent=0.4, global_shift=0.7)(q0, q1),
-        cirq.YYPowGate(exponent=0.8, global_shift=0.5)(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.I(q0),
-        cirq.I(q1),
-        cirq.IdentityGate(2)(q2, q3)
-      ]),
-      cirq.Moment([
-        cirq.rx(0.7)(q0),
-        cirq.ry(0.2)(q1),
-        cirq.rz(0.4)(q2),
-        cirq.PhasedXPowGate(
-            phase_exponent=0.8, exponent=0.6, global_shift=0.3)(q3),
-      ]),
-      cirq.Moment([
-        cirq.ZZPowGate(exponent=0.3, global_shift=1.3)(q0, q2),
-        cirq.ISwapPowGate(exponent=0.6, global_shift=1.2)(q1, q3),
-      ]),
-      cirq.Moment([
-        cirq.XPowGate(exponent=0.1, global_shift=0.9)(q0),
-        cirq.YPowGate(exponent=0.2, global_shift=1)(q1),
-        cirq.ZPowGate(exponent=0.3, global_shift=1.1)(q2),
-        cirq.HPowGate(exponent=0.4, global_shift=1.2)(q3),
-      ]),
-      cirq.Moment([
-        cirq.SwapPowGate(exponent=0.2, global_shift=0.9)(q0, q1),
-        cirq.PhasedISwapPowGate(phase_exponent = 0.8, exponent=0.6)(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.PhasedXZGate(
-            x_exponent=0.2, z_exponent=0.3, axis_phase_exponent=1.4)(q0),
-        cirq.T(q1),
-        cirq.H(q2),
-        cirq.S(q3),
-      ]),
-      cirq.Moment([
-        cirq.SWAP(q0, q2),
-        cirq.XX(q1, q3),
-      ]),
-      cirq.Moment([
-        cirq.rx(0.8)(q0),
-        cirq.ry(0.9)(q1),
-        cirq.rz(1.2)(q2),
-        cirq.T(q3),
-      ]),
-      cirq.Moment([
-        cirq.YY(q0, q1),
-        cirq.ISWAP(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.T(q0),
-        cirq.Z(q1),
-        cirq.Y(q2),
-        cirq.X(q3),
-      ]),
-      cirq.Moment([
-        cirq.FSimGate(0.3, 1.7)(q0, q2),
-        cirq.ZZ(q1, q3),
-      ]),
-      cirq.Moment([
-        cirq.ry(1.3)(q0),
-        cirq.rz(0.4)(q1),
-        cirq.rx(0.7)(q2),
-        cirq.S(q3),
-      ]),
-      cirq.Moment([
-        cirq.IdentityGate(4).on(q0, q1, q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.CCZPowGate(exponent=0.7, global_shift=0.3)(q2, q0, q1),
-      ]),
-      cirq.Moment([
-        cirq.CCXPowGate(exponent=0.4, global_shift=0.6)(
-          q3, q1, q0).controlled_by(q2, control_values=[0]),
-      ]),
-      cirq.Moment([
-        cirq.rx(0.3)(q0),
-        cirq.ry(0.5)(q1),
-        cirq.rz(0.7)(q2),
-        cirq.rx(0.9)(q3),
-      ]),
-      cirq.Moment([
-        cirq.TwoQubitDiagonalGate([0.1, 0.2, 0.3, 0.4])(q0, q1),
-      ]),
-      cirq.Moment([
-        cirq.ThreeQubitDiagonalGate([0.5, 0.6, 0.7, 0.8,
-                                     0.9, 1, 1.2, 1.3])(q1, q2, q3),
-      ]),
-      cirq.Moment([
-          cirq.CSwapGate()(q0, q3, q1),
-      ]),
-      cirq.Moment([
-        cirq.rz(0.6)(q0),
-        cirq.rx(0.7)(q1),
-        cirq.ry(0.8)(q2),
-        cirq.rz(0.9)(q3),
-      ]),
-      cirq.Moment([
-        cirq.TOFFOLI(q3, q2, q0),
-      ]),
-      cirq.Moment([
-        cirq.FREDKIN(q1, q3, q2),
-      ]),
-      cirq.Moment([
-        cirq.MatrixGate(np.array([[0, -0.5 - 0.5j, -0.5 - 0.5j, 0],
-                                  [0.5 - 0.5j, 0, 0, -0.5 + 0.5j],
-                                  [0.5 - 0.5j, 0, 0, 0.5 - 0.5j],
-                                  [0, -0.5 - 0.5j, 0.5 + 0.5j, 0]]))(q0, q1),
-        cirq.MatrixGate(np.array([[0.5 - 0.5j, 0, 0, -0.5 + 0.5j],
-                                  [0, 0.5 - 0.5j, -0.5 + 0.5j, 0],
-                                  [0, -0.5 + 0.5j, -0.5 + 0.5j, 0],
-                                  [0.5 - 0.5j, 0, 0, 0.5 - 0.5j]]))(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.MatrixGate(np.array([[1, 0], [0, 1j]]))(q0),
-        cirq.MatrixGate(np.array([[0, -1j], [1j, 0]]))(q1),
-        cirq.MatrixGate(np.array([[0, 1], [1, 0]]))(q2),
-        cirq.MatrixGate(np.array([[1, 0], [0, -1]]))(q3),
-      ]),
-      cirq.Moment([
-        cirq.riswap(0.7)(q0, q1),
-        cirq.givens(1.2)(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.H(q0),
-        cirq.H(q1),
-        cirq.H(q2),
-        cirq.H(q3),
-      ]),
-    )
+  # Create a circuit
+  cirq_circuit = cirq.Circuit(cirq.CNOT(a, b), cirq.CNOT(b, a), cirq.X(a))
 
-    simulator = cirq.Simulator()
-    cirq_result = simulator.simulate(circuit)
-
-    qsim_simulator = qsimcirq.QSimSimulator()
-    qsim_result = qsim_simulator.simulate(circuit)
-
-    assert cirq.linalg.allclose_up_to_global_phase(
-        qsim_result.state_vector(), cirq_result.state_vector())
+  qsimh_options = {'k': [0], 'w': 0, 'p': 1, 'r': 1}
+  qsimhSim = qsimcirq.QSimhSimulator(qsimh_options)
+  result = qsimhSim.compute_amplitudes(
+      cirq_circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])
+  assert np.allclose(result, [0j, 0j, (1 + 0j), 0j])
 
 
-  def test_cirq_qsim_global_shift(self):
-    q0 = cirq.GridQubit(1, 1)
-    q1 = cirq.GridQubit(1, 0)
-    q2 = cirq.GridQubit(0, 1)
-    q3 = cirq.GridQubit(0, 0)
+def test_cirq_qsim_params():
+  qubit = cirq.GridQubit(0,0)
 
-    circuit = cirq.Circuit(
-      cirq.Moment([
-        cirq.H(q0),
-        cirq.H(q1),
-        cirq.H(q2),
-        cirq.H(q3),
-      ]),
-      cirq.Moment([
-        cirq.CXPowGate(exponent=1, global_shift=0.7)(q0, q1),
-        cirq.CZPowGate(exponent=1, global_shift=0.9)(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.XPowGate(exponent=1, global_shift=1.1)(q0),
-        cirq.YPowGate(exponent=1, global_shift=1)(q1),
-        cirq.ZPowGate(exponent=1, global_shift=0.9)(q2),
-        cirq.HPowGate(exponent=1, global_shift=0.8)(q3),
-      ]),
-      cirq.Moment([
-        cirq.XXPowGate(exponent=1, global_shift=0.2)(q0, q1),
-        cirq.YYPowGate(exponent=1, global_shift=0.3)(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.ZPowGate(exponent=0.25, global_shift=0.4)(q0),
-        cirq.ZPowGate(exponent=0.5, global_shift=0.5)(q1),
-        cirq.YPowGate(exponent=1, global_shift=0.2)(q2),
-        cirq.ZPowGate(exponent=1, global_shift=0.3)(q3),
-      ]),
-      cirq.Moment([
-        cirq.ZZPowGate(exponent=1, global_shift=0.2)(q0, q1),
-        cirq.SwapPowGate(exponent=1, global_shift=0.3)(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.XPowGate(exponent=1, global_shift=0)(q0),
-        cirq.YPowGate(exponent=1, global_shift=0)(q1),
-        cirq.ZPowGate(exponent=1, global_shift=0)(q2),
-        cirq.HPowGate(exponent=1, global_shift=0)(q3),
-      ]),
-      cirq.Moment([
-        cirq.ISwapPowGate(exponent=1, global_shift=0.3)(q0, q1),
-        cirq.ZZPowGate(exponent=1, global_shift=0.5)(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.ZPowGate(exponent=0.5, global_shift=0)(q0),
-        cirq.ZPowGate(exponent=0.25, global_shift=0)(q1),
-        cirq.XPowGate(exponent=0.9, global_shift=0)(q2),
-        cirq.YPowGate(exponent=0.8, global_shift=0)(q3),
-      ]),
-      cirq.Moment([
-        cirq.CZPowGate(exponent=0.3, global_shift=0)(q0, q1),
-        cirq.CXPowGate(exponent=0.4, global_shift=0)(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.ZPowGate(exponent=1.3, global_shift=0)(q0),
-        cirq.HPowGate(exponent=0.8, global_shift=0)(q1),
-        cirq.XPowGate(exponent=0.9, global_shift=0)(q2),
-        cirq.YPowGate(exponent=0.4, global_shift=0)(q3),
-      ]),
-      cirq.Moment([
-        cirq.XXPowGate(exponent=0.8, global_shift=0)(q0, q1),
-        cirq.YYPowGate(exponent=0.6, global_shift=0)(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.HPowGate(exponent=0.7, global_shift=0)(q0),
-        cirq.ZPowGate(exponent=0.2, global_shift=0)(q1),
-        cirq.YPowGate(exponent=0.3, global_shift=0)(q2),
-        cirq.XPowGate(exponent=0.7, global_shift=0)(q3),
-      ]),
-      cirq.Moment([
-        cirq.ZZPowGate(exponent=0.1, global_shift=0)(q0, q1),
-        cirq.SwapPowGate(exponent=0.6, global_shift=0)(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.XPowGate(exponent=0.4, global_shift=0)(q0),
-        cirq.YPowGate(exponent=0.3, global_shift=0)(q1),
-        cirq.ZPowGate(exponent=0.2, global_shift=0)(q2),
-        cirq.HPowGate(exponent=0.1, global_shift=0)(q3),
-      ]),
-      cirq.Moment([
-        cirq.ISwapPowGate(exponent=1.3, global_shift=0)(q0, q1),
-        cirq.CXPowGate(exponent=0.5, global_shift=0)(q2, q3),
-      ]),
-      cirq.Moment([
-        cirq.H(q0),
-        cirq.H(q1),
-        cirq.H(q2),
-        cirq.H(q3),
-      ]),
-    )
+  circuit = cirq.Circuit(cirq.X(qubit)**sympy.Symbol("beta"))
+  params = cirq.ParamResolver({'beta': 0.5})
 
-    simulator = cirq.Simulator()
-    cirq_result = simulator.simulate(circuit)
+  simulator = cirq.Simulator()
+  cirq_result = simulator.simulate(circuit, param_resolver = params)
 
-    qsim_simulator = qsimcirq.QSimSimulator()
-    qsim_result = qsim_simulator.simulate(circuit)
+  qsim_simulator = qsimcirq.QSimSimulator()
+  qsim_result = qsim_simulator.simulate(circuit, param_resolver = params)
 
-    assert cirq.linalg.allclose_up_to_global_phase(
-        qsim_result.state_vector(), cirq_result.state_vector())
+  assert cirq.linalg.allclose_up_to_global_phase(
+      qsim_result.state_vector(), cirq_result.state_vector())
 
 
-if __name__ == '__main__':
-  unittest.main()
+def test_cirq_qsim_all_supported_gates():
+  q0 = cirq.GridQubit(1, 1)
+  q1 = cirq.GridQubit(1, 0)
+  q2 = cirq.GridQubit(0, 1)
+  q3 = cirq.GridQubit(0, 0)
+
+  circuit = cirq.Circuit(
+    cirq.Moment([
+      cirq.H(q0),
+      cirq.H(q1),
+      cirq.H(q2),
+      cirq.H(q3),
+    ]),
+    cirq.Moment([
+      cirq.T(q0),
+      cirq.T(q1),
+      cirq.T(q2),
+      cirq.T(q3),
+    ]),
+    cirq.Moment([
+      cirq.CZPowGate(exponent=0.7, global_shift=0.2)(q0, q1),
+      cirq.CXPowGate(exponent=1.2, global_shift=0.4)(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.XPowGate(exponent=0.3, global_shift=1.1)(q0),
+      cirq.YPowGate(exponent=0.4, global_shift=1)(q1),
+      cirq.ZPowGate(exponent=0.5, global_shift=0.9)(q2),
+      cirq.HPowGate(exponent=0.6, global_shift=0.8)(q3),
+    ]),
+    cirq.Moment([
+      cirq.CX(q0, q2),
+      cirq.CZ(q1, q3),
+    ]),
+    cirq.Moment([
+      cirq.X(q0),
+      cirq.Y(q1),
+      cirq.Z(q2),
+      cirq.S(q3),
+    ]),
+    cirq.Moment([
+      cirq.XXPowGate(exponent=0.4, global_shift=0.7)(q0, q1),
+      cirq.YYPowGate(exponent=0.8, global_shift=0.5)(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.I(q0),
+      cirq.I(q1),
+      cirq.IdentityGate(2)(q2, q3)
+    ]),
+    cirq.Moment([
+      cirq.rx(0.7)(q0),
+      cirq.ry(0.2)(q1),
+      cirq.rz(0.4)(q2),
+      cirq.PhasedXPowGate(
+          phase_exponent=0.8, exponent=0.6, global_shift=0.3)(q3),
+    ]),
+    cirq.Moment([
+      cirq.ZZPowGate(exponent=0.3, global_shift=1.3)(q0, q2),
+      cirq.ISwapPowGate(exponent=0.6, global_shift=1.2)(q1, q3),
+    ]),
+    cirq.Moment([
+      cirq.XPowGate(exponent=0.1, global_shift=0.9)(q0),
+      cirq.YPowGate(exponent=0.2, global_shift=1)(q1),
+      cirq.ZPowGate(exponent=0.3, global_shift=1.1)(q2),
+      cirq.HPowGate(exponent=0.4, global_shift=1.2)(q3),
+    ]),
+    cirq.Moment([
+      cirq.SwapPowGate(exponent=0.2, global_shift=0.9)(q0, q1),
+      cirq.PhasedISwapPowGate(phase_exponent = 0.8, exponent=0.6)(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.PhasedXZGate(
+          x_exponent=0.2, z_exponent=0.3, axis_phase_exponent=1.4)(q0),
+      cirq.T(q1),
+      cirq.H(q2),
+      cirq.S(q3),
+    ]),
+    cirq.Moment([
+      cirq.SWAP(q0, q2),
+      cirq.XX(q1, q3),
+    ]),
+    cirq.Moment([
+      cirq.rx(0.8)(q0),
+      cirq.ry(0.9)(q1),
+      cirq.rz(1.2)(q2),
+      cirq.T(q3),
+    ]),
+    cirq.Moment([
+      cirq.YY(q0, q1),
+      cirq.ISWAP(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.T(q0),
+      cirq.Z(q1),
+      cirq.Y(q2),
+      cirq.X(q3),
+    ]),
+    cirq.Moment([
+      cirq.FSimGate(0.3, 1.7)(q0, q2),
+      cirq.ZZ(q1, q3),
+    ]),
+    cirq.Moment([
+      cirq.ry(1.3)(q0),
+      cirq.rz(0.4)(q1),
+      cirq.rx(0.7)(q2),
+      cirq.S(q3),
+    ]),
+    cirq.Moment([
+      cirq.IdentityGate(4).on(q0, q1, q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.CCZPowGate(exponent=0.7, global_shift=0.3)(q2, q0, q1),
+    ]),
+    cirq.Moment([
+      cirq.CCXPowGate(exponent=0.4, global_shift=0.6)(
+        q3, q1, q0).controlled_by(q2, control_values=[0]),
+    ]),
+    cirq.Moment([
+      cirq.rx(0.3)(q0),
+      cirq.ry(0.5)(q1),
+      cirq.rz(0.7)(q2),
+      cirq.rx(0.9)(q3),
+    ]),
+    cirq.Moment([
+      cirq.TwoQubitDiagonalGate([0.1, 0.2, 0.3, 0.4])(q0, q1),
+    ]),
+    cirq.Moment([
+      cirq.ThreeQubitDiagonalGate([0.5, 0.6, 0.7, 0.8,
+                                    0.9, 1, 1.2, 1.3])(q1, q2, q3),
+    ]),
+    cirq.Moment([
+        cirq.CSwapGate()(q0, q3, q1),
+    ]),
+    cirq.Moment([
+      cirq.rz(0.6)(q0),
+      cirq.rx(0.7)(q1),
+      cirq.ry(0.8)(q2),
+      cirq.rz(0.9)(q3),
+    ]),
+    cirq.Moment([
+      cirq.TOFFOLI(q3, q2, q0),
+    ]),
+    cirq.Moment([
+      cirq.FREDKIN(q1, q3, q2),
+    ]),
+    cirq.Moment([
+      cirq.MatrixGate(np.array([[0, -0.5 - 0.5j, -0.5 - 0.5j, 0],
+                                [0.5 - 0.5j, 0, 0, -0.5 + 0.5j],
+                                [0.5 - 0.5j, 0, 0, 0.5 - 0.5j],
+                                [0, -0.5 - 0.5j, 0.5 + 0.5j, 0]]))(q0, q1),
+      cirq.MatrixGate(np.array([[0.5 - 0.5j, 0, 0, -0.5 + 0.5j],
+                                [0, 0.5 - 0.5j, -0.5 + 0.5j, 0],
+                                [0, -0.5 + 0.5j, -0.5 + 0.5j, 0],
+                                [0.5 - 0.5j, 0, 0, 0.5 - 0.5j]]))(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.MatrixGate(np.array([[1, 0], [0, 1j]]))(q0),
+      cirq.MatrixGate(np.array([[0, -1j], [1j, 0]]))(q1),
+      cirq.MatrixGate(np.array([[0, 1], [1, 0]]))(q2),
+      cirq.MatrixGate(np.array([[1, 0], [0, -1]]))(q3),
+    ]),
+    cirq.Moment([
+      cirq.riswap(0.7)(q0, q1),
+      cirq.givens(1.2)(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.H(q0),
+      cirq.H(q1),
+      cirq.H(q2),
+      cirq.H(q3),
+    ]),
+  )
+
+  simulator = cirq.Simulator()
+  cirq_result = simulator.simulate(circuit)
+
+  qsim_simulator = qsimcirq.QSimSimulator()
+  qsim_result = qsim_simulator.simulate(circuit)
+
+  assert cirq.linalg.allclose_up_to_global_phase(
+      qsim_result.state_vector(), cirq_result.state_vector())
+
+
+def test_cirq_qsim_global_shift():
+  q0 = cirq.GridQubit(1, 1)
+  q1 = cirq.GridQubit(1, 0)
+  q2 = cirq.GridQubit(0, 1)
+  q3 = cirq.GridQubit(0, 0)
+
+  circuit = cirq.Circuit(
+    cirq.Moment([
+      cirq.H(q0),
+      cirq.H(q1),
+      cirq.H(q2),
+      cirq.H(q3),
+    ]),
+    cirq.Moment([
+      cirq.CXPowGate(exponent=1, global_shift=0.7)(q0, q1),
+      cirq.CZPowGate(exponent=1, global_shift=0.9)(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.XPowGate(exponent=1, global_shift=1.1)(q0),
+      cirq.YPowGate(exponent=1, global_shift=1)(q1),
+      cirq.ZPowGate(exponent=1, global_shift=0.9)(q2),
+      cirq.HPowGate(exponent=1, global_shift=0.8)(q3),
+    ]),
+    cirq.Moment([
+      cirq.XXPowGate(exponent=1, global_shift=0.2)(q0, q1),
+      cirq.YYPowGate(exponent=1, global_shift=0.3)(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.ZPowGate(exponent=0.25, global_shift=0.4)(q0),
+      cirq.ZPowGate(exponent=0.5, global_shift=0.5)(q1),
+      cirq.YPowGate(exponent=1, global_shift=0.2)(q2),
+      cirq.ZPowGate(exponent=1, global_shift=0.3)(q3),
+    ]),
+    cirq.Moment([
+      cirq.ZZPowGate(exponent=1, global_shift=0.2)(q0, q1),
+      cirq.SwapPowGate(exponent=1, global_shift=0.3)(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.XPowGate(exponent=1, global_shift=0)(q0),
+      cirq.YPowGate(exponent=1, global_shift=0)(q1),
+      cirq.ZPowGate(exponent=1, global_shift=0)(q2),
+      cirq.HPowGate(exponent=1, global_shift=0)(q3),
+    ]),
+    cirq.Moment([
+      cirq.ISwapPowGate(exponent=1, global_shift=0.3)(q0, q1),
+      cirq.ZZPowGate(exponent=1, global_shift=0.5)(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.ZPowGate(exponent=0.5, global_shift=0)(q0),
+      cirq.ZPowGate(exponent=0.25, global_shift=0)(q1),
+      cirq.XPowGate(exponent=0.9, global_shift=0)(q2),
+      cirq.YPowGate(exponent=0.8, global_shift=0)(q3),
+    ]),
+    cirq.Moment([
+      cirq.CZPowGate(exponent=0.3, global_shift=0)(q0, q1),
+      cirq.CXPowGate(exponent=0.4, global_shift=0)(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.ZPowGate(exponent=1.3, global_shift=0)(q0),
+      cirq.HPowGate(exponent=0.8, global_shift=0)(q1),
+      cirq.XPowGate(exponent=0.9, global_shift=0)(q2),
+      cirq.YPowGate(exponent=0.4, global_shift=0)(q3),
+    ]),
+    cirq.Moment([
+      cirq.XXPowGate(exponent=0.8, global_shift=0)(q0, q1),
+      cirq.YYPowGate(exponent=0.6, global_shift=0)(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.HPowGate(exponent=0.7, global_shift=0)(q0),
+      cirq.ZPowGate(exponent=0.2, global_shift=0)(q1),
+      cirq.YPowGate(exponent=0.3, global_shift=0)(q2),
+      cirq.XPowGate(exponent=0.7, global_shift=0)(q3),
+    ]),
+    cirq.Moment([
+      cirq.ZZPowGate(exponent=0.1, global_shift=0)(q0, q1),
+      cirq.SwapPowGate(exponent=0.6, global_shift=0)(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.XPowGate(exponent=0.4, global_shift=0)(q0),
+      cirq.YPowGate(exponent=0.3, global_shift=0)(q1),
+      cirq.ZPowGate(exponent=0.2, global_shift=0)(q2),
+      cirq.HPowGate(exponent=0.1, global_shift=0)(q3),
+    ]),
+    cirq.Moment([
+      cirq.ISwapPowGate(exponent=1.3, global_shift=0)(q0, q1),
+      cirq.CXPowGate(exponent=0.5, global_shift=0)(q2, q3),
+    ]),
+    cirq.Moment([
+      cirq.H(q0),
+      cirq.H(q1),
+      cirq.H(q2),
+      cirq.H(q3),
+    ]),
+  )
+
+  simulator = cirq.Simulator()
+  cirq_result = simulator.simulate(circuit)
+
+  qsim_simulator = qsimcirq.QSimSimulator()
+  qsim_result = qsim_simulator.simulate(circuit)
+
+  assert cirq.linalg.allclose_up_to_global_phase(
+      qsim_result.state_vector(), cirq_result.state_vector())

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -21,7 +21,39 @@ import qsimcirq
 
 class MainTest(unittest.TestCase):
 
-  # TODO: test with noise
+  # TODO: update to full circuit-translation tests
+  def test_noisy_circuit_placeholder(self):
+    from qsimcirq import qsim
+    nc = qsim.NoisyCircuit()
+    assert qsim.count_gates(nc) == 0
+
+    a, b, c = cirq.LineQubit.range(3)
+    gate_to_add = cirq.X(a)
+
+    gkind = qsim.kX
+    time = 0
+    qubits = [0]
+    params = {}
+    qsim.add_gate_channel(gkind, time, qubits, params, nc)
+    assert qsim.count_gates(nc) == 1
+
+    time = 1
+    qubits = [0, 1]
+    angles = [0.25, 0.5, 0.75]
+    qsim.add_diagonal_gate_channel(time, qubits, angles, nc)
+    assert qsim.count_gates(nc) == 2
+
+    time = 2
+    qubits = [2]
+    matrix = [0, 1, 1, 0]
+    qsim.add_matrix_gate_channel(time, qubits, matrix, nc)
+    assert qsim.count_gates(nc) == 3
+
+    control_qubits = [0]
+    control_values = [1]
+    qsim.control_last_gate_channel(control_qubits, control_values, nc)
+    assert qsim.count_gates(nc) == 3
+
 
   def test_cirq_too_big_gate(self):
     # Pick qubits.

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -21,6 +21,8 @@ import qsimcirq
 
 class MainTest(unittest.TestCase):
 
+  # TODO: test with noise
+
   def test_cirq_too_big_gate(self):
     # Pick qubits.
     a, b, c, d, e, f, g = [


### PR DESCRIPTION
Fixes #270. Since this is a fairly large PR, below is a high-level overview of what's changing.

-----
`qtrajectory.h`:
* Added a `qubit_count` method to calculate `num_qubits` from a qsim `Circuit`

`pybind_main.(h|cpp)`:
* Split the `add_gate` methods into `create_gate` and `add_gate` methods
* Added `add_gate_channel` methods for adding single-gate (i.e. noiseless) channels to a `NoisyCircuit`
* Added `add_channel` for adding Cirq `Mixture` and `Channel` objects to a `NoisyCircuit`
* Added qtrajectory equivalents of all `qsim_(simulate|sample)` methods

`qsim_circuit.py`:
* Split "add operation to circuit" behavior into a helper method
* Added `translate_cirq_to_qtrajectory`, which translates arbitrary noisy Cirq circuits to qsim `NoisyCircuit`s

`qsim_simulator.py`:
* Added `_needs_trajectories` to check if a circuit has noise (and thus requires trajectory simulation)
    * This should be added to Cirq, but until the next release we won't have access to it.
* Updated `simulate` and `sample` methods to call qtrajectory methods when needed

`qsimcirq_test.py`:
* Parameterized existing `simulate` and `sample` tests to run in both qsim and qtrajectory modes
* Added tests for noisy circuit simulation
