### PR TITLE
Support the Cirq expectation value API.

### DIFF
--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -347,7 +347,7 @@ void add_channel(const unsigned time,
 void add_gate_to_opstring(const Cirq::GateKind gate_kind,
                           const std::vector<unsigned>& qubits,
                           OpString<Cirq::GateCirq<float>>* opstring) {
-  std::map<std::string, float> params;
+  static std::map<std::string, float> params;
   opstring->ops.push_back(create_gate(gate_kind, 0, qubits, params));
 }
 
@@ -720,13 +720,10 @@ std::vector<std::complex<double>> state_to_python_expectation_value(
     const auto& opsum = std::get<0>(opsum_qubit_count_pair);
     const auto& opsum_qubits = std::get<1>(opsum_qubit_count_pair);
     if (opsum_qubits <= 6) {
-      results.push_back(
-        ExpectationValue<IO, Fuser, Simulator, Cirq::GateCirq<float>>(
-          opsum, simulator, state));
+      results.push_back(ExpectationValue<IO, Fuser>(opsum, simulator, state));
     } else {
       Fuser::Parameter param;
-      results.push_back(
-        ExpectationValue<Fuser, Simulator, Cirq::GateCirq<float>>(
+      results.push_back(ExpectationValue<Fuser>(
           param, opsum, state_space, simulator, state, ket));
     }
   }

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "../lib/bitstring.h"
+#include "../lib/expect.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_mqubit.h"
 #include "../lib/gates_qsim.h"
@@ -343,7 +344,12 @@ void add_channel(const unsigned time,
   ncircuit->push_back(channel);
 }
 
-// TODO: need methods for adding channels.
+void add_gate_to_opstring(const Cirq::GateKind gate_kind,
+                          const std::vector<unsigned>& qubits,
+                          OpString<Cirq::GateCirq<float>>* opstring) {
+  std::map<std::string, float> params;
+  opstring->ops.push_back(create_gate(gate_kind, 0, qubits, params));
+}
 
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options) {
   Circuit<Cirq::GateCirq<float>> circuit;
@@ -670,6 +676,105 @@ py::array_t<float> qtrajectory_simulate_fullstate(
     const py::dict &options, const py::array_t<float> &input_vector) {
   return state_to_python(
     options, _noisy_sim_from_input_vector(options, input_vector));
+}
+
+// Methods for calculating expectation values.
+
+std::vector<std::complex<double>> state_to_python_expectation_value(
+    const py::dict &options,
+    const std::vector<std::tuple<
+                          std::vector<OpString<Cirq::GateCirq<float>>>,
+                          unsigned>>& opsums_and_qubit_counts,
+    qsim::Simulator<For>::State&& state){
+  unsigned total_qubits;
+  unsigned num_threads;
+  try {
+    total_qubits = parseOptions<unsigned>(options, "n\0");
+    num_threads = parseOptions<unsigned>(options, "t\0");
+  } catch (const std::invalid_argument &exp) {
+    IO::errorf(exp.what());
+    return {};
+  }
+
+  using Simulator = qsim::Simulator<For>;
+  using StateSpace = Simulator::StateSpace;
+  using State = StateSpace::State;
+
+  Simulator simulator(num_threads);
+  StateSpace state_space(num_threads);
+  using Fuser = MultiQubitGateFuser<IO, Cirq::GateCirq<float>>;
+
+  State ket = state_space.Null();
+  for (const auto& opsum_qubit_count_pair : opsums_and_qubit_counts) {
+    const unsigned& qubit_count = std::get<1>(opsum_qubit_count_pair);
+    if (qubit_count > 6) {
+      // For more than 6 qubits, scratch space is required.
+      ket = state_space.Create(total_qubits);
+      break;
+    }
+  }
+
+  std::vector<std::complex<double>> results;
+  results.reserve(opsums_and_qubit_counts.size());
+  for (const auto& opsum_qubit_count_pair : opsums_and_qubit_counts) {
+    const auto& opsum = std::get<0>(opsum_qubit_count_pair);
+    const auto& opsum_qubits = std::get<1>(opsum_qubit_count_pair);
+    if (opsum_qubits <= 6) {
+      results.push_back(
+        ExpectationValue<IO, Fuser, Simulator, Cirq::GateCirq<float>>(
+          opsum, simulator, state));
+    } else {
+      Fuser::Parameter param;
+      results.push_back(
+        ExpectationValue<Fuser, Simulator, Cirq::GateCirq<float>>(
+          param, opsum, state_space, simulator, state, ket));
+    }
+  }
+  return results;
+}
+
+std::vector<std::complex<double>> qsim_simulate_expectation_values(
+    const py::dict &options,
+    const std::vector<std::tuple<
+                          std::vector<OpString<Cirq::GateCirq<float>>>,
+                          unsigned>>& opsums_and_qubit_counts,
+    uint64_t input_state) {
+  return state_to_python_expectation_value(
+    options, opsums_and_qubit_counts, 
+    _noiseless_sim_from_input_state(options, input_state));
+}
+
+std::vector<std::complex<double>> qsim_simulate_expectation_values(
+    const py::dict &options,
+    const std::vector<std::tuple<
+                          std::vector<OpString<Cirq::GateCirq<float>>>,
+                          unsigned>>& opsums_and_qubit_counts,
+    const py::array_t<float> &input_vector) {
+  return state_to_python_expectation_value(
+    options, opsums_and_qubit_counts, 
+    _noiseless_sim_from_input_vector(options, input_vector));
+}
+
+std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
+    const py::dict &options,
+    const std::vector<std::tuple<
+                          std::vector<OpString<Cirq::GateCirq<float>>>,
+                          unsigned>>& opsums_and_qubit_counts,
+    uint64_t input_state) {
+  return state_to_python_expectation_value(
+    options, opsums_and_qubit_counts, 
+    _noisy_sim_from_input_state(options, input_state));
+}
+
+std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
+    const py::dict &options,
+    const std::vector<std::tuple<
+                          std::vector<OpString<Cirq::GateCirq<float>>>,
+                          unsigned>>& opsums_and_qubit_counts,
+    const py::array_t<float> &input_vector) {
+  return state_to_python_expectation_value(
+    options, opsums_and_qubit_counts, 
+    _noisy_sim_from_input_vector(options, input_vector));
 }
 
 std::vector<unsigned> qsim_sample(const py::dict &options) {

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -144,6 +144,31 @@ def _control_details(gate: cirq.ops.ControlledGate, qubits):
   return (control_qubits, control_values)
 
 
+def add_op_to_opstring(
+    qsim_op: cirq.GateOperation,
+    qubit_to_index_dict: Dict[cirq.Qid, int],
+    opstring: qsim.OpString,
+):
+  """Adds an operation to an opstring (observable).
+  
+  Raises:
+    ValueError if qsim_op is not a single-qubit Pauli (I, X, Y, or Z).
+  """
+  qsim_gate = qsim_op.gate
+  gate_kind = _cirq_gate_kind(qsim_gate)
+  if gate_kind not in {qsim.kX, qsim.kY, qsim.kZ, qsim.kI1}:
+    raise ValueError(f'OpString should only have Paulis; got {gate_kind}')
+  qubits = [qubit_to_index_dict[q] for q in qsim_op.qubits]
+  if len(qubits) != 1:
+    raise ValueError(f'OpString ops should have 1 qubit; got {len(qubits)}')
+
+  is_controlled = isinstance(qsim_gate, cirq.ops.ControlledGate)
+  if is_controlled:
+    raise ValueError(f'OpString ops should not be controlled.')
+
+  qsim.add_gate_to_opstring(gate_kind, qubits, opstring)
+
+
 def add_op_to_circuit(
     qsim_op: cirq.GateOperation,
     time: int,

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -158,14 +158,15 @@ def add_op_to_opstring(
   gate_kind = _cirq_gate_kind(qsim_gate)
   if gate_kind not in {qsim.kX, qsim.kY, qsim.kZ, qsim.kI1}:
     raise ValueError(f'OpString should only have Paulis; got {gate_kind}')
-  qubits = [qubit_to_index_dict[q] for q in qsim_op.qubits]
-  if len(qubits) != 1:
-    raise ValueError(f'OpString ops should have 1 qubit; got {len(qubits)}')
+  if len(qsim_op.qubits) != 1:
+    raise ValueError(
+      f'OpString ops should have 1 qubit; got {len(qsim_op.qubits)}')
 
   is_controlled = isinstance(qsim_gate, cirq.ops.ControlledGate)
   if is_controlled:
     raise ValueError(f'OpString ops should not be controlled.')
 
+  qubits = [qubit_to_index_dict[q] for q in qsim_op.qubits]
   qsim.add_gate_to_opstring(gate_kind, qubits, opstring)
 
 

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -440,11 +440,11 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
       observables = [observables]
     psumlist = [ops.PauliSum.wrap(pslike) for pslike in observables]
 
-    qubits = program.all_qubits()
-    num_qubits = len(qubits)
-    qubit_map = {
-      qubit: index for index, qubit in enumerate(qubits)
-    }
+    ordered_qubits = ops.QubitOrder.as_qubit_order(qubit_order).order_for(
+      program.all_qubits())
+    ordered_qubits = list(reversed(ordered_qubits))
+    num_qubits = len(ordered_qubits)
+    qubit_map = {qubit: index for index, qubit in enumerate(ordered_qubits)}
 
     opsums_and_qubit_counts = []
     for psum in psumlist:

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -471,8 +471,6 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
     options.update(self.qsim_options)
 
     param_resolvers = study.to_resolvers(params)
-    qubits = program.all_qubits()
-    num_qubits = len(qubits)
     if isinstance(initial_state, np.ndarray):
       if initial_state.dtype != np.complex64:
         raise TypeError(f'initial_state vector must have dtype np.complex64.')


### PR DESCRIPTION
This PR allows Cirq users to invoke the `simulate_expectation_values` method with a qsim simulator. Due to moderate version skew between qsim and Cirq, some additional changes are necessary after the next Cirq release.

Fixes #271.