### PR TITLE
Extend docker tests to Mac/Windows

### DIFF
--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-10.15]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Existing cross-platform tests are for the C++ portion of qsim. This change adds Mac and Windows to our Docker CI tests.