### PR TITLE
Improve parameter validation

### DIFF
--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -217,7 +217,7 @@ def add_op_to_circuit(
   else:
     params = {
       p.strip('_'): val for p, val in vars(qsim_gate).items()
-      if isinstance(val, float) or isinstance(val, int)
+      if isinstance(val, (int, float, np.integer, np.floating))
     }
     if isinstance(circuit, qsim.Circuit):
       qsim.add_gate(gate_kind, time, qsim_qubits, params, circuit)

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -174,6 +174,7 @@ def test_cirq_qsim_simulate_sweep(mode: str):
     assert cirq.linalg.allclose_up_to_global_phase(
       qsim_result[i].state_vector(), cirq_result[i].state_vector())
 
+
 def test_input_vector_validation():
   cirq_circuit = cirq.Circuit(
     cirq.X(cirq.LineQubit(0)), cirq.X(cirq.LineQubit(1))
@@ -190,6 +191,16 @@ def test_input_vector_validation():
     initial_state = np.asarray([0.5]*4)
     qsim_result = qsimSim.simulate_sweep(
       cirq_circuit, params, initial_state=initial_state)
+
+
+def test_numpy_params():
+  q0 = cirq.LineQubit(0)
+  x, y = sympy.Symbol('x'), sympy.Symbol('y')
+  circuit = cirq.Circuit(cirq.X(q0) ** x, cirq.H(q0) ** y)
+  prs = [{x: np.int64(0), y: np.int64(1)}, {x: np.int64(1), y: np.int64(0)}]
+
+  qsim_simulator = qsimcirq.QSimSimulator()
+  qsim_result = qsim_simulator.simulate_sweep(circuit, params=prs)
 
 
 @pytest.mark.parametrize('mode', ['noiseless', 'noisy'])

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -203,6 +203,18 @@ def test_numpy_params():
   qsim_result = qsim_simulator.simulate_sweep(circuit, params=prs)
 
 
+def test_invalid_params():
+  # Parameters must have numeric values.
+  q0 = cirq.LineQubit(0)
+  x, y = sympy.Symbol('x'), sympy.Symbol('y')
+  circuit = cirq.Circuit(cirq.X(q0) ** x, cirq.H(q0) ** y)
+  prs = [{x: np.int64(0), y: np.int64(1)}, {x: np.int64(1), y: 'z'}]
+
+  qsim_simulator = qsimcirq.QSimSimulator()
+  with pytest.raises(ValueError, match='Parameters must be numeric'):
+    _ = qsim_simulator.simulate_sweep(circuit, params=prs)
+
+
 @pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
 def test_cirq_qsim_run(mode: str):
   # Pick qubits.


### PR DESCRIPTION
Fixes #296.

There are a limited number of parameters attached to a Cirq proto-formatted gate which qsim actually cares about. This PR allows those parameters to be numpy types, and validates those types prior to pybind to provide a useful error message.