### PR TITLE
Update _resolve_parameters_ to match Cirq

### DIFF
--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -266,9 +266,15 @@ class QSimCircuit(cirq.Circuit):
     # equality is tested, for the moment, for cirq.Circuit
     return super().__eq__(other)
 
-  def _resolve_parameters_(self, param_resolver: cirq.study.ParamResolver):
+  def _resolve_parameters_(
+      self,
+      param_resolver: cirq.study.ParamResolver,
+      recursive: bool = True
+  ):
     return QSimCircuit(
-      cirq.resolve_parameters(super(), param_resolver), device=self.device)
+      cirq.resolve_parameters(super(), param_resolver, recursive),
+      device=self.device,
+    )
 
   def translate_cirq_to_qsim(
       self,


### PR DESCRIPTION
Part of #306. Cirq uses a `recursive` parameter in `_resolve_parameters_`, which will be mandatory after the next Cirq release.