### PR TITLE
Add quantum trajectory test.

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -172,6 +172,8 @@ cc_test(
     srcs = ["qtrajectory_test.cc"],
     deps = [
         "@com_google_googletest//:gtest_main",
+        "//lib:channels_cirq",
+        "//lib:circuit_noisy",
         "//lib:formux",
         "//lib:fuser_mqubit",
         "//lib:gate_appl",


### PR DESCRIPTION
Add a quantum trajectory test that shows how the final state can be uncomputed back to the initial state.