### PR TITLE
Ensure all qubits are used in qsimcirq result

### DIFF
--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -38,9 +38,10 @@ def _cirq_gate_kind(gate: cirq.ops.Gate):
       return qsim.kI2
     if gate.num_qubits() <= 6:
       return qsim.kI
-    raise NotImplementedError(
-      f'Received identity on {gate.num_qubits()} qubits; '
-      + 'only up to 6-qubit gates are supported.')
+    warnings.warn(
+      f'Identities on 7+ qubits are converted to no-ops. Source: {gate}',
+      RuntimeWarning,
+    )
   if isinstance(gate, cirq.ops.XPowGate):
     # cirq.rx also uses this path.
     if gate.exponent == 1 and gate.global_shift == 0:
@@ -287,10 +288,10 @@ class QSimCircuit(cirq.Circuit):
         """
 
     qsim_circuit = qsim.Circuit()
-    qubits = self.all_qubits()
-    qsim_circuit.num_qubits = len(qubits)
     ordered_qubits = cirq.ops.QubitOrder.as_qubit_order(qubit_order).order_for(
-      qubits)
+      self.all_qubits()
+    )
+    qsim_circuit.num_qubits = len(ordered_qubits)
 
     # qsim numbers qubits in reverse order from cirq
     ordered_qubits = list(reversed(ordered_qubits))

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -32,16 +32,8 @@ def _cirq_gate_kind(gate: cirq.ops.Gate):
   if isinstance(gate, cirq.ops.ControlledGate):
     return _cirq_gate_kind(gate.sub_gate)
   if isinstance(gate, cirq.ops.identity.IdentityGate):
-    if gate.num_qubits() == 1:
-      return qsim.kI1
-    if gate.num_qubits() == 2:
-      return qsim.kI2
-    if gate.num_qubits() <= 6:
-      return qsim.kI
-    warnings.warn(
-      f'Identities on 7+ qubits are converted to no-ops. Source: {gate}',
-      RuntimeWarning,
-    )
+    # Identity gates will decompose to no-ops.
+    pass
   if isinstance(gate, cirq.ops.XPowGate):
     # cirq.rx also uses this path.
     if gate.exponent == 1 and gate.global_shift == 0:

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -272,10 +272,10 @@ class QSimSimulator(
     if not isinstance(program, qsimc.QSimCircuit):
       program = qsimc.QSimCircuit(program, device=program.device)
 
-    num_qubits = len(program.all_qubits())
     # qsim numbers qubits in reverse order from cirq
     cirq_order = ops.QubitOrder.as_qubit_order(qubit_order).order_for(
       program.all_qubits())
+    num_qubits = len(cirq_order)
     bitstrings = [format(bitstring, 'b').zfill(num_qubits)[::-1]
                   for bitstring in bitstrings]
 
@@ -344,12 +344,11 @@ class QSimSimulator(
     options.update(self.qsim_options)
 
     param_resolvers = study.to_resolvers(params)
-    qubits = program.all_qubits()
-    num_qubits = len(qubits)
     # qsim numbers qubits in reverse order from cirq
     cirq_order = ops.QubitOrder.as_qubit_order(qubit_order).order_for(
-      qubits)
+      program.all_qubits())
     qsim_order = list(reversed(cirq_order))
+    num_qubits = len(qsim_order)
     if isinstance(initial_state, np.ndarray):
       if initial_state.dtype != np.complex64:
         raise TypeError(f'initial_state vector must have dtype np.complex64.')

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -67,7 +67,7 @@ def test_cirq_too_big_gate():
     qsimSim.compute_amplitudes(cirq_circuit, bitstrings=[0b0, 0b1])
 
 
-def test_cirq_too_big_identity():
+def test_cirq_giant_identity():
   # Pick qubits.
   a, b, c, d, e, f, g, h = [
       cirq.GridQubit(0, 0),
@@ -86,9 +86,13 @@ def test_cirq_too_big_identity():
     cirq.X(h),
   )
 
+  no_id_circuit = cirq.Circuit(cirq.X(h))
   qsimSim = qsimcirq.QSimSimulator()
-  with pytest.warns(RuntimeWarning, match='Identities on 7\+ qubits'):
-    qsimSim.compute_amplitudes(cirq_circuit, bitstrings=[0b0, 0b1])
+
+  assert (
+    qsimSim.simulate(cirq_circuit) ==
+    qsimSim.simulate(no_id_circuit, qubit_order=[a,b,c,d,e,f,g,h])
+  )
 
 
 @pytest.mark.parametrize('mode', ['noiseless', 'noisy'])

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -32,6 +32,11 @@ class NoiseTrigger(cirq.SingleQubitGate):
     return (np.asarray([1, 0, 0, 1]),)
 
 
+def test_empty_circuit():
+  result = qsimcirq.QSimSimulator().simulate(cirq.Circuit())
+  assert result.final_state_vector.shape == (1,)
+
+
 def test_cirq_too_big_gate():
   # Pick qubits.
   a, b, c, d, e, f, g = [
@@ -44,11 +49,45 @@ def test_cirq_too_big_gate():
       cirq.GridQubit(2, 0),
   ]
 
+  class BigGate(cirq.Gate):
+    def _num_qubits_(self):
+      return 7
+
+    def _qid_shape_(self):
+      return (2,) * 7
+
+    def _unitary_(self):
+      return np.eye(128)
+
   # Create a circuit with a gate larger than 6 qubits.
-  cirq_circuit = cirq.Circuit(cirq.IdentityGate(7).on(a, b, c, d, e, f, g))
+  cirq_circuit = cirq.Circuit(BigGate().on(a, b, c, d, e, f, g))
 
   qsimSim = qsimcirq.QSimSimulator()
   with pytest.raises(NotImplementedError):
+    qsimSim.compute_amplitudes(cirq_circuit, bitstrings=[0b0, 0b1])
+
+
+def test_cirq_too_big_identity():
+  # Pick qubits.
+  a, b, c, d, e, f, g, h = [
+      cirq.GridQubit(0, 0),
+      cirq.GridQubit(0, 1),
+      cirq.GridQubit(0, 2),
+      cirq.GridQubit(1, 0),
+      cirq.GridQubit(1, 1),
+      cirq.GridQubit(1, 2),
+      cirq.GridQubit(2, 0),
+      cirq.GridQubit(2, 1),
+  ]
+
+  # Create a circuit with a gate larger than 6 qubits.
+  cirq_circuit = cirq.Circuit(
+    cirq.IdentityGate(7).on(a, b, c, d, e, f, g),
+    cirq.X(h),
+  )
+
+  qsimSim = qsimcirq.QSimSimulator()
+  with pytest.warns(RuntimeWarning, match='Identities on 7\+ qubits'):
     qsimSim.compute_amplitudes(cirq_circuit, bitstrings=[0b0, 0b1])
 
 
@@ -246,6 +285,22 @@ def test_iterable_qubit_order():
     params={},
     permit_terminal_measurements=True,
   )
+
+
+@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+def test_preserve_qubits(mode: str):
+  # Check to confirm that qubits in qubit_order appear in the result.
+  q = cirq.LineQubit.range(2)
+  circuit = cirq.Circuit(cirq.X(q[0]))
+  if mode == 'noisy':
+    circuit.append(NoiseTrigger().on(q[0]))
+  circuit_with_id = circuit + cirq.I(q[1])
+  qsim_simulator = qsimcirq.QSimSimulator()
+  order_result = qsim_simulator.simulate(circuit, qubit_order=q)
+  id_result = qsim_simulator.simulate(circuit_with_id)
+
+  assert order_result == id_result
+  assert order_result.final_state_vector.shape == (4,)
 
 
 @pytest.mark.parametrize('mode', ['noiseless', 'noisy'])


### PR DESCRIPTION
This PR addresses two closely-related issues.

Fixes #327:

The root issue here was that we sometimes used `Circuit.all_qubits()` for `num_qubits`, when `ordered_qubits` could sometimes have more qubits (e.g. if the user wanted "extra" qubits to appear in the result).

Fixes #330:

Identities will now decompose to no-ops. Since the qubits used by qsim are based on the input circuit + qubit order, this can be done safely without affecting the simulator behavior.