### PR TITLE
Update version to 0.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ description = ('Schrödinger and Schrödinger-Feynman simulators for quantum cir
 # README file as long_description.
 long_description = open('README.md', encoding='utf-8').read()
 
-__version__ = '0.7.1'
+__version__ = '0.8.0'
 
 setup(
     name='qsimcirq',


### PR DESCRIPTION
Do not merge until after #299.

The primary motivation for this release is to avoid incompatibility with Cirq due to #278; however, enough features have been submitted since 0.7.1 that a new minor version is justified.