### PR TITLE
Reduce proliferation of methods in pybind

### DIFF
--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -463,10 +463,9 @@ struct SimulatorHelper {
   static py::array_t<float> simulate_fullstate(
       const py::dict &options, bool is_noisy, StateType input_state) {
     auto helper = SimulatorHelper::from_options(options, is_noisy);
-    if (!helper.is_valid) {
+    if (!helper.is_valid || !helper.simulate(input_state)) {
       return {};
     }
-    helper.simulate(input_state);
     return helper.release_state_to_python();
   }
 
@@ -478,10 +477,9 @@ struct SimulatorHelper {
                             unsigned>>& opsums_and_qubit_counts,
       bool is_noisy, StateType input_state) {
     auto helper = SimulatorHelper::from_options(options, is_noisy);
-    if (!helper.is_valid) {
+    if (!helper.is_valid || !helper.simulate(input_state)) {
       return {};
     }
-    helper.simulate(input_state);
     return helper.get_expectation_value(opsums_and_qubit_counts);
   }
 

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -448,297 +448,188 @@ std::vector<std::complex<float>> qtrajectory_simulate(const py::dict &options) {
   return amplitudes;
 }
 
-// Simulate from a "pure" starting state.
-qsim::Simulator<For>::State _noiseless_sim_from_input_state(
-    const py::dict &options, uint64_t input_state) {
+// Helper class for simulating circuits of all types.
+struct SimulatorHelper {
   using Simulator = qsim::Simulator<For>;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
 
-  Circuit<Cirq::GateCirq<float>> circuit;
-  try {
-    circuit = getCircuit(options);
-  } catch (const std::invalid_argument &exp) {
-    IO::errorf(exp.what());
-    return StateSpace::Null();
+  using Gate = Cirq::GateCirq<float>;
+  using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Gate>, Simulator>;
+  using NoisyRunner = qsim::QuantumTrajectorySimulator<
+      IO, Gate, MultiQubitGateFuser, Simulator>;
+
+  static SimulatorHelper from_options(
+      const py::dict &options, bool is_noisy) {
+    SimulatorHelper helper{
+      .state_space = StateSpace(1),
+      .state = StateSpace::Null(),
+      .scratch = StateSpace::Null()
+    };
+
+    helper.is_noisy = is_noisy;
+    try {
+      if (is_noisy) {
+        helper.ncircuit = getNoisyCircuit(options);
+        helper.num_qubits = parseOptions<unsigned>(options, "n\0");
+      } else {
+        helper.circuit = getCircuit(options);
+        helper.num_qubits = helper.circuit.num_qubits;
+      }
+      helper.num_threads = parseOptions<unsigned>(options, "t\0");
+      helper.max_fused_size = parseOptions<unsigned>(options, "f\0");
+      helper.verbosity = parseOptions<unsigned>(options, "v\0");
+      helper.seed = parseOptions<unsigned>(options, "s\0");
+    } catch (const std::invalid_argument &exp) {
+      IO::errorf(exp.what());
+      return helper;
+    }
+
+    helper.state_space = StateSpace(helper.num_threads);
+    helper.state = helper.state_space.Create(helper.num_qubits);
+    return helper;
   }
 
-  using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Cirq::GateCirq<float>>,
-                            Simulator>;
-  Runner::Parameter param;
-  try {
-    param.num_threads = parseOptions<unsigned>(options, "t\0");
-    param.max_fused_size = parseOptions<unsigned>(options, "f\0");
-    param.verbosity = parseOptions<unsigned>(options, "v\0");
-    param.seed = parseOptions<unsigned>(options, "s\0");
-  } catch (const std::invalid_argument &exp) {
-    IO::errorf(exp.what());
-    return StateSpace::Null();
+  void init_state(uint64_t input_state) {
+    state_space.SetAllZeros(state);
+    state_space.SetAmpl(state, input_state, 1, 0);
   }
 
-  StateSpace state_space(param.num_threads);
-  State state = state_space.Create(circuit.num_qubits);
-  state_space.SetAllZeros(state);
-  state_space.SetAmpl(state, input_state, 1, 0);
-
-  if (!Runner::Run(param, circuit, state)) {
-    IO::errorf("qsim full state simulation of the circuit errored out.\n");
-    return StateSpace::Null();
-  }
-  return state;
-}
-
-// Simulate from an initial state vector.
-qsim::Simulator<For>::State _noiseless_sim_from_input_vector(
-    const py::dict &options, const py::array_t<float> &input_vector) {
-  using Simulator = qsim::Simulator<For>;
-  using StateSpace = Simulator::StateSpace;
-  using State = StateSpace::State;
-
-  Circuit<Cirq::GateCirq<float>> circuit;
-  try {
-    circuit = getCircuit(options);
-  } catch (const std::invalid_argument &exp) {
-    IO::errorf(exp.what());
-    return StateSpace::Null();
+  void init_state(const py::array_t<float> &input_vector) {
+    const float* ptr = input_vector.data();
+    auto f = [](unsigned n, unsigned m, uint64_t i, const float* ptr,
+                float* fsv) {
+      fsv[i] = ptr[i];
+    };
+    For(num_threads).Run(input_vector.size(), f, ptr, state.get());
+    state_space.NormalToInternalOrder(state);
   }
 
-  using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Cirq::GateCirq<float>>,
-                            Simulator>;
-  Runner::Parameter param;
-  try {
-    param.num_threads = parseOptions<unsigned>(options, "t\0");
-    param.max_fused_size = parseOptions<unsigned>(options, "f\0");
-    param.verbosity = parseOptions<unsigned>(options, "v\0");
-    param.seed = parseOptions<unsigned>(options, "s\0");
-  } catch (const std::invalid_argument &exp) {
-    IO::errorf(exp.what());
-    return StateSpace::Null();
+  Runner::Parameter get_params() {
+    Runner::Parameter params;
+    params.num_threads = num_threads;
+    params.max_fused_size = max_fused_size;
+    params.verbosity = verbosity;
+    params.seed = seed;
+    return params;
   }
 
-  StateSpace state_space(param.num_threads);
-  State state = state_space.Create(circuit.num_qubits);
-  const float* ptr = input_vector.data();
-  auto f = [](unsigned n, unsigned m, uint64_t i, const float* ptr,
-              float* fsv) {
-    fsv[i] = ptr[i];
-  };
-  For(param.num_threads).Run(input_vector.size(), f, ptr, state.get());
-  state_space.NormalToInternalOrder(state);
-
-  if (!Runner::Run(param, circuit, state)) {
-    IO::errorf("qsim full state simulation of the circuit errored out.\n");
-    return StateSpace::Null();
-  }
-  return state;
-}
-
-qsim::Simulator<For>::State _noisy_sim_from_input_state(
-    const py::dict &options, uint64_t input_state) {
-  using Simulator = qsim::Simulator<For>;
-  using StateSpace = Simulator::StateSpace;
-  using State = StateSpace::State;
-
-  NoisyCircuit<Cirq::GateCirq<float>> ncircuit;
-  unsigned num_qubits;
-  try {
-    ncircuit = getNoisyCircuit(options);
-    num_qubits = parseOptions<unsigned>(options, "n\0");
-  } catch (const std::invalid_argument &exp) {
-    IO::errorf(exp.what());
-    return StateSpace::Null();
+  NoisyRunner::Parameter get_noisy_params() {
+    NoisyRunner::Parameter params;
+    params.num_threads = num_threads;
+    params.max_fused_size = max_fused_size;
+    params.verbosity = verbosity;
+    return params;
   }
 
-  using Runner = qsim::QuantumTrajectorySimulator<IO, Cirq::GateCirq<float>,
-                                                  MultiQubitGateFuser,
-                                                  Simulator>;
-  Runner::Parameter param;
-  uint64_t seed;
-  try {
-    param.num_threads = parseOptions<unsigned>(options, "t\0");
-    param.max_fused_size = parseOptions<unsigned>(options, "f\0");
-    param.verbosity = parseOptions<unsigned>(options, "v\0");
-    seed = parseOptions<unsigned>(options, "s\0");
-  } catch (const std::invalid_argument &exp) {
-    IO::errorf(exp.what());
-    return StateSpace::Null();
+  bool simulate(uint64_t input_state) {
+    init_state(input_state);
+    return simulate_no_init();
   }
 
-  StateSpace state_space(param.num_threads);
-  State state = state_space.Create(num_qubits);
-  state_space.SetAllZeros(state);
-  state_space.SetAmpl(state, input_state, 1, 0);
-
-  State scratch = StateSpace(1).Null();
-  std::vector<uint64_t> stat;
-  if (!Runner::Run(param, num_qubits, ncircuit, seed, scratch, state, stat)) {
-    IO::errorf(
-      "qtrajectory full state simulation of the circuit errored out.\n");
-    return StateSpace::Null();
-  }
-  return state;
-}
-
-qsim::Simulator<For>::State _noisy_sim_from_input_vector(
-    const py::dict &options, const py::array_t<float> &input_vector) {
-  using Simulator = qsim::Simulator<For>;
-  using StateSpace = Simulator::StateSpace;
-  using State = StateSpace::State;
-
-  NoisyCircuit<Cirq::GateCirq<float>> ncircuit;
-  unsigned num_qubits;
-  try {
-    ncircuit = getNoisyCircuit(options);
-    num_qubits = parseOptions<unsigned>(options, "n\0");
-  } catch (const std::invalid_argument &exp) {
-    IO::errorf(exp.what());
-    return StateSpace::Null();
+  bool simulate(const py::array_t<float> &input_vector) {
+    init_state(input_vector);
+    return simulate_no_init();
   }
 
-  using Runner = qsim::QuantumTrajectorySimulator<IO, Cirq::GateCirq<float>,
-                                                  MultiQubitGateFuser,
-                                                  Simulator>;
-  Runner::Parameter param;
-  uint64_t seed;
-  try {
-    param.num_threads = parseOptions<unsigned>(options, "t\0");
-    param.max_fused_size = parseOptions<unsigned>(options, "f\0");
-    param.verbosity = parseOptions<unsigned>(options, "v\0");
-    seed = parseOptions<unsigned>(options, "s\0");
-  } catch (const std::invalid_argument &exp) {
-    IO::errorf(exp.what());
-    return StateSpace::Null();
+  bool simulate_no_init() {
+    if (is_noisy) {
+      std::vector<uint64_t> stat;
+      return NoisyRunner::Run(
+        get_noisy_params(), num_qubits, ncircuit, seed, scratch, state, stat);
+    }
+    return Runner::Run(get_params(), circuit, state);
   }
 
-  StateSpace state_space(param.num_threads);
-  State state = state_space.Create(num_qubits);
-  const float* ptr = input_vector.data();
-  auto f = [](unsigned n, unsigned m, uint64_t i, const float* ptr,
-              float* fsv) {
-    fsv[i] = ptr[i];
-  };
-  For(param.num_threads).Run(input_vector.size(), f, ptr, state.get());
-  state_space.NormalToInternalOrder(state);
-
-  State scratch = StateSpace(1).Null();
-  std::vector<uint64_t> stat;
-  if (!Runner::Run(param, num_qubits, ncircuit, seed, scratch, state, stat)) {
-    IO::errorf(
-      "qtrajectory full state simulation of the circuit errored out.\n");
-    return StateSpace::Null();
+  py::array_t<float> release_state_to_python() {
+    state_space.InternalToNormalOrder(state);
+    uint64_t fsv_size = 2 * (uint64_t{1} << num_qubits);
+    float* fsv = state.release();
+    auto capsule = py::capsule(
+        fsv, [](void *data) { delete reinterpret_cast<float *>(data); });
+    return py::array_t<float>(fsv_size, fsv, capsule);
   }
-  return state;
-}
 
-py::array_t<float> state_to_python(
-    const py::dict &options, qsim::Simulator<For>::State&& state){
+  std::vector<std::complex<double>> get_expectation_value(
+      const std::vector<std::tuple<
+                            std::vector<OpString<Cirq::GateCirq<float>>>,
+                            unsigned>>& opsums_and_qubit_counts){
+    Simulator simulator(num_threads);
+    using Fuser = MultiQubitGateFuser<IO, Cirq::GateCirq<float>>;
+
+    std::vector<std::complex<double>> results;
+    results.reserve(opsums_and_qubit_counts.size());
+    for (const auto& opsum_qubit_count_pair : opsums_and_qubit_counts) {
+      const auto& opsum = std::get<0>(opsum_qubit_count_pair);
+      const auto& opsum_qubits = std::get<1>(opsum_qubit_count_pair);
+      if (opsum_qubits <= 6) {
+        results.push_back(ExpectationValue<IO, Fuser>(opsum, simulator, state));
+      } else {
+        Fuser::Parameter param;
+        results.push_back(ExpectationValue<Fuser>(
+            param, opsum, state_space, simulator, state, scratch));
+      }
+    }
+    return results;
+  }
+
+  bool is_noisy;
+  // Only one of these will be populated, as specified by is_noisy.
+  Circuit<Gate> circuit;
+  NoisyCircuit<Gate> ncircuit;
+
+  StateSpace state_space;
+  State state;
+  State scratch;
+
   unsigned num_qubits;
   unsigned num_threads;
-  try {
-    num_qubits = parseOptions<unsigned>(options, "n\0");
-    num_threads = parseOptions<unsigned>(options, "t\0");
-  } catch (const std::invalid_argument &exp) {
-    IO::errorf(exp.what());
-    return {};
-  }
+  unsigned max_fused_size;
+  unsigned verbosity;
+  unsigned seed;
+};
 
-  qsim::Simulator<For>::StateSpace state_space(num_threads);
-  state_space.InternalToNormalOrder(state);
-
-  uint64_t fsv_size = 2 * (uint64_t{1} << num_qubits);
-  float* fsv = state.release();
-  auto capsule = py::capsule(
-      fsv, [](void *data) { delete reinterpret_cast<float *>(data); });
-  return py::array_t<float>(fsv_size, fsv, capsule);
-}
-
-// Externally-visible methods invoking the simulators above.
+// Methods for simulating full state vectors.
 
 py::array_t<float> qsim_simulate_fullstate(
     const py::dict &options, uint64_t input_state) {
-  return state_to_python(
-    options, _noiseless_sim_from_input_state(options, input_state));
+  auto helper = SimulatorHelper::from_options(options, false);
+  helper.simulate(input_state);
+  return helper.release_state_to_python();
 }
 
 py::array_t<float> qsim_simulate_fullstate(
     const py::dict &options, const py::array_t<float> &input_vector) {
-  return state_to_python(
-    options, _noiseless_sim_from_input_vector(options, input_vector));
+  auto helper = SimulatorHelper::from_options(options, false);
+  helper.simulate(input_vector);
+  return helper.release_state_to_python();
 }
 
 py::array_t<float> qtrajectory_simulate_fullstate(
     const py::dict &options, uint64_t input_state) {
-  return state_to_python(
-    options, _noisy_sim_from_input_state(options, input_state));
+  auto helper = SimulatorHelper::from_options(options, true);
+  helper.simulate(input_state);
+  return helper.release_state_to_python();
 }
 
 py::array_t<float> qtrajectory_simulate_fullstate(
     const py::dict &options, const py::array_t<float> &input_vector) {
-  return state_to_python(
-    options, _noisy_sim_from_input_vector(options, input_vector));
+  auto helper = SimulatorHelper::from_options(options, true);
+  helper.simulate(input_vector);
+  return helper.release_state_to_python();
 }
 
 // Methods for calculating expectation values.
 
-std::vector<std::complex<double>> state_to_python_expectation_value(
-    const py::dict &options,
-    const std::vector<std::tuple<
-                          std::vector<OpString<Cirq::GateCirq<float>>>,
-                          unsigned>>& opsums_and_qubit_counts,
-    qsim::Simulator<For>::State&& state){
-  unsigned total_qubits;
-  unsigned num_threads;
-  try {
-    total_qubits = parseOptions<unsigned>(options, "n\0");
-    num_threads = parseOptions<unsigned>(options, "t\0");
-  } catch (const std::invalid_argument &exp) {
-    IO::errorf(exp.what());
-    return {};
-  }
-
-  using Simulator = qsim::Simulator<For>;
-  using StateSpace = Simulator::StateSpace;
-  using State = StateSpace::State;
-
-  Simulator simulator(num_threads);
-  StateSpace state_space(num_threads);
-  using Fuser = MultiQubitGateFuser<IO, Cirq::GateCirq<float>>;
-
-  State ket = state_space.Null();
-  for (const auto& opsum_qubit_count_pair : opsums_and_qubit_counts) {
-    const unsigned& qubit_count = std::get<1>(opsum_qubit_count_pair);
-    if (qubit_count > 6) {
-      // For more than 6 qubits, scratch space is required.
-      ket = state_space.Create(total_qubits);
-      break;
-    }
-  }
-
-  std::vector<std::complex<double>> results;
-  results.reserve(opsums_and_qubit_counts.size());
-  for (const auto& opsum_qubit_count_pair : opsums_and_qubit_counts) {
-    const auto& opsum = std::get<0>(opsum_qubit_count_pair);
-    const auto& opsum_qubits = std::get<1>(opsum_qubit_count_pair);
-    if (opsum_qubits <= 6) {
-      results.push_back(ExpectationValue<IO, Fuser>(opsum, simulator, state));
-    } else {
-      Fuser::Parameter param;
-      results.push_back(ExpectationValue<Fuser>(
-          param, opsum, state_space, simulator, state, ket));
-    }
-  }
-  return results;
-}
-
 std::vector<std::complex<double>> qsim_simulate_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<
                           std::vector<OpString<Cirq::GateCirq<float>>>,
                           unsigned>>& opsums_and_qubit_counts,
     uint64_t input_state) {
-  return state_to_python_expectation_value(
-    options, opsums_and_qubit_counts, 
-    _noiseless_sim_from_input_state(options, input_state));
+  auto helper = SimulatorHelper::from_options(options, false);
+  helper.simulate(input_state);
+  return helper.get_expectation_value(opsums_and_qubit_counts);
 }
 
 std::vector<std::complex<double>> qsim_simulate_expectation_values(
@@ -747,9 +638,9 @@ std::vector<std::complex<double>> qsim_simulate_expectation_values(
                           std::vector<OpString<Cirq::GateCirq<float>>>,
                           unsigned>>& opsums_and_qubit_counts,
     const py::array_t<float> &input_vector) {
-  return state_to_python_expectation_value(
-    options, opsums_and_qubit_counts, 
-    _noiseless_sim_from_input_vector(options, input_vector));
+  auto helper = SimulatorHelper::from_options(options, false);
+  helper.simulate(input_vector);
+  return helper.get_expectation_value(opsums_and_qubit_counts);
 }
 
 std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
@@ -758,9 +649,9 @@ std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
                           std::vector<OpString<Cirq::GateCirq<float>>>,
                           unsigned>>& opsums_and_qubit_counts,
     uint64_t input_state) {
-  return state_to_python_expectation_value(
-    options, opsums_and_qubit_counts, 
-    _noisy_sim_from_input_state(options, input_state));
+  auto helper = SimulatorHelper::from_options(options, true);
+  helper.simulate(input_state);
+  return helper.get_expectation_value(opsums_and_qubit_counts);
 }
 
 std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
@@ -769,9 +660,9 @@ std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
                           std::vector<OpString<Cirq::GateCirq<float>>>,
                           unsigned>>& opsums_and_qubit_counts,
     const py::array_t<float> &input_vector) {
-  return state_to_python_expectation_value(
-    options, opsums_and_qubit_counts, 
-    _noisy_sim_from_input_vector(options, input_vector));
+  auto helper = SimulatorHelper::from_options(options, true);
+  helper.simulate(input_vector);
+  return helper.get_expectation_value(opsums_and_qubit_counts);
 }
 
 std::vector<unsigned> qsim_sample(const py::dict &options) {

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -522,17 +522,9 @@ struct SimulatorHelper {
     return params;
   }
 
-  bool simulate(uint64_t input_state) {
+  template <typename StateType>
+  bool simulate(StateType input_state) {
     init_state(input_state);
-    return simulate_no_init();
-  }
-
-  bool simulate(const py::array_t<float> &input_vector) {
-    init_state(input_vector);
-    return simulate_no_init();
-  }
-
-  bool simulate_no_init() {
     if (is_noisy) {
       std::vector<uint64_t> stat;
       return NoisyRunner::Run(
@@ -551,11 +543,10 @@ struct SimulatorHelper {
   }
 
   std::vector<std::complex<double>> get_expectation_value(
-      const std::vector<std::tuple<
-                            std::vector<OpString<Cirq::GateCirq<float>>>,
-                            unsigned>>& opsums_and_qubit_counts){
+      const std::vector<std::tuple<std::vector<OpString<Gate>>,
+                                   unsigned>>& opsums_and_qubit_counts){
     Simulator simulator(num_threads);
-    using Fuser = MultiQubitGateFuser<IO, Cirq::GateCirq<float>>;
+    using Fuser = MultiQubitGateFuser<IO, Gate>;
 
     std::vector<std::complex<double>> results;
     results.reserve(opsums_and_qubit_counts.size());


### PR DESCRIPTION
There are eight different simulation "types" supported in the pybind layer, resulting from three binary choices in simulation:
- input state or vector,
- noisy or noiseless simulation,
- return states or expectation values

The amount of code repetition in this file was starting to get silly, so I've created SimulatorHelper to help. Crucially, this class separates state prep, simulation, and output into different steps so each simulation type only does the work that's absolutely required for it.

Prerequisite for expectation value improvements.