### PR TITLE
Update index code snippet.

### DIFF
--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -59,7 +59,7 @@ landing_page:
         import cirq
         import qsimcirq
 
-        # Pick up to ~25 qubits to simulate (requires ~128MB of RAM)
+        # Pick up to ~25 qubits to simulate (requires ~256MB of RAM)
         qubits = [cirq.GridQubit(i,j) for i in range(5) for j in range(5)]
 
         # Define a circuit to run

--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -59,13 +59,17 @@ landing_page:
         import cirq
         import qsimcirq
 
-        # Pick up to ~36 qubits to run on a large multi-core Intel CPU machine
-        qubits = [cirq.GridQubit(i,j) for i in range(6) for j in range(6)]
+        # Pick up to ~25 qubits to simulate (requires ~128MB of RAM)
+        qubits = [cirq.GridQubit(i,j) for i in range(5) for j in range(5)]
 
-        # Define a circuit to run (e.g. Quantum Supremacy Circuits)
+        # Define a circuit to run
+        # (Example is from the 2019 "Quantum Supremacy" experiement)
         circuit = cirq.experiments.
             random_rotations_between_grid_interaction_layers_circuit(
             qubits=qubits, depth=16)
+
+        # Measure qubits at the end of the circuit
+        circuit.append(cirq.measure(*qubits, key='all_qubits'))
 
         # Simulate the circuit with qsim and return just the measurement values
         # just like you would with Cirq


### PR DESCRIPTION
CC @karlunho, @dstrain115

Discussion with users highlighted two issues with the previous code snippet:
- The 6x6 grid is too large for the average desktop (requires ~256GB RAM)
- Lack of measurements in the circuit triggered a Cirq error

My concerns with this:
- Will changing the snippet length mess up the [qsim landing page](https://quantumai.google/qsim)?
- Was there a reason we needed to mention multi-core Intel CPUs?