### PR TITLE
Allow empty moments

### DIFF
--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -305,7 +305,7 @@ class QSimCircuit(cirq.Circuit):
         cirq.decompose(op, fallback_decomposer=to_matrix, keep=has_qsim_kind)
         for op in moment
       ]
-      moment_length = max([0] + [len(gate_ops) for gate_ops in ops_by_gate])
+      moment_length = max((len(gate_ops) for gate_ops in ops_by_gate), default=0)
 
       # Gates must be added in time order.
       for gi in range(moment_length):

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -305,7 +305,7 @@ class QSimCircuit(cirq.Circuit):
         cirq.decompose(op, fallback_decomposer=to_matrix, keep=has_qsim_kind)
         for op in moment
       ]
-      moment_length = max(len(gate_ops) for gate_ops in ops_by_gate)
+      moment_length = max([0] + [len(gate_ops) for gate_ops in ops_by_gate])
 
       # Gates must be added in time order.
       for gi in range(moment_length):

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -37,6 +37,22 @@ def test_empty_circuit():
   assert result.final_state_vector.shape == (1,)
 
 
+@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+def test_empty_moment(mode: str):
+  qs = cirq.LineQubit.range(2)
+  circuit = cirq.Circuit(
+    cirq.X(qs[0])**0.5,
+    cirq.Moment(),
+    cirq.X(qs[1])**0.5,
+  )
+
+  if mode == 'noisy':
+    circuit.append(NoiseTrigger().on(qs[0]))
+
+  result = qsimcirq.QSimSimulator().simulate(circuit)
+  assert result.final_state_vector.shape == (4,)
+
+
 def test_cirq_too_big_gate():
   # Pick qubits.
   a, b, c, d, e, f, g = [


### PR DESCRIPTION
Fixes #336.

This issue only affected the noiseless simulator, as noisy translation gets `moment_length` one gate at a time. Tests are included for both to prevent a regression.

Fun fact: `max(0, *[len(gate_ops) for gate_ops in ops_by_gate])` doesn't work here, because if the `ops_by_gate` list is empty Python will see `max(0)` and try to parse `0` as a list.