### PR TITLE
Add deps required by internal version

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -469,8 +469,7 @@ cc_library(
     hdrs = ["unitary_calculator_avx.h"],
     deps = [
         ":bits",
-        ":unitaryspace_avx",
-        ":unitaryspace_basic"
+        ":unitaryspace_avx"
     ],
 )
 
@@ -488,7 +487,6 @@ cc_library(
     hdrs = ["unitary_calculator_sse.h"],
     deps = [
         ":bits",
-        ":unitaryspace_basic",
         ":unitaryspace_sse"
     ],
 )

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -469,6 +469,7 @@ cc_library(
     hdrs = ["unitary_calculator_avx.h"],
     deps = [
         ":bits",
+        ":unitaryspace_avx",
         ":unitaryspace_basic"
     ],
 )
@@ -487,7 +488,8 @@ cc_library(
     hdrs = ["unitary_calculator_sse.h"],
     deps = [
         ":bits",
-        ":unitaryspace_basic"
+        ":unitaryspace_basic",
+        ":unitaryspace_sse"
     ],
 )
 


### PR DESCRIPTION
These dependencies are required for the internal version of these BUILD rules.

(long story short, internal bazel is not a fan of transitive dependencies)