### PR TITLE
Support aggregation of expectation values in qsimcirq

### DIFF
--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -495,23 +495,19 @@ class SimulatorHelper {
     // Aggregate expectation values for noisy circuits.
     std::vector<std::complex<double>> results(
       opsums_and_qubit_counts.size(), 0);
-    For aggregator(helper.num_threads);
-    auto add_evs = [&results](unsigned n, unsigned m, uint64_t i,
-                              const std::vector<std::complex<double>>& evs) {
-      results[i] += evs.at(i);
-    };
     for (unsigned rep = 0; rep < helper.noisy_reps; ++rep) {
       if (!helper.simulate(input_state)) {
         return {};
       }
       auto evs = helper.get_expectation_value(opsums_and_qubit_counts);
-      aggregator.Run(evs.size(), add_evs, evs);
+      for (unsigned i = 0; i < evs.size(); ++i) {
+        results[i] += evs[i];
+      }
     }
-    auto avg_evs = [&results](unsigned n, unsigned m, uint64_t i,
-                              unsigned num_reps) {
-      results[i] /= num_reps;
-    };
-    aggregator.Run(results.size(), avg_evs, helper.noisy_reps);
+    double inverse_num_reps = 1.0 / helper.noisy_reps;
+    for (unsigned i = 0; i < results.size(); ++i) {
+      results[i] *= inverse_num_reps;
+    }
     return results;
   }
 

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -80,9 +80,13 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
             applied to all circuits run using this simulator. Accepted keys and
             their behavior are as follows:
                 - 'f': int (> 0). Maximum size of fused gates. Default: 2.
+                - 'r': int (> 0). Noisy repetitions (see below). Default: 1.
                 - 't': int (> 0). Number of threads to run on. Default: 1.
                 - 'v': int (>= 0). Log verbosity. Default: 0.
             See qsim/docs/usage.md for more details on these options.
+            "Noisy repetitions" specifies how many repetitions to aggregate
+            over when calculating expectation values for a noisy circuit.
+            Note that this does not apply to other simulation types.
         seed: A random state or seed object, as defined in cirq.value.
     
     Raises:
@@ -94,7 +98,7 @@ class QSimSimulator(SimulatesSamples, SimulatesAmplitudes, SimulatesFinalState):
           'used in QSimCircuit instantiation.'
       )
     self._prng = value.parse_random_state(seed)
-    self.qsim_options = {'t': 1, 'f': 2, 'v': 0}
+    self.qsim_options = {'t': 1, 'f': 2, 'v': 0, 'r': 1}
     self.qsim_options.update(qsim_options)
 
   def get_seed(self):


### PR DESCRIPTION
Fixes #293.

Users can now specify a "noisy repetitions" option for `QSimSimulator`. This value determines how many times to execute a noisy circuit when calculating expectation values for that circuit.