### PR TITLE
Borrow Cirq formatting tools.

### DIFF
--- a/check/format-incremental
+++ b/check/format-incremental
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Based on the Cirq python-formatting script:
+# https://github.com/quantumlib/Cirq/blob/master/check/format-incremental
+#
+# Formats python files that have been modified.
+#
+# Usage:
+#     check/format-incremental [BASE_REVISION] [--apply] [--all]
+#
+# By default, the script runs flynt to convert old string literal formatting to f-strings
+# and analyzes python files that have changed relative to the
+# base revision and determines whether they need to be formatted. If any changes
+# are needed, it prints the diff and exits with code 1, otherwise it exits with
+# code 0.
+#
+# With '--apply', reformats the files instead of printing the diff and exits
+# with code 0.
+#
+# With '--all', analyzes all python files, instead of only changed files.
+#
+# You can specify a base git revision to compare against (i.e. to use when
+# determining whether or not a file is considered to have "changed"). For
+# example, you can compare against 'origin/master' or 'HEAD~1'.
+#
+# If you don't specify a base revision, the following defaults will be tried, in
+# order, until one exists:
+#
+#     1. upstream/master
+#     2. origin/master
+#     3. master
+#
+# If none exists, the script fails.
+################################################################################
+
+# Get the working directory to the repo root.
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$(git rev-parse --show-toplevel)"
+
+
+# Parse arguments.
+only_print=1
+only_changed=1
+rev=""
+for arg in $@; do
+    if [[ "${arg}" == "--apply" ]]; then
+        only_print=0
+    elif [[ "${arg}" == "--all" ]]; then
+        only_changed=0
+    elif [ -z "${rev}" ]; then
+        if [ "$(git cat-file -t ${arg} 2> /dev/null)" != "commit" ]; then
+            echo -e "\033[31mNo revision '${arg}'.\033[0m" >&2
+            exit 1
+        fi
+        rev="${arg}"
+    else
+        echo -e "\033[31mToo many arguments. Expected [revision] [--apply] [--all].\033[0m" >&2
+        exit 1
+    fi
+done
+
+if (( only_changed == 1 )); then
+    # Figure out which branch to compare against.
+    if [ -z "${rev}" ]; then
+        if [ "$(git cat-file -t upstream/master 2> /dev/null)" == "commit" ]; then
+            rev=upstream/master
+        elif [ "$(git cat-file -t origin/master 2> /dev/null)" == "commit" ]; then
+            rev=origin/master
+        elif [ "$(git cat-file -t master 2> /dev/null)" == "commit" ]; then
+            rev=master
+        else
+            echo -e "\033[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/master' or 'HEAD~1').\033[0m" >&2
+            exit 1
+        fi
+    fi
+    base="$(git merge-base ${rev} HEAD)"
+    if [ "$(git rev-parse ${rev})" == "${base}" ]; then
+        echo -e "Comparing against revision '${rev}'." >&2
+    else
+        echo -e "Comparing against revision '${rev}' (merge base ${base})." >&2
+        rev="${base}"
+    fi
+
+    # Get the modified and added python files. Lines in git diff --name-status look like this:
+    # M       qsimcirq/__init__.py
+    # A       qsimcirq/added.py
+    modified_files=$(git diff --name-status ${rev} -- | grep '\.py$' | grep -v '_pb2\.py$' | grep '^[MA].*$' | awk '{print $2}')
+
+    # Get the moved python files. Lines in git diff --name-status look like this:
+    # R100    qsimcirq/_doc.py    qsimcirq/_doc2.py
+    moved_files=$(git diff --name-status ${rev} -- | grep '\.py$' | grep -v '_pb2\.py$' | grep '^R.*$' | awk '{print $3}')
+
+    format_files="$modified_files $moved_files"
+
+else
+    echo -e "Formatting all python files." >&2
+    format_files=$(find . -name "*.py" | grep -v "_pb2\.py$")
+fi
+
+any_files=0
+for format_file in ${format_files}; do
+  any_files=1
+done
+
+if (( any_files == 0 )); then
+    echo -e "\033[32mNo files to format\033[0m."
+    exit 0
+fi
+
+flynt_args=("--quiet" "-f")
+if (( only_print == 1 )); then
+    flynt_args+=("--dry-run")
+fi
+
+flynt ${format_files} "${flynt_args[@]}"
+FLYNTSTATUS=$?
+
+echo "Running the black formatter..."
+
+args=("--color")
+if (( only_print == 1 )); then
+    args+=("--check" "--diff")
+fi
+
+# Warn users about bug in black: https://github.com/psf/black/issues/1629
+# Once that is fixed upstream, we can just do:
+# black "${args[@]}" ${format_files}
+# exit $?
+LOGS="$(black "${args[@]}" ${format_files} 2>&1)"
+BLACKSTATUS=$?
+echo "${LOGS}"
+if [[ "$BLACKSTATUS" == "123" && "$LOGS" =~ ^.*"INTERNAL ERROR: Black produced different code on the second pass of the formatter.".*$ ]]; then
+  echo -e "\033[31mWarning, it seems we ran into https://github.com/psf/black/issues/1629. Typically, this can be fixed by adding a trailing comma. If you get stuck, please file a cirq issue on github.\033[0m"
+fi
+
+if [[ "$FLYNTSTATUS" != "0" || "$BLACKSTATUS" != "0"  ]]; then
+  exit 1
+fi
+exit 0

--- a/docs/_scripts/build_api_docs.py
+++ b/docs/_scripts/build_api_docs.py
@@ -25,15 +25,19 @@ import qsimcirq as qs
 
 flags.DEFINE_string("output_dir", "/tmp/qsim_api", "Where to output the docs")
 
-flags.DEFINE_string("code_url_prefix",
-                    ("https://github.com/quantumlib/qsim/tree/master/"
-                     "qsimcirq"), "The url prefix for links to code.")
+flags.DEFINE_string(
+    "code_url_prefix",
+    ("https://github.com/quantumlib/qsim/tree/master/" "qsimcirq"),
+    "The url prefix for links to code.",
+)
 
-flags.DEFINE_bool("search_hints", True,
-                  "Include metadata search hints in the generated files")
+flags.DEFINE_bool(
+    "search_hints", True, "Include metadata search hints in the generated files"
+)
 
-flags.DEFINE_string("site_path", "/quark/qsim/api_docs/python",
-                    "Path prefix in the _toc.yaml")
+flags.DEFINE_string(
+    "site_path", "/quark/qsim/api_docs/python", "Path prefix in the _toc.yaml"
+)
 
 FLAGS = flags.FLAGS
 
@@ -55,7 +59,8 @@ def main(unused_argv):
                 "qsim_simulator",
                 "qsimh_simulator",
             ]
-        })
+        },
+    )
 
     doc_generator.build(output_dir=FLAGS.output_dir)
 

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -22,127 +22,133 @@ from typing import Dict, Union
 
 # List of parameter names that appear in valid Cirq protos.
 GATE_PARAMS = [
-  'exponent', 'phase_exponent', 'global_shift',
-  'x_exponent', 'z_exponent', 'axis_phase_exponent',
-  'phi', 'theta'
+    "exponent",
+    "phase_exponent",
+    "global_shift",
+    "x_exponent",
+    "z_exponent",
+    "axis_phase_exponent",
+    "phi",
+    "theta",
 ]
 
 
 def _cirq_gate_kind(gate: cirq.ops.Gate):
-  if isinstance(gate, cirq.ops.ControlledGate):
-    return _cirq_gate_kind(gate.sub_gate)
-  if isinstance(gate, cirq.ops.identity.IdentityGate):
-    # Identity gates will decompose to no-ops.
-    pass
-  if isinstance(gate, cirq.ops.XPowGate):
-    # cirq.rx also uses this path.
-    if gate.exponent == 1 and gate.global_shift == 0:
-      return qsim.kX
-    return qsim.kXPowGate
-  if isinstance(gate, cirq.ops.YPowGate):
-    # cirq.ry also uses this path.
-    if gate.exponent == 1 and gate.global_shift == 0:
-      return qsim.kY
-    return qsim.kYPowGate
-  if isinstance(gate, cirq.ops.ZPowGate):
-    # cirq.rz also uses this path.
-    if gate.global_shift == 0:
-      if gate.exponent == 1:
-        return qsim.kZ
-      if gate.exponent == 0.5:
-        return qsim.kS
-      if gate.exponent == 0.25:
-        return qsim.kT
-    return qsim.kZPowGate
-  if isinstance(gate, cirq.ops.HPowGate):
-    if gate.exponent == 1 and gate.global_shift == 0:
-      return qsim.kH
-    return qsim.kHPowGate
-  if isinstance(gate, cirq.ops.CZPowGate):
-    if gate.exponent == 1 and gate.global_shift == 0:
-      return qsim.kCZ
-    return qsim.kCZPowGate
-  if isinstance(gate, cirq.ops.CXPowGate):
-    if gate.exponent == 1 and gate.global_shift == 0:
-      return qsim.kCX
-    return qsim.kCXPowGate
-  if isinstance(gate, cirq.ops.PhasedXPowGate):
-    return qsim.kPhasedXPowGate
-  if isinstance(gate, cirq.ops.PhasedXZGate):
-    return qsim.kPhasedXZGate
-  if isinstance(gate, cirq.ops.XXPowGate):
-    if gate.exponent == 1 and gate.global_shift == 0:
-      return qsim.kXX
-    return qsim.kXXPowGate
-  if isinstance(gate, cirq.ops.YYPowGate):
-    if gate.exponent == 1 and gate.global_shift == 0:
-      return qsim.kYY
-    return qsim.kYYPowGate
-  if isinstance(gate, cirq.ops.ZZPowGate):
-    if gate.exponent == 1 and gate.global_shift == 0:
-      return qsim.kZZ
-    return qsim.kZZPowGate
-  if isinstance(gate, cirq.ops.SwapPowGate):
-    if gate.exponent == 1 and gate.global_shift == 0:
-      return qsim.kSWAP
-    return qsim.kSwapPowGate
-  if isinstance(gate, cirq.ops.ISwapPowGate):
-    # cirq.riswap also uses this path.
-    if gate.exponent == 1 and gate.global_shift == 0:
-      return qsim.kISWAP
-    return qsim.kISwapPowGate
-  if isinstance(gate, cirq.ops.PhasedISwapPowGate):
-    # cirq.givens also uses this path.
-    return qsim.kPhasedISwapPowGate
-  if isinstance(gate, cirq.ops.FSimGate):
-    return qsim.kFSimGate
-  if isinstance(gate, cirq.ops.TwoQubitDiagonalGate):
-    return qsim.kTwoQubitDiagonalGate
-  if isinstance(gate, cirq.ops.ThreeQubitDiagonalGate):
-    return qsim.kThreeQubitDiagonalGate
-  if isinstance(gate, cirq.ops.CCZPowGate):
-    if gate.exponent == 1 and gate.global_shift == 0:
-      return qsim.kCCZ
-    return qsim.kCCZPowGate
-  if isinstance(gate, cirq.ops.CCXPowGate):
-    if gate.exponent == 1 and gate.global_shift == 0:
-      return qsim.kCCX
-    return qsim.kCCXPowGate
-  if isinstance(gate, cirq.ops.CSwapGate):
-    return qsim.kCSwapGate
-  if isinstance(gate, cirq.ops.MatrixGate):
-    if gate.num_qubits() <= 6:
-      return qsim.kMatrixGate
-    raise NotImplementedError(
-      f'Received matrix on {gate.num_qubits()} qubits; '
-      + 'only up to 6-qubit gates are supported.')
-  if isinstance(gate, cirq.ops.MeasurementGate):
-    # needed to inherit SimulatesSamples in sims
-    return qsim.kMeasurement
-  # Unrecognized gates will be decomposed.
-  return None
+    if isinstance(gate, cirq.ops.ControlledGate):
+        return _cirq_gate_kind(gate.sub_gate)
+    if isinstance(gate, cirq.ops.identity.IdentityGate):
+        # Identity gates will decompose to no-ops.
+        pass
+    if isinstance(gate, cirq.ops.XPowGate):
+        # cirq.rx also uses this path.
+        if gate.exponent == 1 and gate.global_shift == 0:
+            return qsim.kX
+        return qsim.kXPowGate
+    if isinstance(gate, cirq.ops.YPowGate):
+        # cirq.ry also uses this path.
+        if gate.exponent == 1 and gate.global_shift == 0:
+            return qsim.kY
+        return qsim.kYPowGate
+    if isinstance(gate, cirq.ops.ZPowGate):
+        # cirq.rz also uses this path.
+        if gate.global_shift == 0:
+            if gate.exponent == 1:
+                return qsim.kZ
+            if gate.exponent == 0.5:
+                return qsim.kS
+            if gate.exponent == 0.25:
+                return qsim.kT
+        return qsim.kZPowGate
+    if isinstance(gate, cirq.ops.HPowGate):
+        if gate.exponent == 1 and gate.global_shift == 0:
+            return qsim.kH
+        return qsim.kHPowGate
+    if isinstance(gate, cirq.ops.CZPowGate):
+        if gate.exponent == 1 and gate.global_shift == 0:
+            return qsim.kCZ
+        return qsim.kCZPowGate
+    if isinstance(gate, cirq.ops.CXPowGate):
+        if gate.exponent == 1 and gate.global_shift == 0:
+            return qsim.kCX
+        return qsim.kCXPowGate
+    if isinstance(gate, cirq.ops.PhasedXPowGate):
+        return qsim.kPhasedXPowGate
+    if isinstance(gate, cirq.ops.PhasedXZGate):
+        return qsim.kPhasedXZGate
+    if isinstance(gate, cirq.ops.XXPowGate):
+        if gate.exponent == 1 and gate.global_shift == 0:
+            return qsim.kXX
+        return qsim.kXXPowGate
+    if isinstance(gate, cirq.ops.YYPowGate):
+        if gate.exponent == 1 and gate.global_shift == 0:
+            return qsim.kYY
+        return qsim.kYYPowGate
+    if isinstance(gate, cirq.ops.ZZPowGate):
+        if gate.exponent == 1 and gate.global_shift == 0:
+            return qsim.kZZ
+        return qsim.kZZPowGate
+    if isinstance(gate, cirq.ops.SwapPowGate):
+        if gate.exponent == 1 and gate.global_shift == 0:
+            return qsim.kSWAP
+        return qsim.kSwapPowGate
+    if isinstance(gate, cirq.ops.ISwapPowGate):
+        # cirq.riswap also uses this path.
+        if gate.exponent == 1 and gate.global_shift == 0:
+            return qsim.kISWAP
+        return qsim.kISwapPowGate
+    if isinstance(gate, cirq.ops.PhasedISwapPowGate):
+        # cirq.givens also uses this path.
+        return qsim.kPhasedISwapPowGate
+    if isinstance(gate, cirq.ops.FSimGate):
+        return qsim.kFSimGate
+    if isinstance(gate, cirq.ops.TwoQubitDiagonalGate):
+        return qsim.kTwoQubitDiagonalGate
+    if isinstance(gate, cirq.ops.ThreeQubitDiagonalGate):
+        return qsim.kThreeQubitDiagonalGate
+    if isinstance(gate, cirq.ops.CCZPowGate):
+        if gate.exponent == 1 and gate.global_shift == 0:
+            return qsim.kCCZ
+        return qsim.kCCZPowGate
+    if isinstance(gate, cirq.ops.CCXPowGate):
+        if gate.exponent == 1 and gate.global_shift == 0:
+            return qsim.kCCX
+        return qsim.kCCXPowGate
+    if isinstance(gate, cirq.ops.CSwapGate):
+        return qsim.kCSwapGate
+    if isinstance(gate, cirq.ops.MatrixGate):
+        if gate.num_qubits() <= 6:
+            return qsim.kMatrixGate
+        raise NotImplementedError(
+            f"Received matrix on {gate.num_qubits()} qubits; "
+            + "only up to 6-qubit gates are supported."
+        )
+    if isinstance(gate, cirq.ops.MeasurementGate):
+        # needed to inherit SimulatesSamples in sims
+        return qsim.kMeasurement
+    # Unrecognized gates will be decomposed.
+    return None
 
 
 def _control_details(gate: cirq.ops.ControlledGate, qubits):
-  control_qubits = []
-  control_values = []
-  # TODO: support qudit control
-  for i, cvs in enumerate(gate.control_values):
-    if 0 in cvs and 1 in cvs:
-      # This qubit does not affect control.
-      continue
-    elif 0 not in cvs and 1 not in cvs:
-      # This gate will never trigger.
-      warnings.warn(f'Gate has no valid control value: {gate}', RuntimeWarning)
-      return (None, None)
-    # Either 0 or 1 is in cvs, but not both.
-    control_qubits.append(qubits[i])
-    if 0 in cvs:
-      control_values.append(0)
-    elif 1 in cvs:
-      control_values.append(1)
+    control_qubits = []
+    control_values = []
+    # TODO: support qudit control
+    for i, cvs in enumerate(gate.control_values):
+        if 0 in cvs and 1 in cvs:
+            # This qubit does not affect control.
+            continue
+        elif 0 not in cvs and 1 not in cvs:
+            # This gate will never trigger.
+            warnings.warn(f"Gate has no valid control value: {gate}", RuntimeWarning)
+            return (None, None)
+        # Either 0 or 1 is in cvs, but not both.
+        control_qubits.append(qubits[i])
+        if 0 in cvs:
+            control_values.append(0)
+        elif 1 in cvs:
+            control_values.append(1)
 
-  return (control_qubits, control_values)
+    return (control_qubits, control_values)
 
 
 def add_op_to_opstring(
@@ -150,265 +156,266 @@ def add_op_to_opstring(
     qubit_to_index_dict: Dict[cirq.Qid, int],
     opstring: qsim.OpString,
 ):
-  """Adds an operation to an opstring (observable).
+    """Adds an operation to an opstring (observable).
 
-  Raises:
-    ValueError if qsim_op is not a single-qubit Pauli (I, X, Y, or Z).
-  """
-  qsim_gate = qsim_op.gate
-  gate_kind = _cirq_gate_kind(qsim_gate)
-  if gate_kind not in {qsim.kX, qsim.kY, qsim.kZ, qsim.kI1}:
-    raise ValueError(f'OpString should only have Paulis; got {gate_kind}')
-  if len(qsim_op.qubits) != 1:
-    raise ValueError(
-      f'OpString ops should have 1 qubit; got {len(qsim_op.qubits)}')
+    Raises:
+      ValueError if qsim_op is not a single-qubit Pauli (I, X, Y, or Z).
+    """
+    qsim_gate = qsim_op.gate
+    gate_kind = _cirq_gate_kind(qsim_gate)
+    if gate_kind not in {qsim.kX, qsim.kY, qsim.kZ, qsim.kI1}:
+        raise ValueError(f"OpString should only have Paulis; got {gate_kind}")
+    if len(qsim_op.qubits) != 1:
+        raise ValueError(f"OpString ops should have 1 qubit; got {len(qsim_op.qubits)}")
 
-  is_controlled = isinstance(qsim_gate, cirq.ops.ControlledGate)
-  if is_controlled:
-    raise ValueError(f'OpString ops should not be controlled.')
+    is_controlled = isinstance(qsim_gate, cirq.ops.ControlledGate)
+    if is_controlled:
+        raise ValueError(f"OpString ops should not be controlled.")
 
-  qubits = [qubit_to_index_dict[q] for q in qsim_op.qubits]
-  qsim.add_gate_to_opstring(gate_kind, qubits, opstring)
+    qubits = [qubit_to_index_dict[q] for q in qsim_op.qubits]
+    qsim.add_gate_to_opstring(gate_kind, qubits, opstring)
 
 
 def add_op_to_circuit(
     qsim_op: cirq.GateOperation,
     time: int,
     qubit_to_index_dict: Dict[cirq.Qid, int],
-    circuit: Union[qsim.Circuit, qsim.NoisyCircuit]
+    circuit: Union[qsim.Circuit, qsim.NoisyCircuit],
 ):
-  """Adds an operation to a noisy or noiseless circuit."""
-  qsim_gate = qsim_op.gate
-  gate_kind = _cirq_gate_kind(qsim_gate)
-  qubits = [qubit_to_index_dict[q] for q in qsim_op.qubits]
+    """Adds an operation to a noisy or noiseless circuit."""
+    qsim_gate = qsim_op.gate
+    gate_kind = _cirq_gate_kind(qsim_gate)
+    qubits = [qubit_to_index_dict[q] for q in qsim_op.qubits]
 
-  qsim_qubits = qubits
-  is_controlled = isinstance(qsim_gate, cirq.ops.ControlledGate)
-  if is_controlled:
-    control_qubits, control_values = _control_details(qsim_gate, qubits)
-    if control_qubits is None:
-      # This gate has no valid control, and will be omitted.
-      return
+    qsim_qubits = qubits
+    is_controlled = isinstance(qsim_gate, cirq.ops.ControlledGate)
+    if is_controlled:
+        control_qubits, control_values = _control_details(qsim_gate, qubits)
+        if control_qubits is None:
+            # This gate has no valid control, and will be omitted.
+            return
 
-    if qsim_gate.num_qubits() > 4:
-      raise NotImplementedError(
-      f'Received control gate on {gate.num_qubits()} target qubits; '
-      + 'only up to 4-qubit gates are supported.')
+        if qsim_gate.num_qubits() > 4:
+            raise NotImplementedError(
+                f"Received control gate on {gate.num_qubits()} target qubits; "
+                + "only up to 4-qubit gates are supported."
+            )
 
-    qsim_qubits = qubits[qsim_gate.num_controls():]
-    qsim_gate = qsim_gate.sub_gate
+        qsim_qubits = qubits[qsim_gate.num_controls() :]
+        qsim_gate = qsim_gate.sub_gate
 
-  if (gate_kind == qsim.kTwoQubitDiagonalGate or
-      gate_kind == qsim.kThreeQubitDiagonalGate):
-    if isinstance(circuit, qsim.Circuit):
-      qsim.add_diagonal_gate(
-        time, qsim_qubits, qsim_gate._diag_angles_radians, circuit)
+    if (
+        gate_kind == qsim.kTwoQubitDiagonalGate
+        or gate_kind == qsim.kThreeQubitDiagonalGate
+    ):
+        if isinstance(circuit, qsim.Circuit):
+            qsim.add_diagonal_gate(
+                time, qsim_qubits, qsim_gate._diag_angles_radians, circuit
+            )
+        else:
+            qsim.add_diagonal_gate_channel(
+                time, qsim_qubits, qsim_gate._diag_angles_radians, circuit
+            )
+    elif gate_kind == qsim.kMatrixGate:
+        m = [
+            val for i in list(cirq.unitary(qsim_gate).flat) for val in [i.real, i.imag]
+        ]
+        if isinstance(circuit, qsim.Circuit):
+            qsim.add_matrix_gate(time, qsim_qubits, m, circuit)
+        else:
+            qsim.add_matrix_gate_channel(time, qsim_qubits, m, circuit)
     else:
-      qsim.add_diagonal_gate_channel(
-        time, qsim_qubits, qsim_gate._diag_angles_radians, circuit)
-  elif gate_kind == qsim.kMatrixGate:
-    m = [
-      val for i in list(cirq.unitary(qsim_gate).flat)
-      for val in [i.real, i.imag]
-    ]
-    if isinstance(circuit, qsim.Circuit):
-      qsim.add_matrix_gate(time, qsim_qubits, m, circuit)
-    else:
-      qsim.add_matrix_gate_channel(time, qsim_qubits, m, circuit)
-  else:
-    params = {}
-    for p, val in vars(qsim_gate).items():
-      key = p.strip('_')
-      if key not in GATE_PARAMS:
-        continue
-      if isinstance(val, (int, float, np.integer, np.floating)):
-        params[key] = val
-      else:
-        raise ValueError('Parameters must be numeric.')
-    if isinstance(circuit, qsim.Circuit):
-      qsim.add_gate(gate_kind, time, qsim_qubits, params, circuit)
-    else:
-      qsim.add_gate_channel(gate_kind, time, qsim_qubits, params, circuit)
+        params = {}
+        for p, val in vars(qsim_gate).items():
+            key = p.strip("_")
+            if key not in GATE_PARAMS:
+                continue
+            if isinstance(val, (int, float, np.integer, np.floating)):
+                params[key] = val
+            else:
+                raise ValueError("Parameters must be numeric.")
+        if isinstance(circuit, qsim.Circuit):
+            qsim.add_gate(gate_kind, time, qsim_qubits, params, circuit)
+        else:
+            qsim.add_gate_channel(gate_kind, time, qsim_qubits, params, circuit)
 
-  if is_controlled:
-    if isinstance(circuit, qsim.Circuit):
-      qsim.control_last_gate(control_qubits, control_values, circuit)
-    else:
-      qsim.control_last_gate_channel(control_qubits, control_values, circuit)
+    if is_controlled:
+        if isinstance(circuit, qsim.Circuit):
+            qsim.control_last_gate(control_qubits, control_values, circuit)
+        else:
+            qsim.control_last_gate_channel(control_qubits, control_values, circuit)
 
 
 class QSimCircuit(cirq.Circuit):
+    def __init__(
+        self,
+        cirq_circuit: cirq.Circuit,
+        device: cirq.devices = cirq.devices.UNCONSTRAINED_DEVICE,
+        allow_decomposition: bool = False,
+    ):
 
-  def __init__(self,
-               cirq_circuit: cirq.Circuit,
-               device: cirq.devices = cirq.devices.UNCONSTRAINED_DEVICE,
-               allow_decomposition: bool = False):
+        if allow_decomposition:
+            super().__init__([], device=device)
+            for moment in cirq_circuit:
+                for op in moment:
+                    # This should call decompose on the gates
+                    self.append(op)
+        else:
+            super().__init__(cirq_circuit, device=device)
 
-    if allow_decomposition:
-      super().__init__([], device=device)
-      for moment in cirq_circuit:
-        for op in moment:
-          # This should call decompose on the gates
-          self.append(op)
-    else:
-      super().__init__(cirq_circuit, device=device)
+    def __eq__(self, other):
+        if not isinstance(other, QSimCircuit):
+            return False
+        # equality is tested, for the moment, for cirq.Circuit
+        return super().__eq__(other)
 
-  def __eq__(self, other):
-    if not isinstance(other, QSimCircuit):
-      return False
-    # equality is tested, for the moment, for cirq.Circuit
-    return super().__eq__(other)
+    def _resolve_parameters_(
+        self, param_resolver: cirq.study.ParamResolver, recursive: bool = True
+    ):
+        return QSimCircuit(
+            cirq.resolve_parameters(super(), param_resolver, recursive),
+            device=self.device,
+        )
 
-  def _resolve_parameters_(
-      self,
-      param_resolver: cirq.study.ParamResolver,
-      recursive: bool = True
-  ):
-    return QSimCircuit(
-      cirq.resolve_parameters(super(), param_resolver, recursive),
-      device=self.device,
-    )
-
-  def translate_cirq_to_qsim(
-      self,
-      qubit_order: cirq.ops.QubitOrderOrList = cirq.ops.QubitOrder.DEFAULT
-  ) -> qsim.Circuit:
-    """
+    def translate_cirq_to_qsim(
+        self, qubit_order: cirq.ops.QubitOrderOrList = cirq.ops.QubitOrder.DEFAULT
+    ) -> qsim.Circuit:
+        """
         Translates this Cirq circuit to the qsim representation.
         :qubit_order: Ordering of qubits
         :return: a C++ qsim Circuit object
         """
 
-    qsim_circuit = qsim.Circuit()
-    ordered_qubits = cirq.ops.QubitOrder.as_qubit_order(qubit_order).order_for(
-      self.all_qubits()
-    )
-    qsim_circuit.num_qubits = len(ordered_qubits)
+        qsim_circuit = qsim.Circuit()
+        ordered_qubits = cirq.ops.QubitOrder.as_qubit_order(qubit_order).order_for(
+            self.all_qubits()
+        )
+        qsim_circuit.num_qubits = len(ordered_qubits)
 
-    # qsim numbers qubits in reverse order from cirq
-    ordered_qubits = list(reversed(ordered_qubits))
+        # qsim numbers qubits in reverse order from cirq
+        ordered_qubits = list(reversed(ordered_qubits))
 
-    def has_qsim_kind(op: cirq.ops.GateOperation):
-      return _cirq_gate_kind(op.gate) != None
+        def has_qsim_kind(op: cirq.ops.GateOperation):
+            return _cirq_gate_kind(op.gate) != None
 
-    def to_matrix(op: cirq.ops.GateOperation):
-      mat = cirq.protocols.unitary(op.gate, None)
-      if mat is None:
-          return NotImplemented
+        def to_matrix(op: cirq.ops.GateOperation):
+            mat = cirq.protocols.unitary(op.gate, None)
+            if mat is None:
+                return NotImplemented
 
-      return cirq.ops.MatrixGate(mat).on(*op.qubits)
+            return cirq.ops.MatrixGate(mat).on(*op.qubits)
 
-    qubit_to_index_dict = {q: i for i, q in enumerate(ordered_qubits)}
-    time_offset = 0
-    for moment in self:
-      ops_by_gate = [
-        cirq.decompose(op, fallback_decomposer=to_matrix, keep=has_qsim_kind)
-        for op in moment
-      ]
-      moment_length = max(len(gate_ops) for gate_ops in ops_by_gate)
+        qubit_to_index_dict = {q: i for i, q in enumerate(ordered_qubits)}
+        time_offset = 0
+        for moment in self:
+            ops_by_gate = [
+                cirq.decompose(op, fallback_decomposer=to_matrix, keep=has_qsim_kind)
+                for op in moment
+            ]
+            moment_length = max(len(gate_ops) for gate_ops in ops_by_gate)
 
-      # Gates must be added in time order.
-      for gi in range(moment_length):
-        for gate_ops in ops_by_gate:
-          if gi >= len(gate_ops):
-            continue
-          qsim_op = gate_ops[gi]
-          time = time_offset + gi
-          gate_kind = _cirq_gate_kind(qsim_op.gate)
-          add_op_to_circuit(qsim_op, time, qubit_to_index_dict, qsim_circuit)
-      time_offset += moment_length
+            # Gates must be added in time order.
+            for gi in range(moment_length):
+                for gate_ops in ops_by_gate:
+                    if gi >= len(gate_ops):
+                        continue
+                    qsim_op = gate_ops[gi]
+                    time = time_offset + gi
+                    gate_kind = _cirq_gate_kind(qsim_op.gate)
+                    add_op_to_circuit(qsim_op, time, qubit_to_index_dict, qsim_circuit)
+            time_offset += moment_length
 
-    return qsim_circuit
+        return qsim_circuit
 
-
-  def translate_cirq_to_qtrajectory(
-      self,
-      qubit_order: cirq.ops.QubitOrderOrList = cirq.ops.QubitOrder.DEFAULT
-  ) -> qsim.NoisyCircuit:
-    """
+    def translate_cirq_to_qtrajectory(
+        self, qubit_order: cirq.ops.QubitOrderOrList = cirq.ops.QubitOrder.DEFAULT
+    ) -> qsim.NoisyCircuit:
+        """
         Translates this noisy Cirq circuit to the qsim representation.
         :qubit_order: Ordering of qubits
         :return: a C++ qsim NoisyCircuit object
         """
-    qsim_ncircuit = qsim.NoisyCircuit()
-    ordered_qubits = cirq.ops.QubitOrder.as_qubit_order(qubit_order).order_for(
-        self.all_qubits())
+        qsim_ncircuit = qsim.NoisyCircuit()
+        ordered_qubits = cirq.ops.QubitOrder.as_qubit_order(qubit_order).order_for(
+            self.all_qubits()
+        )
 
-    # qsim numbers qubits in reverse order from cirq
-    ordered_qubits = list(reversed(ordered_qubits))
+        # qsim numbers qubits in reverse order from cirq
+        ordered_qubits = list(reversed(ordered_qubits))
 
-    qsim_ncircuit.num_qubits = len(ordered_qubits)
+        qsim_ncircuit.num_qubits = len(ordered_qubits)
 
-    def has_qsim_kind(op: cirq.ops.GateOperation):
-      return _cirq_gate_kind(op.gate) != None
+        def has_qsim_kind(op: cirq.ops.GateOperation):
+            return _cirq_gate_kind(op.gate) != None
 
-    def to_matrix(op: cirq.ops.GateOperation):
-      mat = cirq.unitary(op.gate, None)
-      if mat is None:
-          return NotImplemented
+        def to_matrix(op: cirq.ops.GateOperation):
+            mat = cirq.unitary(op.gate, None)
+            if mat is None:
+                return NotImplemented
 
-      return cirq.ops.MatrixGate(mat).on(*op.qubits)
+            return cirq.ops.MatrixGate(mat).on(*op.qubits)
 
-    qubit_to_index_dict = {q: i for i, q in enumerate(ordered_qubits)}
-    time_offset = 0
-    for moment in self:
-      moment_length = 0
-      ops_by_gate = []
-      ops_by_mix = []
-      ops_by_channel = []
-      # Capture ops of each type in the appropriate list.
-      for qsim_op in moment:
-        if cirq.has_unitary(qsim_op) or cirq.is_measurement(qsim_op):
-          oplist = cirq.decompose(
-            qsim_op, fallback_decomposer=to_matrix, keep=has_qsim_kind)
-          ops_by_gate.append(oplist)
-          moment_length = max(moment_length, len(oplist))
-          pass
-        elif cirq.has_mixture(qsim_op):
-          ops_by_mix.append(qsim_op)
-          moment_length = max(moment_length, 1)
-          pass
-        elif cirq.has_channel(qsim_op):
-          ops_by_channel.append(qsim_op)
-          moment_length = max(moment_length, 1)
-          pass
-        else:
-          raise ValueError(f'Encountered unparseable op: {qsim_op}')
+        qubit_to_index_dict = {q: i for i, q in enumerate(ordered_qubits)}
+        time_offset = 0
+        for moment in self:
+            moment_length = 0
+            ops_by_gate = []
+            ops_by_mix = []
+            ops_by_channel = []
+            # Capture ops of each type in the appropriate list.
+            for qsim_op in moment:
+                if cirq.has_unitary(qsim_op) or cirq.is_measurement(qsim_op):
+                    oplist = cirq.decompose(
+                        qsim_op, fallback_decomposer=to_matrix, keep=has_qsim_kind
+                    )
+                    ops_by_gate.append(oplist)
+                    moment_length = max(moment_length, len(oplist))
+                    pass
+                elif cirq.has_mixture(qsim_op):
+                    ops_by_mix.append(qsim_op)
+                    moment_length = max(moment_length, 1)
+                    pass
+                elif cirq.has_channel(qsim_op):
+                    ops_by_channel.append(qsim_op)
+                    moment_length = max(moment_length, 1)
+                    pass
+                else:
+                    raise ValueError(f"Encountered unparseable op: {qsim_op}")
 
-      # Gates must be added in time order.
-      for gi in range(moment_length):
-        # Handle gate output.
-        for gate_ops in ops_by_gate:
-          if gi >= len(gate_ops):
-            continue
-          qsim_op = gate_ops[gi]
-          time = time_offset + gi
-          gate_kind = _cirq_gate_kind(qsim_op.gate)
-          add_op_to_circuit(qsim_op, time, qubit_to_index_dict, qsim_ncircuit)
-        # Handle mixture output.
-        for mixture in ops_by_mix:
-          mixdata = []
-          for prob, mat in cirq.mixture(mixture):
-            square_mat = np.reshape(mat, (int(np.sqrt(mat.size)), -1))
-            unitary = cirq.is_unitary(square_mat)
-            # Package matrix into a qsim-friendly format.
-            mat = np.reshape(mat, (-1,)).astype(np.complex64, copy=False)
-            mixdata.append((prob, mat.view(np.float32), unitary))
-          qubits = [qubit_to_index_dict[q] for q in mixture.qubits]
-          qsim.add_channel(time_offset, qubits, mixdata, qsim_ncircuit)
-        # Handle channel output.
-        for channel in ops_by_channel:
-          chdata = []
-          for i, mat in enumerate(cirq.channel(channel)):
-            square_mat = np.reshape(mat, (int(np.sqrt(mat.size)), -1))
-            unitary = cirq.is_unitary(square_mat)
-            singular_vals = np.linalg.svd(square_mat)[1]
-            lower_bound_prob = min(singular_vals) ** 2
-            # Package matrix into a qsim-friendly format.
-            mat = np.reshape(mat, (-1,)).astype(np.complex64, copy=False)
-            chdata.append((lower_bound_prob, mat.view(np.float32), unitary))
-          qubits = [qubit_to_index_dict[q] for q in channel.qubits]
-          qsim.add_channel(time_offset, qubits, chdata, qsim_ncircuit)
-      time_offset += moment_length
+            # Gates must be added in time order.
+            for gi in range(moment_length):
+                # Handle gate output.
+                for gate_ops in ops_by_gate:
+                    if gi >= len(gate_ops):
+                        continue
+                    qsim_op = gate_ops[gi]
+                    time = time_offset + gi
+                    gate_kind = _cirq_gate_kind(qsim_op.gate)
+                    add_op_to_circuit(qsim_op, time, qubit_to_index_dict, qsim_ncircuit)
+                # Handle mixture output.
+                for mixture in ops_by_mix:
+                    mixdata = []
+                    for prob, mat in cirq.mixture(mixture):
+                        square_mat = np.reshape(mat, (int(np.sqrt(mat.size)), -1))
+                        unitary = cirq.is_unitary(square_mat)
+                        # Package matrix into a qsim-friendly format.
+                        mat = np.reshape(mat, (-1,)).astype(np.complex64, copy=False)
+                        mixdata.append((prob, mat.view(np.float32), unitary))
+                    qubits = [qubit_to_index_dict[q] for q in mixture.qubits]
+                    qsim.add_channel(time_offset, qubits, mixdata, qsim_ncircuit)
+                # Handle channel output.
+                for channel in ops_by_channel:
+                    chdata = []
+                    for i, mat in enumerate(cirq.channel(channel)):
+                        square_mat = np.reshape(mat, (int(np.sqrt(mat.size)), -1))
+                        unitary = cirq.is_unitary(square_mat)
+                        singular_vals = np.linalg.svd(square_mat)[1]
+                        lower_bound_prob = min(singular_vals) ** 2
+                        # Package matrix into a qsim-friendly format.
+                        mat = np.reshape(mat, (-1,)).astype(np.complex64, copy=False)
+                        chdata.append((lower_bound_prob, mat.view(np.float32), unitary))
+                    qubits = [qubit_to_index_dict[q] for q in channel.qubits]
+                    qsim.add_channel(time_offset, qubits, chdata, qsim_ncircuit)
+            time_offset += moment_length
 
-    return qsim_ncircuit
+        return qsim_ncircuit

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -277,147 +277,145 @@ class QSimCircuit(cirq.Circuit):
             device=self.device,
         )
 
+    def translate_cirq_to_qsim(
+        self, qubit_order: cirq.ops.QubitOrderOrList = cirq.ops.QubitOrder.DEFAULT
+    ) -> qsim.Circuit:
+        """
+        Translates this Cirq circuit to the qsim representation.
+        :qubit_order: Ordering of qubits
+        :return: a C++ qsim Circuit object
+        """
 
-def translate_cirq_to_qsim(
-    self, qubit_order: cirq.ops.QubitOrderOrList = cirq.ops.QubitOrder.DEFAULT
-) -> qsim.Circuit:
-    """
-    Translates this Cirq circuit to the qsim representation.
-    :qubit_order: Ordering of qubits
-    :return: a C++ qsim Circuit object
-    """
+        qsim_circuit = qsim.Circuit()
+        ordered_qubits = cirq.ops.QubitOrder.as_qubit_order(qubit_order).order_for(
+            self.all_qubits()
+        )
+        qsim_circuit.num_qubits = len(ordered_qubits)
 
-    qsim_circuit = qsim.Circuit()
-    ordered_qubits = cirq.ops.QubitOrder.as_qubit_order(qubit_order).order_for(
-        self.all_qubits()
-    )
-    qsim_circuit.num_qubits = len(ordered_qubits)
+        # qsim numbers qubits in reverse order from cirq
+        ordered_qubits = list(reversed(ordered_qubits))
 
-    # qsim numbers qubits in reverse order from cirq
-    ordered_qubits = list(reversed(ordered_qubits))
+        def has_qsim_kind(op: cirq.ops.GateOperation):
+            return _cirq_gate_kind(op.gate) != None
 
-    def has_qsim_kind(op: cirq.ops.GateOperation):
-        return _cirq_gate_kind(op.gate) != None
+        def to_matrix(op: cirq.ops.GateOperation):
+            mat = cirq.protocols.unitary(op.gate, None)
+            if mat is None:
+                return NotImplemented
 
-    def to_matrix(op: cirq.ops.GateOperation):
-        mat = cirq.protocols.unitary(op.gate, None)
-        if mat is None:
-            return NotImplemented
+            return cirq.ops.MatrixGate(mat).on(*op.qubits)
 
-        return cirq.ops.MatrixGate(mat).on(*op.qubits)
+        qubit_to_index_dict = {q: i for i, q in enumerate(ordered_qubits)}
+        time_offset = 0
+        for moment in self:
+            ops_by_gate = [
+                cirq.decompose(op, fallback_decomposer=to_matrix, keep=has_qsim_kind)
+                for op in moment
+            ]
+            moment_length = max((len(gate_ops) for gate_ops in ops_by_gate), default=0)
 
-    qubit_to_index_dict = {q: i for i, q in enumerate(ordered_qubits)}
-    time_offset = 0
-    for moment in self:
-        ops_by_gate = [
-            cirq.decompose(op, fallback_decomposer=to_matrix, keep=has_qsim_kind)
-            for op in moment
-        ]
-        moment_length = max((len(gate_ops) for gate_ops in ops_by_gate), default=0)
+            # Gates must be added in time order.
+            for gi in range(moment_length):
+                for gate_ops in ops_by_gate:
+                    if gi >= len(gate_ops):
+                        continue
+                    qsim_op = gate_ops[gi]
+                    time = time_offset + gi
+                    gate_kind = _cirq_gate_kind(qsim_op.gate)
+                    add_op_to_circuit(qsim_op, time, qubit_to_index_dict, qsim_circuit)
+            time_offset += moment_length
 
-        # Gates must be added in time order.
-        for gi in range(moment_length):
-            for gate_ops in ops_by_gate:
-                if gi >= len(gate_ops):
-                    continue
-                qsim_op = gate_ops[gi]
-                time = time_offset + gi
-                gate_kind = _cirq_gate_kind(qsim_op.gate)
-                add_op_to_circuit(qsim_op, time, qubit_to_index_dict, qsim_circuit)
-        time_offset += moment_length
+        return qsim_circuit
 
-    return qsim_circuit
+    def translate_cirq_to_qtrajectory(
+        self, qubit_order: cirq.ops.QubitOrderOrList = cirq.ops.QubitOrder.DEFAULT
+    ) -> qsim.NoisyCircuit:
+        """
+        Translates this noisy Cirq circuit to the qsim representation.
+        :qubit_order: Ordering of qubits
+        :return: a C++ qsim NoisyCircuit object
+        """
+        qsim_ncircuit = qsim.NoisyCircuit()
+        ordered_qubits = cirq.ops.QubitOrder.as_qubit_order(qubit_order).order_for(
+            self.all_qubits()
+        )
 
+        # qsim numbers qubits in reverse order from cirq
+        ordered_qubits = list(reversed(ordered_qubits))
 
-def translate_cirq_to_qtrajectory(
-    self, qubit_order: cirq.ops.QubitOrderOrList = cirq.ops.QubitOrder.DEFAULT
-) -> qsim.NoisyCircuit:
-    """
-    Translates this noisy Cirq circuit to the qsim representation.
-    :qubit_order: Ordering of qubits
-    :return: a C++ qsim NoisyCircuit object
-    """
-    qsim_ncircuit = qsim.NoisyCircuit()
-    ordered_qubits = cirq.ops.QubitOrder.as_qubit_order(qubit_order).order_for(
-        self.all_qubits()
-    )
+        qsim_ncircuit.num_qubits = len(ordered_qubits)
 
-    # qsim numbers qubits in reverse order from cirq
-    ordered_qubits = list(reversed(ordered_qubits))
+        def has_qsim_kind(op: cirq.ops.GateOperation):
+            return _cirq_gate_kind(op.gate) != None
 
-    qsim_ncircuit.num_qubits = len(ordered_qubits)
+        def to_matrix(op: cirq.ops.GateOperation):
+            mat = cirq.unitary(op.gate, None)
+            if mat is None:
+                return NotImplemented
 
-    def has_qsim_kind(op: cirq.ops.GateOperation):
-        return _cirq_gate_kind(op.gate) != None
+            return cirq.ops.MatrixGate(mat).on(*op.qubits)
 
-    def to_matrix(op: cirq.ops.GateOperation):
-        mat = cirq.unitary(op.gate, None)
-        if mat is None:
-            return NotImplemented
+        qubit_to_index_dict = {q: i for i, q in enumerate(ordered_qubits)}
+        time_offset = 0
+        for moment in self:
+            moment_length = 0
+            ops_by_gate = []
+            ops_by_mix = []
+            ops_by_channel = []
+            # Capture ops of each type in the appropriate list.
+            for qsim_op in moment:
+                if cirq.has_unitary(qsim_op) or cirq.is_measurement(qsim_op):
+                    oplist = cirq.decompose(
+                        qsim_op, fallback_decomposer=to_matrix, keep=has_qsim_kind
+                    )
+                    ops_by_gate.append(oplist)
+                    moment_length = max(moment_length, len(oplist))
+                    pass
+                elif cirq.has_mixture(qsim_op):
+                    ops_by_mix.append(qsim_op)
+                    moment_length = max(moment_length, 1)
+                    pass
+                elif cirq.has_channel(qsim_op):
+                    ops_by_channel.append(qsim_op)
+                    moment_length = max(moment_length, 1)
+                    pass
+                else:
+                    raise ValueError(f"Encountered unparseable op: {qsim_op}")
 
-        return cirq.ops.MatrixGate(mat).on(*op.qubits)
+            # Gates must be added in time order.
+            for gi in range(moment_length):
+                # Handle gate output.
+                for gate_ops in ops_by_gate:
+                    if gi >= len(gate_ops):
+                        continue
+                    qsim_op = gate_ops[gi]
+                    time = time_offset + gi
+                    gate_kind = _cirq_gate_kind(qsim_op.gate)
+                    add_op_to_circuit(qsim_op, time, qubit_to_index_dict, qsim_ncircuit)
+                # Handle mixture output.
+                for mixture in ops_by_mix:
+                    mixdata = []
+                    for prob, mat in cirq.mixture(mixture):
+                        square_mat = np.reshape(mat, (int(np.sqrt(mat.size)), -1))
+                        unitary = cirq.is_unitary(square_mat)
+                        # Package matrix into a qsim-friendly format.
+                        mat = np.reshape(mat, (-1,)).astype(np.complex64, copy=False)
+                        mixdata.append((prob, mat.view(np.float32), unitary))
+                    qubits = [qubit_to_index_dict[q] for q in mixture.qubits]
+                    qsim.add_channel(time_offset, qubits, mixdata, qsim_ncircuit)
+                # Handle channel output.
+                for channel in ops_by_channel:
+                    chdata = []
+                    for i, mat in enumerate(cirq.channel(channel)):
+                        square_mat = np.reshape(mat, (int(np.sqrt(mat.size)), -1))
+                        unitary = cirq.is_unitary(square_mat)
+                        singular_vals = np.linalg.svd(square_mat)[1]
+                        lower_bound_prob = min(singular_vals) ** 2
+                        # Package matrix into a qsim-friendly format.
+                        mat = np.reshape(mat, (-1,)).astype(np.complex64, copy=False)
+                        chdata.append((lower_bound_prob, mat.view(np.float32), unitary))
+                    qubits = [qubit_to_index_dict[q] for q in channel.qubits]
+                    qsim.add_channel(time_offset, qubits, chdata, qsim_ncircuit)
+            time_offset += moment_length
 
-    qubit_to_index_dict = {q: i for i, q in enumerate(ordered_qubits)}
-    time_offset = 0
-    for moment in self:
-        moment_length = 0
-        ops_by_gate = []
-        ops_by_mix = []
-        ops_by_channel = []
-        # Capture ops of each type in the appropriate list.
-        for qsim_op in moment:
-            if cirq.has_unitary(qsim_op) or cirq.is_measurement(qsim_op):
-                oplist = cirq.decompose(
-                    qsim_op, fallback_decomposer=to_matrix, keep=has_qsim_kind
-                )
-                ops_by_gate.append(oplist)
-                moment_length = max(moment_length, len(oplist))
-                pass
-            elif cirq.has_mixture(qsim_op):
-                ops_by_mix.append(qsim_op)
-                moment_length = max(moment_length, 1)
-                pass
-            elif cirq.has_channel(qsim_op):
-                ops_by_channel.append(qsim_op)
-                moment_length = max(moment_length, 1)
-                pass
-            else:
-                raise ValueError(f"Encountered unparseable op: {qsim_op}")
-
-        # Gates must be added in time order.
-        for gi in range(moment_length):
-            # Handle gate output.
-            for gate_ops in ops_by_gate:
-                if gi >= len(gate_ops):
-                    continue
-                qsim_op = gate_ops[gi]
-                time = time_offset + gi
-                gate_kind = _cirq_gate_kind(qsim_op.gate)
-                add_op_to_circuit(qsim_op, time, qubit_to_index_dict, qsim_ncircuit)
-            # Handle mixture output.
-            for mixture in ops_by_mix:
-                mixdata = []
-                for prob, mat in cirq.mixture(mixture):
-                    square_mat = np.reshape(mat, (int(np.sqrt(mat.size)), -1))
-                    unitary = cirq.is_unitary(square_mat)
-                    # Package matrix into a qsim-friendly format.
-                    mat = np.reshape(mat, (-1,)).astype(np.complex64, copy=False)
-                    mixdata.append((prob, mat.view(np.float32), unitary))
-                qubits = [qubit_to_index_dict[q] for q in mixture.qubits]
-                qsim.add_channel(time_offset, qubits, mixdata, qsim_ncircuit)
-            # Handle channel output.
-            for channel in ops_by_channel:
-                chdata = []
-                for i, mat in enumerate(cirq.channel(channel)):
-                    square_mat = np.reshape(mat, (int(np.sqrt(mat.size)), -1))
-                    unitary = cirq.is_unitary(square_mat)
-                    singular_vals = np.linalg.svd(square_mat)[1]
-                    lower_bound_prob = min(singular_vals) ** 2
-                    # Package matrix into a qsim-friendly format.
-                    mat = np.reshape(mat, (-1,)).astype(np.complex64, copy=False)
-                    chdata.append((lower_bound_prob, mat.view(np.float32), unitary))
-                qubits = [qubit_to_index_dict[q] for q in channel.qubits]
-                qsim.add_channel(time_offset, qubits, chdata, qsim_ncircuit)
-        time_offset += moment_length
-
-    return qsim_ncircuit
+        return qsim_ncircuit

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -15,17 +15,18 @@
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from cirq import (
-  circuits,
-  linalg,
-  ops,
-  protocols,
-  sim,
-  study,
-  value,
-  SimulatesAmplitudes,
-  SimulatesFinalState,
-  SimulatesSamples,
+    circuits,
+    linalg,
+    ops,
+    protocols,
+    sim,
+    study,
+    value,
+    SimulatesAmplitudes,
+    SimulatesFinalState,
+    SimulatesSamples,
 )
+
 # TODO: import from cirq directly when fix is released
 from cirq.sim.simulator import SimulatesExpectationValues
 
@@ -36,467 +37,480 @@ import qsimcirq.qsim_circuit as qsimc
 
 
 class QSimSimulatorState(sim.StateVectorSimulatorState):
-
-    def __init__(self,
-                 qsim_data: np.ndarray,
-                 qubit_map: Dict[ops.Qid, int]):
-      state_vector = qsim_data.view(np.complex64)
-      super().__init__(state_vector=state_vector, qubit_map=qubit_map)
+    def __init__(self, qsim_data: np.ndarray, qubit_map: Dict[ops.Qid, int]):
+        state_vector = qsim_data.view(np.complex64)
+        super().__init__(state_vector=state_vector, qubit_map=qubit_map)
 
 
 class QSimSimulatorTrialResult(sim.StateVectorTrialResult):
-
-    def __init__(self,
-                 params: study.ParamResolver,
-                 measurements: Dict[str, np.ndarray],
-                 final_simulator_state: QSimSimulatorState):
-      super().__init__(params=params,
-                       measurements=measurements,
-                       final_simulator_state=final_simulator_state)
+    def __init__(
+        self,
+        params: study.ParamResolver,
+        measurements: Dict[str, np.ndarray],
+        final_simulator_state: QSimSimulatorState,
+    ):
+        super().__init__(
+            params=params,
+            measurements=measurements,
+            final_simulator_state=final_simulator_state,
+        )
 
 
 # This should probably live in Cirq...
 # TODO: update to support CircuitOperations.
 def _needs_trajectories(circuit: circuits.Circuit) -> bool:
-  """Checks if the circuit requires trajectory simulation."""
-  for op in circuit.all_operations():
-    test_op = (
-      op if not protocols.is_parameterized(op)
-      else protocols.resolve_parameters(
-          op, {param: 1 for param in protocols.parameter_names(op)}
+    """Checks if the circuit requires trajectory simulation."""
+    for op in circuit.all_operations():
+        test_op = (
+            op
+            if not protocols.is_parameterized(op)
+            else protocols.resolve_parameters(
+                op, {param: 1 for param in protocols.parameter_names(op)}
+            )
         )
-    )
-    if not (protocols.has_unitary(test_op) or protocols.is_measurement(test_op)):
-      return True
-  return False
+        if not (protocols.has_unitary(test_op) or protocols.is_measurement(test_op)):
+            return True
+    return False
 
 
 class QSimSimulator(
-  SimulatesSamples,
-  SimulatesAmplitudes,
-  SimulatesFinalState,
-  SimulatesExpectationValues,
+    SimulatesSamples,
+    SimulatesAmplitudes,
+    SimulatesFinalState,
+    SimulatesExpectationValues,
 ):
+    def __init__(
+        self, qsim_options: dict = {}, seed: value.RANDOM_STATE_OR_SEED_LIKE = None
+    ):
+        """Creates a new QSimSimulator using the given options and seed.
 
-  def __init__(self, qsim_options: dict = {},
-               seed: value.RANDOM_STATE_OR_SEED_LIKE = None):
-    """Creates a new QSimSimulator using the given options and seed.
+        Args:
+            qsim_options: A map of circuit options for the simulator. These will be
+                applied to all circuits run using this simulator. Accepted keys and
+                their behavior are as follows:
+                    - 'f': int (> 0). Maximum size of fused gates. Default: 2.
+                    - 'r': int (> 0). Noisy repetitions (see below). Default: 1.
+                    - 't': int (> 0). Number of threads to run on. Default: 1.
+                    - 'v': int (>= 0). Log verbosity. Default: 0.
+                See qsim/docs/usage.md for more details on these options.
+                "Noisy repetitions" specifies how many repetitions to aggregate
+                over when calculating expectation values for a noisy circuit.
+                Note that this does not apply to other simulation types.
+            seed: A random state or seed object, as defined in cirq.value.
 
-    Args:
-        qsim_options: A map of circuit options for the simulator. These will be
-            applied to all circuits run using this simulator. Accepted keys and
-            their behavior are as follows:
-                - 'f': int (> 0). Maximum size of fused gates. Default: 2.
-                - 'r': int (> 0). Noisy repetitions (see below). Default: 1.
-                - 't': int (> 0). Number of threads to run on. Default: 1.
-                - 'v': int (>= 0). Log verbosity. Default: 0.
-            See qsim/docs/usage.md for more details on these options.
-            "Noisy repetitions" specifies how many repetitions to aggregate
-            over when calculating expectation values for a noisy circuit.
-            Note that this does not apply to other simulation types.
-        seed: A random state or seed object, as defined in cirq.value.
+        Raises:
+            ValueError if internal keys 'c', 'i' or 's' are included in 'qsim_options'.
+        """
+        if any(k in qsim_options for k in ("c", "i", "s")):
+            raise ValueError(
+                'Keys {"c", "i", "s"} are reserved for internal use and cannot be '
+                "used in QSimCircuit instantiation."
+            )
+        self._prng = value.parse_random_state(seed)
+        self.qsim_options = {"t": 1, "f": 2, "v": 0, "r": 1}
+        self.qsim_options.update(qsim_options)
 
-    Raises:
-        ValueError if internal keys 'c', 'i' or 's' are included in 'qsim_options'.
-    """
-    if any(k in qsim_options for k in ('c', 'i', 's')):
-      raise ValueError(
-          'Keys {"c", "i", "s"} are reserved for internal use and cannot be '
-          'used in QSimCircuit instantiation.'
-      )
-    self._prng = value.parse_random_state(seed)
-    self.qsim_options = {'t': 1, 'f': 2, 'v': 0, 'r': 1}
-    self.qsim_options.update(qsim_options)
+    def get_seed(self):
+        # Limit seed size to 32-bit integer for C++ conversion.
+        return self._prng.randint(2 ** 31 - 1)
 
-  def get_seed(self):
-    # Limit seed size to 32-bit integer for C++ conversion.
-    return self._prng.randint(2 ** 31 - 1)
-
-  def _run(
+    def _run(
         self,
         circuit: circuits.Circuit,
         param_resolver: study.ParamResolver,
-        repetitions: int
-  ) -> Dict[str, np.ndarray]:
-    """Run a simulation, mimicking quantum hardware.
+        repetitions: int,
+    ) -> Dict[str, np.ndarray]:
+        """Run a simulation, mimicking quantum hardware.
 
-    Args:
-        program: The circuit to simulate.
-        param_resolver: Parameters to run with the program.
-        repetitions: Number of times to repeat the run.
+        Args:
+            program: The circuit to simulate.
+            param_resolver: Parameters to run with the program.
+            repetitions: Number of times to repeat the run.
 
-    Returns:
-        A dictionary from measurement gate key to measurement
-        results.
-    """
-    param_resolver = param_resolver or study.ParamResolver({})
-    solved_circuit = protocols.resolve_parameters(circuit, param_resolver)
+        Returns:
+            A dictionary from measurement gate key to measurement
+            results.
+        """
+        param_resolver = param_resolver or study.ParamResolver({})
+        solved_circuit = protocols.resolve_parameters(circuit, param_resolver)
 
-    return self._sample_measure_results(solved_circuit, repetitions)
+        return self._sample_measure_results(solved_circuit, repetitions)
 
-  def _sample_measure_results(
-    self,
-    program: circuits.Circuit,
-    repetitions: int = 1,
-  ) -> Dict[str, np.ndarray]:
-    """Samples from measurement gates in the circuit.
+    def _sample_measure_results(
+        self,
+        program: circuits.Circuit,
+        repetitions: int = 1,
+    ) -> Dict[str, np.ndarray]:
+        """Samples from measurement gates in the circuit.
 
-    Note that this will execute the circuit 'repetitions' times.
+        Note that this will execute the circuit 'repetitions' times.
 
-    Args:
-        program: The circuit to sample from.
-        repetitions: The number of samples to take.
+        Args:
+            program: The circuit to sample from.
+            repetitions: The number of samples to take.
 
-    Returns:
-        A dictionary from measurement gate key to measurement
-        results. Measurement results are stored in a 2-dimensional
-        numpy array, the first dimension corresponding to the repetition
-        and the second to the actual boolean measurement results (ordered
-        by the qubits being measured.)
+        Returns:
+            A dictionary from measurement gate key to measurement
+            results. Measurement results are stored in a 2-dimensional
+            numpy array, the first dimension corresponding to the repetition
+            and the second to the actual boolean measurement results (ordered
+            by the qubits being measured.)
 
-    Raises:
-        ValueError: If there are multiple MeasurementGates with the same key,
-            or if repetitions is negative.
-    """
-    if not isinstance(program, qsimc.QSimCircuit):
-      program = qsimc.QSimCircuit(program, device=program.device)
+        Raises:
+            ValueError: If there are multiple MeasurementGates with the same key,
+                or if repetitions is negative.
+        """
+        if not isinstance(program, qsimc.QSimCircuit):
+            program = qsimc.QSimCircuit(program, device=program.device)
 
-    # Compute indices of measured qubits
-    ordered_qubits = ops.QubitOrder.DEFAULT.order_for(program.all_qubits())
-    num_qubits = len(ordered_qubits)
+        # Compute indices of measured qubits
+        ordered_qubits = ops.QubitOrder.DEFAULT.order_for(program.all_qubits())
+        num_qubits = len(ordered_qubits)
 
-    qubit_map = {
-      qubit: index for index, qubit in enumerate(ordered_qubits)
-    }
+        qubit_map = {qubit: index for index, qubit in enumerate(ordered_qubits)}
 
-    # Computes
-    # - the list of qubits to be measured
-    # - the start (inclusive) and end (exclusive) indices of each measurement
-    # - a mapping from measurement key to measurement gate
-    measurement_ops = [
-      op for _, op, _ in program.findall_operations_with_gate_type(ops.MeasurementGate)
-    ]
-    measured_qubits = []  # type: List[ops.Qid]
-    bounds = {}  # type: Dict[str, Tuple]
-    meas_ops = {}  # type: Dict[str, cirq.GateOperation]
-    current_index = 0
-    for op in measurement_ops:
-      gate = op.gate
-      key = protocols.measurement_key(gate)
-      meas_ops[key] = op
-      if key in bounds:
-        raise ValueError("Duplicate MeasurementGate with key {}".format(key))
-      bounds[key] = (current_index, current_index + len(op.qubits))
-      measured_qubits.extend(op.qubits)
-      current_index += len(op.qubits)
+        # Computes
+        # - the list of qubits to be measured
+        # - the start (inclusive) and end (exclusive) indices of each measurement
+        # - a mapping from measurement key to measurement gate
+        measurement_ops = [
+            op
+            for _, op, _ in program.findall_operations_with_gate_type(
+                ops.MeasurementGate
+            )
+        ]
+        measured_qubits = []  # type: List[ops.Qid]
+        bounds = {}  # type: Dict[str, Tuple]
+        meas_ops = {}  # type: Dict[str, cirq.GateOperation]
+        current_index = 0
+        for op in measurement_ops:
+            gate = op.gate
+            key = protocols.measurement_key(gate)
+            meas_ops[key] = op
+            if key in bounds:
+                raise ValueError(f"Duplicate MeasurementGate with key {key}")
+            bounds[key] = (current_index, current_index + len(op.qubits))
+            measured_qubits.extend(op.qubits)
+            current_index += len(op.qubits)
 
-    # Set qsim options
-    options = {}
-    options.update(self.qsim_options)
+        # Set qsim options
+        options = {}
+        options.update(self.qsim_options)
 
-    results = {}
-    for key, bound in bounds.items():
-      results[key] = np.ndarray(shape=(repetitions, bound[1]-bound[0]),
-                                dtype=int)
-
-
-    noisy = _needs_trajectories(program)
-    if noisy:
-      translator_fn_name = 'translate_cirq_to_qtrajectory'
-      sampler_fn = qsim.qtrajectory_sample
-    else:
-      translator_fn_name = 'translate_cirq_to_qsim'
-      sampler_fn = qsim.qsim_sample
-
-    if not noisy and program.are_all_measurements_terminal() and repetitions > 1:
-      print('Provided circuit has no intermediate measurements. ' +
-            'Sampling repeatedly from final state vector.')
-      # Measurements must be replaced with identity gates to sample properly.
-      # Simply removing them may omit qubits from the circuit.
-      for i in range(len(program.moments)):
-        program.moments[i] = ops.Moment(
-          op if not isinstance(op.gate, ops.MeasurementGate)
-          else [ops.IdentityGate(1).on(q) for q in op.qubits]
-          for op in program.moments[i]
-        )
-      options['c'] = program.translate_cirq_to_qsim(ops.QubitOrder.DEFAULT)
-      options['s'] = self.get_seed()
-      final_state = qsim.qsim_simulate_fullstate(options, 0)
-      full_results = sim.sample_state_vector(
-        final_state.view(np.complex64), range(num_qubits),
-        repetitions=repetitions, seed=self._prng)
-
-      for i in range(repetitions):
-        for key, op in meas_ops.items():
-          meas_indices = [qubit_map[qubit] for qubit in op.qubits]
-          for j, q in enumerate(meas_indices):
-            results[key][i][j] = full_results[i][q]
-    else:
-      translator_fn = getattr(program, translator_fn_name)
-      options['c'] = translator_fn(ops.QubitOrder.DEFAULT)
-      for i in range(repetitions):
-        options['s'] = self.get_seed()
-        measurements = sampler_fn(options)
+        results = {}
         for key, bound in bounds.items():
-          for j in range(bound[1]-bound[0]):
-            results[key][i][j] = int(measurements[bound[0]+j])
+            results[key] = np.ndarray(
+                shape=(repetitions, bound[1] - bound[0]), dtype=int
+            )
 
-    return results
+        noisy = _needs_trajectories(program)
+        if noisy:
+            translator_fn_name = "translate_cirq_to_qtrajectory"
+            sampler_fn = qsim.qtrajectory_sample
+        else:
+            translator_fn_name = "translate_cirq_to_qsim"
+            sampler_fn = qsim.qsim_sample
 
+        if not noisy and program.are_all_measurements_terminal() and repetitions > 1:
+            print(
+                "Provided circuit has no intermediate measurements. "
+                + "Sampling repeatedly from final state vector."
+            )
+            # Measurements must be replaced with identity gates to sample properly.
+            # Simply removing them may omit qubits from the circuit.
+            for i in range(len(program.moments)):
+                program.moments[i] = ops.Moment(
+                    op
+                    if not isinstance(op.gate, ops.MeasurementGate)
+                    else [ops.IdentityGate(1).on(q) for q in op.qubits]
+                    for op in program.moments[i]
+                )
+            options["c"] = program.translate_cirq_to_qsim(ops.QubitOrder.DEFAULT)
+            options["s"] = self.get_seed()
+            final_state = qsim.qsim_simulate_fullstate(options, 0)
+            full_results = sim.sample_state_vector(
+                final_state.view(np.complex64),
+                range(num_qubits),
+                repetitions=repetitions,
+                seed=self._prng,
+            )
 
-  def compute_amplitudes_sweep(
-      self,
-      program: circuits.Circuit,
-      bitstrings: Sequence[int],
-      params: study.Sweepable,
-      qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
-  ) -> Sequence[Sequence[complex]]:
-    """Computes the desired amplitudes using qsim.
+            for i in range(repetitions):
+                for key, op in meas_ops.items():
+                    meas_indices = [qubit_map[qubit] for qubit in op.qubits]
+                    for j, q in enumerate(meas_indices):
+                        results[key][i][j] = full_results[i][q]
+        else:
+            translator_fn = getattr(program, translator_fn_name)
+            options["c"] = translator_fn(ops.QubitOrder.DEFAULT)
+            for i in range(repetitions):
+                options["s"] = self.get_seed()
+                measurements = sampler_fn(options)
+                for key, bound in bounds.items():
+                    for j in range(bound[1] - bound[0]):
+                        results[key][i][j] = int(measurements[bound[0] + j])
 
-      The initial state is assumed to be the all zeros state.
+        return results
 
-      Args:
-          program: The circuit to simulate.
-          bitstrings: The bitstrings whose amplitudes are desired, input as an
-            string array where each string is formed from measured qubit values
-            according to `qubit_order` from most to least significant qubit,
-            i.e. in big-endian ordering.
-          param_resolver: Parameters to run with the program.
-          qubit_order: Determines the canonical ordering of the qubits. This is
-            often used in specifying the initial state, i.e. the ordering of the
-            computational basis states.
+    def compute_amplitudes_sweep(
+        self,
+        program: circuits.Circuit,
+        bitstrings: Sequence[int],
+        params: study.Sweepable,
+        qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
+    ) -> Sequence[Sequence[complex]]:
+        """Computes the desired amplitudes using qsim.
 
-      Returns:
-          List of amplitudes.
-      """
-    if not isinstance(program, qsimc.QSimCircuit):
-      program = qsimc.QSimCircuit(program, device=program.device)
+        The initial state is assumed to be the all zeros state.
 
-    # qsim numbers qubits in reverse order from cirq
-    cirq_order = ops.QubitOrder.as_qubit_order(qubit_order).order_for(
-      program.all_qubits())
-    num_qubits = len(cirq_order)
-    bitstrings = [format(bitstring, 'b').zfill(num_qubits)[::-1]
-                  for bitstring in bitstrings]
+        Args:
+            program: The circuit to simulate.
+            bitstrings: The bitstrings whose amplitudes are desired, input as an
+              string array where each string is formed from measured qubit values
+              according to `qubit_order` from most to least significant qubit,
+              i.e. in big-endian ordering.
+            param_resolver: Parameters to run with the program.
+            qubit_order: Determines the canonical ordering of the qubits. This is
+              often used in specifying the initial state, i.e. the ordering of the
+              computational basis states.
 
-    options = {'i': '\n'.join(bitstrings)}
-    options.update(self.qsim_options)
+        Returns:
+            List of amplitudes.
+        """
+        if not isinstance(program, qsimc.QSimCircuit):
+            program = qsimc.QSimCircuit(program, device=program.device)
 
-    param_resolvers = study.to_resolvers(params)
+        # qsim numbers qubits in reverse order from cirq
+        cirq_order = ops.QubitOrder.as_qubit_order(qubit_order).order_for(
+            program.all_qubits()
+        )
+        num_qubits = len(cirq_order)
+        bitstrings = [
+            format(bitstring, "b").zfill(num_qubits)[::-1] for bitstring in bitstrings
+        ]
 
-    trials_results = []
-    if _needs_trajectories(program):
-      translator_fn_name = 'translate_cirq_to_qtrajectory'
-      simulator_fn = qsim.qtrajectory_simulate
-    else:
-      translator_fn_name = 'translate_cirq_to_qsim'
-      simulator_fn = qsim.qsim_simulate
+        options = {"i": "\n".join(bitstrings)}
+        options.update(self.qsim_options)
 
-    for prs in param_resolvers:
-      solved_circuit = protocols.resolve_parameters(program, prs)
-      translator_fn = getattr(solved_circuit, translator_fn_name)
-      options['c'] = translator_fn(cirq_order)
-      options['s'] = self.get_seed()
-      amplitudes = simulator_fn(options)
-      trials_results.append(amplitudes)
+        param_resolvers = study.to_resolvers(params)
 
-    return trials_results
+        trials_results = []
+        if _needs_trajectories(program):
+            translator_fn_name = "translate_cirq_to_qtrajectory"
+            simulator_fn = qsim.qtrajectory_simulate
+        else:
+            translator_fn_name = "translate_cirq_to_qsim"
+            simulator_fn = qsim.qsim_simulate
 
-  def simulate_sweep(
-      self,
-      program: circuits.Circuit,
-      params: study.Sweepable,
-      qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
-      initial_state: Optional[Union[int, np.ndarray]] = None,
-  ) -> List['SimulationTrialResult']:
-    """Simulates the supplied Circuit.
+        for prs in param_resolvers:
+            solved_circuit = protocols.resolve_parameters(program, prs)
+            translator_fn = getattr(solved_circuit, translator_fn_name)
+            options["c"] = translator_fn(cirq_order)
+            options["s"] = self.get_seed()
+            amplitudes = simulator_fn(options)
+            trials_results.append(amplitudes)
 
-      This method returns a result which allows access to the entire
-      wave function. In contrast to simulate, this allows for sweeping
-      over different parameter values.
+        return trials_results
 
-      Args:
-          program: The circuit to simulate.
-          params: Parameters to run with the program.
-          qubit_order: Determines the canonical ordering of the qubits. This is
-            often used in specifying the initial state, i.e. the ordering of the
-            computational basis states.
-          initial_state: The initial state for the simulation. This can either
-            be an integer representing a pure state (e.g. 11010) or a numpy
-            array containing the full state vector. If none is provided, this
-            is assumed to be the all-zeros state.
+    def simulate_sweep(
+        self,
+        program: circuits.Circuit,
+        params: study.Sweepable,
+        qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
+        initial_state: Optional[Union[int, np.ndarray]] = None,
+    ) -> List["SimulationTrialResult"]:
+        """Simulates the supplied Circuit.
 
-      Returns:
-          List of SimulationTrialResults for this run, one for each
-          possible parameter resolver.
+        This method returns a result which allows access to the entire
+        wave function. In contrast to simulate, this allows for sweeping
+        over different parameter values.
 
-      Raises:
-          TypeError: if an invalid initial_state is provided.
-      """
-    if initial_state is None:
-      initial_state = 0
-    if not isinstance(initial_state, (int, np.ndarray)):
-      raise TypeError('initial_state must be an int or state vector.')
-    if not isinstance(program, qsimc.QSimCircuit):
-      program = qsimc.QSimCircuit(program, device=program.device)
+        Args:
+            program: The circuit to simulate.
+            params: Parameters to run with the program.
+            qubit_order: Determines the canonical ordering of the qubits. This is
+              often used in specifying the initial state, i.e. the ordering of the
+              computational basis states.
+            initial_state: The initial state for the simulation. This can either
+              be an integer representing a pure state (e.g. 11010) or a numpy
+              array containing the full state vector. If none is provided, this
+              is assumed to be the all-zeros state.
 
-    options = {}
-    options.update(self.qsim_options)
+        Returns:
+            List of SimulationTrialResults for this run, one for each
+            possible parameter resolver.
 
-    param_resolvers = study.to_resolvers(params)
-    # qsim numbers qubits in reverse order from cirq
-    cirq_order = ops.QubitOrder.as_qubit_order(qubit_order).order_for(
-      program.all_qubits())
-    qsim_order = list(reversed(cirq_order))
-    num_qubits = len(qsim_order)
-    if isinstance(initial_state, np.ndarray):
-      if initial_state.dtype != np.complex64:
-        raise TypeError(f'initial_state vector must have dtype np.complex64.')
-      input_vector = initial_state.view(np.float32)
-      if len(input_vector) != 2**num_qubits * 2:
-        raise ValueError(f'initial_state vector size must match number of qubits.'
-          f'Expected: {2**num_qubits * 2} Received: {len(input_vector)}')
+        Raises:
+            TypeError: if an invalid initial_state is provided.
+        """
+        if initial_state is None:
+            initial_state = 0
+        if not isinstance(initial_state, (int, np.ndarray)):
+            raise TypeError("initial_state must be an int or state vector.")
+        if not isinstance(program, qsimc.QSimCircuit):
+            program = qsimc.QSimCircuit(program, device=program.device)
 
-    trials_results = []
-    if _needs_trajectories(program):
-      translator_fn_name = 'translate_cirq_to_qtrajectory'
-      fullstate_simulator_fn = qsim.qtrajectory_simulate_fullstate
-    else:
-      translator_fn_name = 'translate_cirq_to_qsim'
-      fullstate_simulator_fn = qsim.qsim_simulate_fullstate
+        options = {}
+        options.update(self.qsim_options)
 
-    for prs in param_resolvers:
-      solved_circuit = protocols.resolve_parameters(program, prs)
-      translator_fn = getattr(solved_circuit, translator_fn_name)
-      options['c'] = translator_fn(cirq_order)
-      options['s'] = self.get_seed()
-      qubit_map = {
-        qubit: index for index, qubit in enumerate(qsim_order)
-      }
+        param_resolvers = study.to_resolvers(params)
+        # qsim numbers qubits in reverse order from cirq
+        cirq_order = ops.QubitOrder.as_qubit_order(qubit_order).order_for(
+            program.all_qubits()
+        )
+        qsim_order = list(reversed(cirq_order))
+        num_qubits = len(qsim_order)
+        if isinstance(initial_state, np.ndarray):
+            if initial_state.dtype != np.complex64:
+                raise TypeError(f"initial_state vector must have dtype np.complex64.")
+            input_vector = initial_state.view(np.float32)
+            if len(input_vector) != 2 ** num_qubits * 2:
+                raise ValueError(
+                    f"initial_state vector size must match number of qubits."
+                    f"Expected: {2**num_qubits * 2} Received: {len(input_vector)}"
+                )
 
-      if isinstance(initial_state, int):
-        qsim_state = fullstate_simulator_fn(options, initial_state)
-      elif isinstance(initial_state, np.ndarray):
-        qsim_state = fullstate_simulator_fn(options, input_vector)
-      assert qsim_state.dtype == np.float32
-      assert qsim_state.ndim == 1
-      final_state = QSimSimulatorState(qsim_state, qubit_map)
-      # create result for this parameter
-      # TODO: We need to support measurements.
-      result = QSimSimulatorTrialResult(params=prs,
-                                        measurements={},
-                                        final_simulator_state=final_state)
-      trials_results.append(result)
+        trials_results = []
+        if _needs_trajectories(program):
+            translator_fn_name = "translate_cirq_to_qtrajectory"
+            fullstate_simulator_fn = qsim.qtrajectory_simulate_fullstate
+        else:
+            translator_fn_name = "translate_cirq_to_qsim"
+            fullstate_simulator_fn = qsim.qsim_simulate_fullstate
 
-    return trials_results
+        for prs in param_resolvers:
+            solved_circuit = protocols.resolve_parameters(program, prs)
+            translator_fn = getattr(solved_circuit, translator_fn_name)
+            options["c"] = translator_fn(cirq_order)
+            options["s"] = self.get_seed()
+            qubit_map = {qubit: index for index, qubit in enumerate(qsim_order)}
 
-  def simulate_expectation_values_sweep(
-    self,
-    program: 'cirq.Circuit',
-    observables: Union['cirq.PauliSumLike', List['cirq.PauliSumLike']],
-    params: 'study.Sweepable',
-    qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
-    initial_state: Any = None,
-    permit_terminal_measurements: bool = False,
-  ) -> List[List[float]]:
-    """Simulates the supplied circuit and calculates exact expectation
-    values for the given observables on its final state.
+            if isinstance(initial_state, int):
+                qsim_state = fullstate_simulator_fn(options, initial_state)
+            elif isinstance(initial_state, np.ndarray):
+                qsim_state = fullstate_simulator_fn(options, input_vector)
+            assert qsim_state.dtype == np.float32
+            assert qsim_state.ndim == 1
+            final_state = QSimSimulatorState(qsim_state, qubit_map)
+            # create result for this parameter
+            # TODO: We need to support measurements.
+            result = QSimSimulatorTrialResult(
+                params=prs, measurements={}, final_simulator_state=final_state
+            )
+            trials_results.append(result)
 
-    This method has no perfect analogy in hardware. Instead compare with
-    Sampler.sample_expectation_values, which calculates estimated
-    expectation values by sampling multiple times.
+        return trials_results
 
-    Args:
-        program: The circuit to simulate.
-        observables: An observable or list of observables.
-        param_resolver: Parameters to run with the program.
-        qubit_order: Determines the canonical ordering of the qubits. This
-            is often used in specifying the initial state, i.e. the
-            ordering of the computational basis states.
-        initial_state: The initial state for the simulation. The form of
-            this state depends on the simulation implementation. See
-            documentation of the implementing class for details.
-        permit_terminal_measurements: If the provided circuit ends with
-            measurement(s), this method will generate an error unless this
-            is set to True. This is meant to prevent measurements from
-            ruining expectation value calculations.
+    def simulate_expectation_values_sweep(
+        self,
+        program: "cirq.Circuit",
+        observables: Union["cirq.PauliSumLike", List["cirq.PauliSumLike"]],
+        params: "study.Sweepable",
+        qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
+        initial_state: Any = None,
+        permit_terminal_measurements: bool = False,
+    ) -> List[List[float]]:
+        """Simulates the supplied circuit and calculates exact expectation
+        values for the given observables on its final state.
 
-    Returns:
-        A list of expectation values, with the value at index `n`
-        corresponding to `observables[n]` from the input.
+        This method has no perfect analogy in hardware. Instead compare with
+        Sampler.sample_expectation_values, which calculates estimated
+        expectation values by sampling multiple times.
 
-    Raises:
-        ValueError if 'program' has terminal measurement(s) and
-        'permit_terminal_measurements' is False. (Note: We cannot test this
-        until Cirq's `are_any_measurements_terminal` is released.)
-    """
-    if not permit_terminal_measurements and program.are_any_measurements_terminal():
-      raise ValueError(
-        'Provided circuit has terminal measurements, which may '
-        'skew expectation values. If this is intentional, set '
-        'permit_terminal_measurements=True.'
-      )
-    if not isinstance(observables, List):
-      observables = [observables]
-    psumlist = [ops.PauliSum.wrap(pslike) for pslike in observables]
+        Args:
+            program: The circuit to simulate.
+            observables: An observable or list of observables.
+            param_resolver: Parameters to run with the program.
+            qubit_order: Determines the canonical ordering of the qubits. This
+                is often used in specifying the initial state, i.e. the
+                ordering of the computational basis states.
+            initial_state: The initial state for the simulation. The form of
+                this state depends on the simulation implementation. See
+                documentation of the implementing class for details.
+            permit_terminal_measurements: If the provided circuit ends with
+                measurement(s), this method will generate an error unless this
+                is set to True. This is meant to prevent measurements from
+                ruining expectation value calculations.
 
-    cirq_order = ops.QubitOrder.as_qubit_order(qubit_order).order_for(
-      program.all_qubits())
-    qsim_order = list(reversed(cirq_order))
-    num_qubits = len(qsim_order)
-    qubit_map = {qubit: index for index, qubit in enumerate(qsim_order)}
+        Returns:
+            A list of expectation values, with the value at index `n`
+            corresponding to `observables[n]` from the input.
 
-    opsums_and_qubit_counts = []
-    for psum in psumlist:
-      opsum = []
-      opsum_qubits = set()
-      for pstr in psum:
-        opstring = qsim.OpString()
-        opstring.weight = pstr.coefficient
-        for q, pauli in pstr.items():
-          op = pauli.on(q)
-          opsum_qubits.add(q)
-          qsimc.add_op_to_opstring(op, qubit_map, opstring)
-        opsum.append(opstring)
-      opsums_and_qubit_counts.append((opsum, len(opsum_qubits)))
+        Raises:
+            ValueError if 'program' has terminal measurement(s) and
+            'permit_terminal_measurements' is False. (Note: We cannot test this
+            until Cirq's `are_any_measurements_terminal` is released.)
+        """
+        if not permit_terminal_measurements and program.are_any_measurements_terminal():
+            raise ValueError(
+                "Provided circuit has terminal measurements, which may "
+                "skew expectation values. If this is intentional, set "
+                "permit_terminal_measurements=True."
+            )
+        if not isinstance(observables, List):
+            observables = [observables]
+        psumlist = [ops.PauliSum.wrap(pslike) for pslike in observables]
 
-    if initial_state is None:
-      initial_state = 0
-    if not isinstance(initial_state, (int, np.ndarray)):
-      raise TypeError('initial_state must be an int or state vector.')
-    if not isinstance(program, qsimc.QSimCircuit):
-      program = qsimc.QSimCircuit(program, device=program.device)
+        cirq_order = ops.QubitOrder.as_qubit_order(qubit_order).order_for(
+            program.all_qubits()
+        )
+        qsim_order = list(reversed(cirq_order))
+        num_qubits = len(qsim_order)
+        qubit_map = {qubit: index for index, qubit in enumerate(qsim_order)}
 
-    options = {}
-    options.update(self.qsim_options)
+        opsums_and_qubit_counts = []
+        for psum in psumlist:
+            opsum = []
+            opsum_qubits = set()
+            for pstr in psum:
+                opstring = qsim.OpString()
+                opstring.weight = pstr.coefficient
+                for q, pauli in pstr.items():
+                    op = pauli.on(q)
+                    opsum_qubits.add(q)
+                    qsimc.add_op_to_opstring(op, qubit_map, opstring)
+                opsum.append(opstring)
+            opsums_and_qubit_counts.append((opsum, len(opsum_qubits)))
 
-    param_resolvers = study.to_resolvers(params)
-    if isinstance(initial_state, np.ndarray):
-      if initial_state.dtype != np.complex64:
-        raise TypeError(f'initial_state vector must have dtype np.complex64.')
-      input_vector = initial_state.view(np.float32)
-      if len(input_vector) != 2**num_qubits * 2:
-        raise ValueError(f'initial_state vector size must match number of qubits.'
-          f'Expected: {2**num_qubits * 2} Received: {len(input_vector)}')
+        if initial_state is None:
+            initial_state = 0
+        if not isinstance(initial_state, (int, np.ndarray)):
+            raise TypeError("initial_state must be an int or state vector.")
+        if not isinstance(program, qsimc.QSimCircuit):
+            program = qsimc.QSimCircuit(program, device=program.device)
 
-    results = []
-    if _needs_trajectories(program):
-      translator_fn_name = 'translate_cirq_to_qtrajectory'
-      ev_simulator_fn = qsim.qtrajectory_simulate_expectation_values
-    else:
-      translator_fn_name = 'translate_cirq_to_qsim'
-      ev_simulator_fn = qsim.qsim_simulate_expectation_values
+        options = {}
+        options.update(self.qsim_options)
 
-    for prs in param_resolvers:
-      solved_circuit = protocols.resolve_parameters(program, prs)
-      translator_fn = getattr(solved_circuit, translator_fn_name)
-      options['c'] = translator_fn(cirq_order)
-      options['s'] = self.get_seed()
+        param_resolvers = study.to_resolvers(params)
+        if isinstance(initial_state, np.ndarray):
+            if initial_state.dtype != np.complex64:
+                raise TypeError(f"initial_state vector must have dtype np.complex64.")
+            input_vector = initial_state.view(np.float32)
+            if len(input_vector) != 2 ** num_qubits * 2:
+                raise ValueError(
+                    f"initial_state vector size must match number of qubits."
+                    f"Expected: {2**num_qubits * 2} Received: {len(input_vector)}"
+                )
 
-      if isinstance(initial_state, int):
-        evs = ev_simulator_fn(options, opsums_and_qubit_counts, initial_state)
-      elif isinstance(initial_state, np.ndarray):
-        evs = ev_simulator_fn(options, opsums_and_qubit_counts, input_vector)
-      results.append(evs)
+        results = []
+        if _needs_trajectories(program):
+            translator_fn_name = "translate_cirq_to_qtrajectory"
+            ev_simulator_fn = qsim.qtrajectory_simulate_expectation_values
+        else:
+            translator_fn_name = "translate_cirq_to_qsim"
+            ev_simulator_fn = qsim.qsim_simulate_expectation_values
 
-    return results
+        for prs in param_resolvers:
+            solved_circuit = protocols.resolve_parameters(program, prs)
+            translator_fn = getattr(solved_circuit, translator_fn_name)
+            options["c"] = translator_fn(cirq_order)
+            options["s"] = self.get_seed()
+
+            if isinstance(initial_state, int):
+                evs = ev_simulator_fn(options, opsums_and_qubit_counts, initial_state)
+            elif isinstance(initial_state, np.ndarray):
+                evs = ev_simulator_fn(options, opsums_and_qubit_counts, input_vector)
+            results.append(evs)
+
+        return results

--- a/qsimcirq/qsimh_simulator.py
+++ b/qsimcirq/qsimh_simulator.py
@@ -14,61 +14,61 @@
 
 from typing import Union, Sequence
 
-from cirq import study, ops, protocols, circuits, value,  SimulatesAmplitudes
+from cirq import study, ops, protocols, circuits, value, SimulatesAmplitudes
 
 from qsimcirq import qsim
 import qsimcirq.qsim_circuit as qsimc
 
 
 class QSimhSimulator(SimulatesAmplitudes):
+    def __init__(self, qsimh_options: dict = {}):
+        """Creates a new QSimhSimulator using the given options.
 
-  def __init__(self, qsimh_options: dict = {}):
-    """Creates a new QSimhSimulator using the given options.
-    
-    Args:
-        qsim_options: A map of circuit options for the simulator. These will be
-            applied to all circuits run using this simulator. Accepted keys and
-            their behavior are as follows:
-                - 'k': Comma-separated list of ints. Indices of "part 1" qubits.
-                - 'p': int (>= 0). Number of "prefix" gates.
-                - 'r': int (>= 0). Number of "root" gates.
-                - 't': int (> 0). Number of threads to run on. Default: 1.
-                - 'v': int (>= 0). Log verbosity. Default: 0.
-                - 'w': int (>= 0). Prefix value.
-            See qsim/docs/usage.md for more details on these options.
-    """
-    self.qsimh_options = {'t': 1, 'f': 2, 'v': 0}
-    self.qsimh_options.update(qsimh_options)
+        Args:
+            qsim_options: A map of circuit options for the simulator. These will be
+                applied to all circuits run using this simulator. Accepted keys and
+                their behavior are as follows:
+                    - 'k': Comma-separated list of ints. Indices of "part 1" qubits.
+                    - 'p': int (>= 0). Number of "prefix" gates.
+                    - 'r': int (>= 0). Number of "root" gates.
+                    - 't': int (> 0). Number of threads to run on. Default: 1.
+                    - 'v': int (>= 0). Log verbosity. Default: 0.
+                    - 'w': int (>= 0). Prefix value.
+                See qsim/docs/usage.md for more details on these options.
+        """
+        self.qsimh_options = {"t": 1, "f": 2, "v": 0}
+        self.qsimh_options.update(qsimh_options)
 
-  def compute_amplitudes_sweep(
-      self,
-      program: circuits.Circuit,
-      bitstrings: Sequence[int],
-      params: study.Sweepable,
-      qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
-  ) -> Sequence[Sequence[complex]]:
+    def compute_amplitudes_sweep(
+        self,
+        program: circuits.Circuit,
+        bitstrings: Sequence[int],
+        params: study.Sweepable,
+        qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
+    ) -> Sequence[Sequence[complex]]:
 
-    if not isinstance(program, qsimc.QSimCircuit):
-      program = qsimc.QSimCircuit(program, device=program.device)
+        if not isinstance(program, qsimc.QSimCircuit):
+            program = qsimc.QSimCircuit(program, device=program.device)
 
-    n_qubits = len(program.all_qubits())
-    # qsim numbers qubits in reverse order from cirq
-    bitstrings = [format(bitstring, 'b').zfill(n_qubits)[::-1]
-                  for bitstring in bitstrings]
+        n_qubits = len(program.all_qubits())
+        # qsim numbers qubits in reverse order from cirq
+        bitstrings = [
+            format(bitstring, "b").zfill(n_qubits)[::-1] for bitstring in bitstrings
+        ]
 
-    options = {'i': '\n'.join(bitstrings)}
-    options.update(self.qsimh_options)
-    param_resolvers = study.to_resolvers(params)
+        options = {"i": "\n".join(bitstrings)}
+        options.update(self.qsimh_options)
+        param_resolvers = study.to_resolvers(params)
 
-    trials_results = []
-    for prs in param_resolvers:
+        trials_results = []
+        for prs in param_resolvers:
 
-      solved_circuit = protocols.resolve_parameters(program, prs)
+            solved_circuit = protocols.resolve_parameters(program, prs)
 
-      options['c'] = solved_circuit.translate_cirq_to_qsim(qubit_order)
+            options["c"] = solved_circuit.translate_cirq_to_qsim(qubit_order)
 
-      options.update(self.qsimh_options)
-      amplitudes = qsim.qsimh_simulate(options)
-      trials_results.append(amplitudes)
+            options.update(self.qsimh_options)
+            amplitudes = qsim.qsimh_simulate(options)
+            trials_results.append(amplitudes)
 
-    return trials_results
+        return trials_results

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -20,1259 +20,1320 @@ import qsimcirq
 
 
 class NoiseTrigger(cirq.SingleQubitGate):
-  """A no-op gate with no _unitary_ method defined.
-  
-  Appending this gate to a circuit will force it to use qtrajectory, but the
-  new circuit will otherwise behave identically to the original.
-  """
-  # def _mixture_(self):
-  #   return ((1.0, np.asarray([1, 0, 0, 1])),)
+    """A no-op gate with no _unitary_ method defined.
 
-  def _channel_(self):
-    return (np.asarray([1, 0, 0, 1]),)
+    Appending this gate to a circuit will force it to use qtrajectory, but the
+    new circuit will otherwise behave identically to the original.
+    """
+
+    # def _mixture_(self):
+    #   return ((1.0, np.asarray([1, 0, 0, 1])),)
+
+    def _channel_(self):
+        return (np.asarray([1, 0, 0, 1]),)
 
 
 def test_empty_circuit():
-  result = qsimcirq.QSimSimulator().simulate(cirq.Circuit())
-  assert result.final_state_vector.shape == (1,)
+    result = qsimcirq.QSimSimulator().simulate(cirq.Circuit())
+    assert result.final_state_vector.shape == (1,)
 
 
 def test_cirq_too_big_gate():
-  # Pick qubits.
-  a, b, c, d, e, f, g = [
-      cirq.GridQubit(0, 0),
-      cirq.GridQubit(0, 1),
-      cirq.GridQubit(0, 2),
-      cirq.GridQubit(1, 0),
-      cirq.GridQubit(1, 1),
-      cirq.GridQubit(1, 2),
-      cirq.GridQubit(2, 0),
-  ]
+    # Pick qubits.
+    a, b, c, d, e, f, g = [
+        cirq.GridQubit(0, 0),
+        cirq.GridQubit(0, 1),
+        cirq.GridQubit(0, 2),
+        cirq.GridQubit(1, 0),
+        cirq.GridQubit(1, 1),
+        cirq.GridQubit(1, 2),
+        cirq.GridQubit(2, 0),
+    ]
 
-  class BigGate(cirq.Gate):
-    def _num_qubits_(self):
-      return 7
+    class BigGate(cirq.Gate):
+        def _num_qubits_(self):
+            return 7
 
-    def _qid_shape_(self):
-      return (2,) * 7
+        def _qid_shape_(self):
+            return (2,) * 7
 
-    def _unitary_(self):
-      return np.eye(128)
+        def _unitary_(self):
+            return np.eye(128)
 
-  # Create a circuit with a gate larger than 6 qubits.
-  cirq_circuit = cirq.Circuit(BigGate().on(a, b, c, d, e, f, g))
+    # Create a circuit with a gate larger than 6 qubits.
+    cirq_circuit = cirq.Circuit(BigGate().on(a, b, c, d, e, f, g))
 
-  qsimSim = qsimcirq.QSimSimulator()
-  with pytest.raises(NotImplementedError):
-    qsimSim.compute_amplitudes(cirq_circuit, bitstrings=[0b0, 0b1])
+    qsimSim = qsimcirq.QSimSimulator()
+    with pytest.raises(NotImplementedError):
+        qsimSim.compute_amplitudes(cirq_circuit, bitstrings=[0b0, 0b1])
 
 
 def test_cirq_giant_identity():
-  # Pick qubits.
-  a, b, c, d, e, f, g, h = [
-      cirq.GridQubit(0, 0),
-      cirq.GridQubit(0, 1),
-      cirq.GridQubit(0, 2),
-      cirq.GridQubit(1, 0),
-      cirq.GridQubit(1, 1),
-      cirq.GridQubit(1, 2),
-      cirq.GridQubit(2, 0),
-      cirq.GridQubit(2, 1),
-  ]
+    # Pick qubits.
+    a, b, c, d, e, f, g, h = [
+        cirq.GridQubit(0, 0),
+        cirq.GridQubit(0, 1),
+        cirq.GridQubit(0, 2),
+        cirq.GridQubit(1, 0),
+        cirq.GridQubit(1, 1),
+        cirq.GridQubit(1, 2),
+        cirq.GridQubit(2, 0),
+        cirq.GridQubit(2, 1),
+    ]
 
-  # Create a circuit with a gate larger than 6 qubits.
-  cirq_circuit = cirq.Circuit(
-    cirq.IdentityGate(7).on(a, b, c, d, e, f, g),
-    cirq.X(h),
-  )
+    # Create a circuit with a gate larger than 6 qubits.
+    cirq_circuit = cirq.Circuit(
+        cirq.IdentityGate(7).on(a, b, c, d, e, f, g),
+        cirq.X(h),
+    )
 
-  no_id_circuit = cirq.Circuit(cirq.X(h))
-  qsimSim = qsimcirq.QSimSimulator()
+    no_id_circuit = cirq.Circuit(cirq.X(h))
+    qsimSim = qsimcirq.QSimSimulator()
 
-  assert (
-    qsimSim.simulate(cirq_circuit) ==
-    qsimSim.simulate(no_id_circuit, qubit_order=[a,b,c,d,e,f,g,h])
-  )
+    assert qsimSim.simulate(cirq_circuit) == qsimSim.simulate(
+        no_id_circuit, qubit_order=[a, b, c, d, e, f, g, h]
+    )
 
 
-@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+@pytest.mark.parametrize("mode", ["noiseless", "noisy"])
 def test_cirq_qsim_simulate(mode: str):
-  # Pick qubits.
-  a, b, c, d = [
-      cirq.GridQubit(0, 0),
-      cirq.GridQubit(0, 1),
-      cirq.GridQubit(1, 1),
-      cirq.GridQubit(1, 0)
-  ]
+    # Pick qubits.
+    a, b, c, d = [
+        cirq.GridQubit(0, 0),
+        cirq.GridQubit(0, 1),
+        cirq.GridQubit(1, 1),
+        cirq.GridQubit(1, 0),
+    ]
 
-  # Create a circuit
-  cirq_circuit = cirq.Circuit(
-      cirq.X(a)**0.5,  # Square root of X.
-      cirq.Y(b)**0.5,  # Square root of Y.
-      cirq.Z(c),  # Z.
-      cirq.CZ(a, d)  # ControlZ.
-  )
+    # Create a circuit
+    cirq_circuit = cirq.Circuit(
+        cirq.X(a) ** 0.5,  # Square root of X.
+        cirq.Y(b) ** 0.5,  # Square root of Y.
+        cirq.Z(c),  # Z.
+        cirq.CZ(a, d),  # ControlZ.
+    )
 
-  if mode == 'noisy':
-    cirq_circuit.append(NoiseTrigger().on(a))
+    if mode == "noisy":
+        cirq_circuit.append(NoiseTrigger().on(a))
 
-  qsimSim = qsimcirq.QSimSimulator()
-  result = qsimSim.compute_amplitudes(
-      cirq_circuit, bitstrings=[0b0100, 0b1011])
-  assert np.allclose(result, [0.5j, 0j])
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.compute_amplitudes(cirq_circuit, bitstrings=[0b0100, 0b1011])
+    assert np.allclose(result, [0.5j, 0j])
 
 
-@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+@pytest.mark.parametrize("mode", ["noiseless", "noisy"])
 def test_cirq_qsim_simulate_fullstate(mode: str):
-  # Pick qubits.
-  a, b, c, d = [
-      cirq.GridQubit(0, 0),
-      cirq.GridQubit(0, 1),
-      cirq.GridQubit(1, 1),
-      cirq.GridQubit(1, 0)
-  ]
+    # Pick qubits.
+    a, b, c, d = [
+        cirq.GridQubit(0, 0),
+        cirq.GridQubit(0, 1),
+        cirq.GridQubit(1, 1),
+        cirq.GridQubit(1, 0),
+    ]
 
-  # Create a circuit.
-  cirq_circuit = cirq.Circuit(
-      cirq.Moment([
-          cirq.X(a)**0.5,  # Square root of X.
-          cirq.H(b),       # Hadamard.
-          cirq.X(c),       # X.
-          cirq.H(d),       # Hadamard.
-      ]),
-      cirq.Moment([
-          cirq.X(a)**0.5,  # Square root of X.
-          cirq.CX(b, c),   # ControlX.
-          cirq.S(d),       # S (square root of Z).
-      ]),
-      cirq.Moment([
-          cirq.I(a),
-          cirq.ISWAP(b, c),
-      ])
-  )
+    # Create a circuit.
+    cirq_circuit = cirq.Circuit(
+        cirq.Moment(
+            cirq.X(a) ** 0.5,  # Square root of X.
+            cirq.H(b),  # Hadamard.
+            cirq.X(c),  # X.
+            cirq.H(d),  # Hadamard.
+        ),
+        cirq.Moment(
+            cirq.X(a) ** 0.5,  # Square root of X.
+            cirq.CX(b, c),  # ControlX.
+            cirq.S(d),  # S (square root of Z).
+        ),
+        cirq.Moment(
+            cirq.I(a),
+            cirq.ISWAP(b, c),
+        ),
+    )
 
-  if mode == 'noisy':
-    cirq_circuit.append(NoiseTrigger().on(a))
+    if mode == "noisy":
+        cirq_circuit.append(NoiseTrigger().on(a))
 
-  qsimSim = qsimcirq.QSimSimulator()
-  result = qsimSim.simulate(cirq_circuit, qubit_order=[a, b, c, d])
-  assert result.state_vector().shape == (16,)
-  cirqSim = cirq.Simulator()
-  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=[a, b, c, d])
-  # When using rotation gates such as S, qsim may add a global phase relative
-  # to other simulators. This is fine, as the result is equivalent.
-  assert cirq.linalg.allclose_up_to_global_phase(
-      result.state_vector(), cirq_result.state_vector())
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=[a, b, c, d])
+    assert result.state_vector().shape == (16,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=[a, b, c, d])
+    # When using rotation gates such as S, qsim may add a global phase relative
+    # to other simulators. This is fine, as the result is equivalent.
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector()
+    )
 
 
-@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+@pytest.mark.parametrize("mode", ["noiseless", "noisy"])
 def test_cirq_qsim_simulate_sweep(mode: str):
-  # Pick qubits.
-  a, b = [
-      cirq.GridQubit(0, 0),
-      cirq.GridQubit(0, 1),
-  ]
-  x = sympy.Symbol('x')
+    # Pick qubits.
+    a, b = [
+        cirq.GridQubit(0, 0),
+        cirq.GridQubit(0, 1),
+    ]
+    x = sympy.Symbol("x")
 
-  # Create a circuit.
-  cirq_circuit = cirq.Circuit(
-      cirq.Moment([
-          cirq.X(a)**x,
-          cirq.H(b),       # Hadamard.
-      ]),
-      cirq.Moment([
-          cirq.CX(a, b),   # ControlX.
-      ]),
-  )
+    # Create a circuit.
+    cirq_circuit = cirq.Circuit(
+        cirq.Moment(
+            cirq.X(a) ** x,
+            cirq.H(b),  # Hadamard.
+        ),
+        cirq.Moment(
+            cirq.CX(a, b),  # ControlX.
+        ),
+    )
 
-  if mode == 'noisy':
-    cirq_circuit.append(NoiseTrigger().on(a))
+    if mode == "noisy":
+        cirq_circuit.append(NoiseTrigger().on(a))
 
-  params = [{x: 0.25}, {x: 0.5}, {x: 0.75}]
-  qsimSim = qsimcirq.QSimSimulator()
-  qsim_result = qsimSim.simulate_sweep(cirq_circuit, params)
-  cirqSim = cirq.Simulator()
-  cirq_result = cirqSim.simulate_sweep(cirq_circuit, params)
+    params = [{x: 0.25}, {x: 0.5}, {x: 0.75}]
+    qsimSim = qsimcirq.QSimSimulator()
+    qsim_result = qsimSim.simulate_sweep(cirq_circuit, params)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate_sweep(cirq_circuit, params)
 
-  for i in range(len(qsim_result)):
-    assert cirq.linalg.allclose_up_to_global_phase(
-      qsim_result[i].state_vector(), cirq_result[i].state_vector())
+    for i in range(len(qsim_result)):
+        assert cirq.linalg.allclose_up_to_global_phase(
+            qsim_result[i].state_vector(), cirq_result[i].state_vector()
+        )
 
-  # initial_state supports bitstrings.
-  qsim_result = qsimSim.simulate_sweep(cirq_circuit, params,
-                                        initial_state=0b01)
-  cirq_result = cirqSim.simulate_sweep(cirq_circuit, params,
-                                        initial_state=0b01)
-  for i in range(len(qsim_result)):
-    assert cirq.linalg.allclose_up_to_global_phase(
-      qsim_result[i].state_vector(), cirq_result[i].state_vector())
+    # initial_state supports bitstrings.
+    qsim_result = qsimSim.simulate_sweep(cirq_circuit, params, initial_state=0b01)
+    cirq_result = cirqSim.simulate_sweep(cirq_circuit, params, initial_state=0b01)
+    for i in range(len(qsim_result)):
+        assert cirq.linalg.allclose_up_to_global_phase(
+            qsim_result[i].state_vector(), cirq_result[i].state_vector()
+        )
 
-  # initial_state supports state vectors.
-  initial_state = np.asarray([0.5j, 0.5, -0.5j, -0.5], dtype=np.complex64)
-  qsim_result = qsimSim.simulate_sweep(
-    cirq_circuit, params, initial_state=initial_state)
-  cirq_result = cirqSim.simulate_sweep(
-    cirq_circuit, params, initial_state=initial_state)
-  for i in range(len(qsim_result)):
-    assert cirq.linalg.allclose_up_to_global_phase(
-      qsim_result[i].state_vector(), cirq_result[i].state_vector())
+    # initial_state supports state vectors.
+    initial_state = np.asarray([0.5j, 0.5, -0.5j, -0.5], dtype=np.complex64)
+    qsim_result = qsimSim.simulate_sweep(
+        cirq_circuit, params, initial_state=initial_state
+    )
+    cirq_result = cirqSim.simulate_sweep(
+        cirq_circuit, params, initial_state=initial_state
+    )
+    for i in range(len(qsim_result)):
+        assert cirq.linalg.allclose_up_to_global_phase(
+            qsim_result[i].state_vector(), cirq_result[i].state_vector()
+        )
 
 
 def test_input_vector_validation():
-  cirq_circuit = cirq.Circuit(
-    cirq.X(cirq.LineQubit(0)), cirq.X(cirq.LineQubit(1))
-  )
-  params = [{}]
-  qsimSim = qsimcirq.QSimSimulator()
+    cirq_circuit = cirq.Circuit(cirq.X(cirq.LineQubit(0)), cirq.X(cirq.LineQubit(1)))
+    params = [{}]
+    qsimSim = qsimcirq.QSimSimulator()
 
-  with pytest.raises(ValueError):
-    initial_state = np.asarray([0.25]*16, dtype=np.complex64)
-    qsim_result = qsimSim.simulate_sweep(
-      cirq_circuit, params, initial_state=initial_state)
+    with pytest.raises(ValueError):
+        initial_state = np.asarray([0.25] * 16, dtype=np.complex64)
+        qsim_result = qsimSim.simulate_sweep(
+            cirq_circuit, params, initial_state=initial_state
+        )
 
-  with pytest.raises(TypeError):
-    initial_state = np.asarray([0.5]*4)
-    qsim_result = qsimSim.simulate_sweep(
-      cirq_circuit, params, initial_state=initial_state)
+    with pytest.raises(TypeError):
+        initial_state = np.asarray([0.5] * 4)
+        qsim_result = qsimSim.simulate_sweep(
+            cirq_circuit, params, initial_state=initial_state
+        )
 
 
 def test_numpy_params():
-  q0 = cirq.LineQubit(0)
-  x, y = sympy.Symbol('x'), sympy.Symbol('y')
-  circuit = cirq.Circuit(cirq.X(q0) ** x, cirq.H(q0) ** y)
-  prs = [{x: np.int64(0), y: np.int64(1)}, {x: np.int64(1), y: np.int64(0)}]
+    q0 = cirq.LineQubit(0)
+    x, y = sympy.Symbol("x"), sympy.Symbol("y")
+    circuit = cirq.Circuit(cirq.X(q0) ** x, cirq.H(q0) ** y)
+    prs = [{x: np.int64(0), y: np.int64(1)}, {x: np.int64(1), y: np.int64(0)}]
 
-  qsim_simulator = qsimcirq.QSimSimulator()
-  qsim_result = qsim_simulator.simulate_sweep(circuit, params=prs)
+    qsim_simulator = qsimcirq.QSimSimulator()
+    qsim_result = qsim_simulator.simulate_sweep(circuit, params=prs)
 
 
 def test_invalid_params():
-  # Parameters must have numeric values.
-  q0 = cirq.LineQubit(0)
-  x, y = sympy.Symbol('x'), sympy.Symbol('y')
-  circuit = cirq.Circuit(cirq.X(q0) ** x, cirq.H(q0) ** y)
-  prs = [{x: np.int64(0), y: np.int64(1)}, {x: np.int64(1), y: 'z'}]
+    # Parameters must have numeric values.
+    q0 = cirq.LineQubit(0)
+    x, y = sympy.Symbol("x"), sympy.Symbol("y")
+    circuit = cirq.Circuit(cirq.X(q0) ** x, cirq.H(q0) ** y)
+    prs = [{x: np.int64(0), y: np.int64(1)}, {x: np.int64(1), y: "z"}]
 
-  qsim_simulator = qsimcirq.QSimSimulator()
-  with pytest.raises(ValueError, match='Parameters must be numeric'):
-    _ = qsim_simulator.simulate_sweep(circuit, params=prs)
+    qsim_simulator = qsimcirq.QSimSimulator()
+    with pytest.raises(ValueError, match="Parameters must be numeric"):
+        _ = qsim_simulator.simulate_sweep(circuit, params=prs)
 
 
 def test_iterable_qubit_order():
-  # Check to confirm that iterable qubit_order works in all cases.
-  q0, q1 = cirq.LineQubit.range(2)
-  circuit = cirq.Circuit(
-    cirq.H(q0), cirq.H(q1),
-  )
-  qsim_simulator = qsimcirq.QSimSimulator()
+    # Check to confirm that iterable qubit_order works in all cases.
+    q0, q1 = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.H(q0),
+        cirq.H(q1),
+    )
+    qsim_simulator = qsimcirq.QSimSimulator()
 
-  assert qsim_simulator.compute_amplitudes(
-    circuit,
-    bitstrings=[0b00, 0b01],
-    qubit_order=reversed([q1, q0]),
-  ) == qsim_simulator.compute_amplitudes(circuit, bitstrings=[0b00, 0b01])
+    assert (
+        qsim_simulator.compute_amplitudes(
+            circuit,
+            bitstrings=[0b00, 0b01],
+            qubit_order=reversed([q1, q0]),
+        )
+        == qsim_simulator.compute_amplitudes(circuit, bitstrings=[0b00, 0b01])
+    )
 
-  assert (
-    qsim_simulator.simulate(circuit, qubit_order=reversed([q1, q0])) ==
-    qsim_simulator.simulate(circuit)
-  )
+    assert qsim_simulator.simulate(
+        circuit, qubit_order=reversed([q1, q0])
+    ) == qsim_simulator.simulate(circuit)
 
-  assert qsim_simulator.simulate_expectation_values_sweep(
-    circuit,
-    observables=[cirq.X(q0) * cirq.Z(q1)],
-    params={},
-    qubit_order=reversed([q1, q0]),
-    permit_terminal_measurements=True,
-  ) == qsim_simulator.simulate_expectation_values_sweep(
-    circuit,
-    observables=[cirq.X(q0) * cirq.Z(q1)],
-    params={},
-    permit_terminal_measurements=True,
-  )
+    assert qsim_simulator.simulate_expectation_values_sweep(
+        circuit,
+        observables=[cirq.X(q0) * cirq.Z(q1)],
+        params={},
+        qubit_order=reversed([q1, q0]),
+        permit_terminal_measurements=True,
+    ) == qsim_simulator.simulate_expectation_values_sweep(
+        circuit,
+        observables=[cirq.X(q0) * cirq.Z(q1)],
+        params={},
+        permit_terminal_measurements=True,
+    )
 
 
-@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+@pytest.mark.parametrize("mode", ["noiseless", "noisy"])
 def test_preserve_qubits(mode: str):
-  # Check to confirm that qubits in qubit_order appear in the result.
-  q = cirq.LineQubit.range(2)
-  circuit = cirq.Circuit(cirq.X(q[0]))
-  if mode == 'noisy':
-    circuit.append(NoiseTrigger().on(q[0]))
-  circuit_with_id = circuit + cirq.I(q[1])
-  qsim_simulator = qsimcirq.QSimSimulator()
-  order_result = qsim_simulator.simulate(circuit, qubit_order=q)
-  id_result = qsim_simulator.simulate(circuit_with_id)
+    # Check to confirm that qubits in qubit_order appear in the result.
+    q = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(cirq.X(q[0]))
+    if mode == "noisy":
+        circuit.append(NoiseTrigger().on(q[0]))
+    circuit_with_id = circuit + cirq.I(q[1])
+    qsim_simulator = qsimcirq.QSimSimulator()
+    order_result = qsim_simulator.simulate(circuit, qubit_order=q)
+    id_result = qsim_simulator.simulate(circuit_with_id)
 
-  assert order_result == id_result
-  assert order_result.final_state_vector.shape == (4,)
+    assert order_result == id_result
+    assert order_result.final_state_vector.shape == (4,)
 
 
-@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+@pytest.mark.parametrize("mode", ["noiseless", "noisy"])
 def test_cirq_qsim_run(mode: str):
-  # Pick qubits.
-  a, b, c, d = [
-      cirq.GridQubit(0, 0),
-      cirq.GridQubit(0, 1),
-      cirq.GridQubit(1, 1),
-      cirq.GridQubit(1, 0)
-  ]
-  # Create a circuit
-  cirq_circuit = cirq.Circuit(
-      cirq.X(a)**0.5,  # Square root of X.
-      cirq.Y(b)**0.5,  # Square root of Y.
-      cirq.Z(c),  # Z.
-      cirq.CZ(a, d),  # ControlZ.
-      # measure qubits
-      cirq.measure(a, key='ma'),
-      cirq.measure(b, key='mb'),
-      cirq.measure(c, key='mc'),
-      cirq.measure(d, key='md'),
-  )
-  if mode == 'noisy':
-    cirq_circuit.append(NoiseTrigger().on(a))
+    # Pick qubits.
+    a, b, c, d = [
+        cirq.GridQubit(0, 0),
+        cirq.GridQubit(0, 1),
+        cirq.GridQubit(1, 1),
+        cirq.GridQubit(1, 0),
+    ]
+    # Create a circuit
+    cirq_circuit = cirq.Circuit(
+        cirq.X(a) ** 0.5,  # Square root of X.
+        cirq.Y(b) ** 0.5,  # Square root of Y.
+        cirq.Z(c),  # Z.
+        cirq.CZ(a, d),  # ControlZ.
+        # measure qubits
+        cirq.measure(a, key="ma"),
+        cirq.measure(b, key="mb"),
+        cirq.measure(c, key="mc"),
+        cirq.measure(d, key="md"),
+    )
+    if mode == "noisy":
+        cirq_circuit.append(NoiseTrigger().on(a))
 
-  qsimSim = qsimcirq.QSimSimulator()
-  assert isinstance(qsimSim, cirq.SimulatesSamples)
+    qsimSim = qsimcirq.QSimSimulator()
+    assert isinstance(qsimSim, cirq.SimulatesSamples)
 
-  result = qsimSim.run(cirq_circuit, repetitions=5)
-  for key, value in result.measurements.items():
-    assert(value.shape == (5, 1))
+    result = qsimSim.run(cirq_circuit, repetitions=5)
+    for key, value in result.measurements.items():
+        assert value.shape == (5, 1)
 
 
-@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+@pytest.mark.parametrize("mode", ["noiseless", "noisy"])
 def test_qsim_run_vs_cirq_run(mode: str):
-  # Simple circuit, want to check mapping of qubit(s) to their measurements
-  a, b, c, d = [
-    cirq.GridQubit(0, 0),
-    cirq.GridQubit(0, 1),
-    cirq.GridQubit(1, 0),
-    cirq.GridQubit(1, 1),
-  ]
-  circuit = cirq.Circuit(
-      cirq.X(b),
-      cirq.CX(b, d),
-      cirq.measure(a, b, c, key='mabc'),
-      cirq.measure(d, key='md'),
-  )
+    # Simple circuit, want to check mapping of qubit(s) to their measurements
+    a, b, c, d = [
+        cirq.GridQubit(0, 0),
+        cirq.GridQubit(0, 1),
+        cirq.GridQubit(1, 0),
+        cirq.GridQubit(1, 1),
+    ]
+    circuit = cirq.Circuit(
+        cirq.X(b),
+        cirq.CX(b, d),
+        cirq.measure(a, b, c, key="mabc"),
+        cirq.measure(d, key="md"),
+    )
 
-  if mode == 'noisy':
-    circuit.append(NoiseTrigger().on(a))
+    if mode == "noisy":
+        circuit.append(NoiseTrigger().on(a))
 
-  # run in cirq
-  simulator = cirq.Simulator()
-  cirq_result = simulator.run(circuit, repetitions=20)
+    # run in cirq
+    simulator = cirq.Simulator()
+    cirq_result = simulator.run(circuit, repetitions=20)
 
-  # run in qsim
-  qsim_simulator = qsimcirq.QSimSimulator()
-  qsim_result = qsim_simulator.run(circuit, repetitions=20)
+    # run in qsim
+    qsim_simulator = qsimcirq.QSimSimulator()
+    qsim_result = qsim_simulator.run(circuit, repetitions=20)
 
-  # are they the same?
-  assert(qsim_result == cirq_result)
+    # are they the same?
+    assert qsim_result == cirq_result
 
 
-@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+@pytest.mark.parametrize("mode", ["noiseless", "noisy"])
 def test_expectation_values(mode: str):
-  a, b = [
-    cirq.GridQubit(0, 0),
-    cirq.GridQubit(0, 1),
-  ]
-  x_exp = sympy.Symbol('x_exp')
-  h_exp = sympy.Symbol('h_exp')
-  circuit = cirq.Circuit(
-    cirq.X(a) ** x_exp, cirq.H(b),
-    cirq.H(a) ** h_exp, cirq.H(b) ** h_exp,
-  )
-  params = [
-    {x_exp: 0, h_exp: 0},  # |0+)
-    {x_exp: 1, h_exp: 0},  # |1+)
-    {x_exp: 0, h_exp: 1},  # |+0)
-    {x_exp: 1, h_exp: 1},  # |-0)
-  ]
-  psum1 = cirq.Z(a) + 3 * cirq.X(b)
-  psum2 = cirq.X(a) - 3 * cirq.Z(b)
+    a, b = [
+        cirq.GridQubit(0, 0),
+        cirq.GridQubit(0, 1),
+    ]
+    x_exp = sympy.Symbol("x_exp")
+    h_exp = sympy.Symbol("h_exp")
+    circuit = cirq.Circuit(
+        cirq.X(a) ** x_exp,
+        cirq.H(b),
+        cirq.H(a) ** h_exp,
+        cirq.H(b) ** h_exp,
+    )
+    params = [
+        {x_exp: 0, h_exp: 0},  # |0+)
+        {x_exp: 1, h_exp: 0},  # |1+)
+        {x_exp: 0, h_exp: 1},  # |+0)
+        {x_exp: 1, h_exp: 1},  # |-0)
+    ]
+    psum1 = cirq.Z(a) + 3 * cirq.X(b)
+    psum2 = cirq.X(a) - 3 * cirq.Z(b)
 
-  if mode == 'noisy':
-    circuit.append(NoiseTrigger().on(a))
+    if mode == "noisy":
+        circuit.append(NoiseTrigger().on(a))
 
-  qsim_simulator = qsimcirq.QSimSimulator()
-  qsim_result = qsim_simulator.simulate_expectation_values_sweep(
-    circuit, [psum1, psum2], params)
+    qsim_simulator = qsimcirq.QSimSimulator()
+    qsim_result = qsim_simulator.simulate_expectation_values_sweep(
+        circuit, [psum1, psum2], params
+    )
 
-  cirq_simulator = cirq.Simulator()
-  cirq_result = cirq_simulator.simulate_expectation_values_sweep(
-    circuit, [psum1, psum2], params)
+    cirq_simulator = cirq.Simulator()
+    cirq_result = cirq_simulator.simulate_expectation_values_sweep(
+        circuit, [psum1, psum2], params
+    )
 
-  assert cirq.approx_eq(qsim_result, cirq_result, atol=1e-6)
+    assert cirq.approx_eq(qsim_result, cirq_result, atol=1e-6)
 
 
 def test_expectation_values_terminal_measurement_check():
-  a, b = [
-    cirq.GridQubit(0, 0),
-    cirq.GridQubit(0, 1),
-  ]
-  circuit = cirq.Circuit(
-    cirq.X(a), cirq.H(b),
-    cirq.measure(a, b, key='m')
-  )
-  psum = cirq.Z(a) + 3 * cirq.X(b)
+    a, b = [
+        cirq.GridQubit(0, 0),
+        cirq.GridQubit(0, 1),
+    ]
+    circuit = cirq.Circuit(cirq.X(a), cirq.H(b), cirq.measure(a, b, key="m"))
+    psum = cirq.Z(a) + 3 * cirq.X(b)
 
-  qsim_simulator = qsimcirq.QSimSimulator()
-  with pytest.raises(ValueError, match='Provided circuit has terminal measurements'):
-    _ = qsim_simulator.simulate_expectation_values(circuit, [psum])
+    qsim_simulator = qsimcirq.QSimSimulator()
+    with pytest.raises(ValueError, match="Provided circuit has terminal measurements"):
+        _ = qsim_simulator.simulate_expectation_values(circuit, [psum])
 
-  # permit_terminal_measurements disables the error.
-  qsim_simulator.simulate_expectation_values(
-    circuit, [psum], permit_terminal_measurements=True)
+    # permit_terminal_measurements disables the error.
+    qsim_simulator.simulate_expectation_values(
+        circuit, [psum], permit_terminal_measurements=True
+    )
 
 
-@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+@pytest.mark.parametrize("mode", ["noiseless", "noisy"])
 def test_intermediate_measure(mode: str):
-  # Demonstrate that intermediate measurement is possible.
-  a, b = [
-    cirq.GridQubit(0, 0),
-    cirq.GridQubit(0, 1),
-  ]
-  circuit = cirq.Circuit(
-    cirq.X(a), cirq.CX(a, b), cirq.measure(a, b, key='m1'),
-    cirq.CZ(a, b), cirq.measure(a, b, key='m2'),
-    cirq.X(a), cirq.CX(a, b), cirq.measure(a, b, key='m3'),
-    # Trailing gates with no measurement do not affect results.
-    cirq.H(a), cirq.H(b),
-  )
+    # Demonstrate that intermediate measurement is possible.
+    a, b = [
+        cirq.GridQubit(0, 0),
+        cirq.GridQubit(0, 1),
+    ]
+    circuit = cirq.Circuit(
+        cirq.X(a),
+        cirq.CX(a, b),
+        cirq.measure(a, b, key="m1"),
+        cirq.CZ(a, b),
+        cirq.measure(a, b, key="m2"),
+        cirq.X(a),
+        cirq.CX(a, b),
+        cirq.measure(a, b, key="m3"),
+        # Trailing gates with no measurement do not affect results.
+        cirq.H(a),
+        cirq.H(b),
+    )
 
-  if mode == 'noisy':
-    circuit.append(NoiseTrigger().on(a))
+    if mode == "noisy":
+        circuit.append(NoiseTrigger().on(a))
 
-  simulator = cirq.Simulator()
-  cirq_result = simulator.run(circuit, repetitions=20)
+    simulator = cirq.Simulator()
+    cirq_result = simulator.run(circuit, repetitions=20)
 
-  qsim_simulator = qsimcirq.QSimSimulator()
-  qsim_result = qsim_simulator.run(circuit, repetitions=20)
+    qsim_simulator = qsimcirq.QSimSimulator()
+    qsim_result = qsim_simulator.run(circuit, repetitions=20)
 
-  assert(qsim_result == cirq_result)
+    assert qsim_result == cirq_result
 
 
-@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+@pytest.mark.parametrize("mode", ["noiseless", "noisy"])
 def test_sampling_nondeterminism(mode: str):
-  # Ensure that reusing a QSimSimulator doesn't reuse the original seed.
-  q = cirq.GridQubit(0, 0)
-  circuit = cirq.Circuit(cirq.H(q), cirq.measure(q, key='m'))
-  if mode == 'noisy':
-    circuit.append(NoiseTrigger().on(q))
+    # Ensure that reusing a QSimSimulator doesn't reuse the original seed.
+    q = cirq.GridQubit(0, 0)
+    circuit = cirq.Circuit(cirq.H(q), cirq.measure(q, key="m"))
+    if mode == "noisy":
+        circuit.append(NoiseTrigger().on(q))
 
-  qsim_simulator = qsimcirq.QSimSimulator()
-  qsim_result = qsim_simulator.run(circuit, repetitions=100)
+    qsim_simulator = qsimcirq.QSimSimulator()
+    qsim_result = qsim_simulator.run(circuit, repetitions=100)
 
-  result_counts = qsim_result.histogram(key='m')
-  assert(result_counts[0] > 1)
-  assert(result_counts[1] > 1)
+    result_counts = qsim_result.histogram(key="m")
+    assert result_counts[0] > 1
+    assert result_counts[1] > 1
 
 
 def test_matrix1_gate():
-  q = cirq.LineQubit(0)
-  m = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
+    q = cirq.LineQubit(0)
+    m = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
 
-  cirq_circuit = cirq.Circuit(cirq.MatrixGate(m).on(q))
-  qsimSim = qsimcirq.QSimSimulator()
-  result = qsimSim.simulate(cirq_circuit)
-  assert result.state_vector().shape == (2,)
-  cirqSim = cirq.Simulator()
-  cirq_result = cirqSim.simulate(cirq_circuit)
-  assert cirq.linalg.allclose_up_to_global_phase(
-      result.state_vector(), cirq_result.state_vector())
+    cirq_circuit = cirq.Circuit(cirq.MatrixGate(m).on(q))
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit)
+    assert result.state_vector().shape == (2,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector()
+    )
 
 
 def test_matrix2_gate():
-  qubits = cirq.LineQubit.range(2)
-  m = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+    qubits = cirq.LineQubit.range(2)
+    m = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
 
-  cirq_circuit = cirq.Circuit(cirq.MatrixGate(m).on(*qubits))
-  qsimSim = qsimcirq.QSimSimulator()
-  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert result.state_vector().shape == (4,)
-  cirqSim = cirq.Simulator()
-  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert cirq.linalg.allclose_up_to_global_phase(
-      result.state_vector(), cirq_result.state_vector())
+    cirq_circuit = cirq.Circuit(cirq.MatrixGate(m).on(*qubits))
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (4,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector()
+    )
 
 
 def test_big_matrix_gates():
-  qubits = cirq.LineQubit.range(3)
-  # Toffoli gate as a matrix.
-  m = np.array([
-    [1, 0, 0, 0, 0, 0, 0, 0],
-    [0, 1, 0, 0, 0, 0, 0, 0],
-    [0, 0, 1, 0, 0, 0, 0, 0],
-    [0, 0, 0, 1, 0, 0, 0, 0],
-    [0, 0, 0, 0, 1, 0, 0, 0],
-    [0, 0, 0, 0, 0, 1, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 1],
-    [0, 0, 0, 0, 0, 0, 1, 0],
-  ])
+    qubits = cirq.LineQubit.range(3)
+    # Toffoli gate as a matrix.
+    m = np.array(
+        [
+            [1, 0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0, 0, 0, 0],
+            [0, 0, 1, 0, 0, 0, 0, 0],
+            [0, 0, 0, 1, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1, 0, 0, 0],
+            [0, 0, 0, 0, 0, 1, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, 1, 0],
+        ]
+    )
 
-  cirq_circuit = cirq.Circuit(
-    cirq.H(qubits[0]), cirq.H(qubits[1]),
-    cirq.MatrixGate(m).on(*qubits),
-  )
-  qsimSim = qsimcirq.QSimSimulator()
-  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert result.state_vector().shape == (8,)
-  cirqSim = cirq.Simulator()
-  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert cirq.linalg.allclose_up_to_global_phase(
-      result.state_vector(), cirq_result.state_vector())
+    cirq_circuit = cirq.Circuit(
+        cirq.H(qubits[0]),
+        cirq.H(qubits[1]),
+        cirq.MatrixGate(m).on(*qubits),
+    )
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (8,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector()
+    )
 
 
 def test_decompose_to_matrix_gates():
+    class UnknownThreeQubitGate(cirq.ops.Gate):
+        """This gate is not recognized by qsim, and cannot be decomposed.
 
-  class UnknownThreeQubitGate(cirq.ops.Gate):
-    """This gate is not recognized by qsim, and cannot be decomposed.
-    
-    qsim should attempt to convert it to a MatrixGate to resolve the issue.
-    """
-    def __init__(self):
-      pass
+        qsim should attempt to convert it to a MatrixGate to resolve the issue.
+        """
 
-    def _num_qubits_(self):
-      return 3
+        def __init__(self):
+            pass
 
-    def _qid_shape_(self):
-      return (2, 2, 2)
+        def _num_qubits_(self):
+            return 3
 
-    def _unitary_(self):
-      # Toffoli gate as a matrix.
-      return np.array([
-        [1, 0, 0, 0, 0, 0, 0, 0],
-        [0, 1, 0, 0, 0, 0, 0, 0],
-        [0, 0, 1, 0, 0, 0, 0, 0],
-        [0, 0, 0, 1, 0, 0, 0, 0],
-        [0, 0, 0, 0, 1, 0, 0, 0],
-        [0, 0, 0, 0, 0, 1, 0, 0],
-        [0, 0, 0, 0, 0, 0, 0, 1],
-        [0, 0, 0, 0, 0, 0, 1, 0],
-      ])
+        def _qid_shape_(self):
+            return (2, 2, 2)
 
-  qubits = cirq.LineQubit.range(3)
-  cirq_circuit = cirq.Circuit(
-    cirq.H(qubits[0]), cirq.H(qubits[1]),
-    UnknownThreeQubitGate().on(*qubits),
-  )
-  qsimSim = qsimcirq.QSimSimulator()
-  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert result.state_vector().shape == (8,)
-  cirqSim = cirq.Simulator()
-  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert cirq.linalg.allclose_up_to_global_phase(
-      result.state_vector(), cirq_result.state_vector())
+        def _unitary_(self):
+            # Toffoli gate as a matrix.
+            return np.array(
+                [
+                    [1, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 1],
+                    [0, 0, 0, 0, 0, 0, 1, 0],
+                ]
+            )
+
+    qubits = cirq.LineQubit.range(3)
+    cirq_circuit = cirq.Circuit(
+        cirq.H(qubits[0]),
+        cirq.H(qubits[1]),
+        UnknownThreeQubitGate().on(*qubits),
+    )
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (8,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector()
+    )
 
 
 def test_basic_controlled_gate():
-  qubits = cirq.LineQubit.range(3)
+    qubits = cirq.LineQubit.range(3)
 
-  cirq_circuit = cirq.Circuit(
-    cirq.H(qubits[1]), cirq.Y(qubits[2]),
-    cirq.X(qubits[0]).controlled_by(qubits[1]),
-    cirq.CX(*qubits[1:]).controlled_by(qubits[0]),
-    cirq.H(qubits[1]).controlled_by(qubits[0], qubits[2]),
-  )
-  qsimSim = qsimcirq.QSimSimulator()
-  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert result.state_vector().shape == (8,)
-  cirqSim = cirq.Simulator()
-  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert cirq.linalg.allclose_up_to_global_phase(
-      result.state_vector(), cirq_result.state_vector())
+    cirq_circuit = cirq.Circuit(
+        cirq.H(qubits[1]),
+        cirq.Y(qubits[2]),
+        cirq.X(qubits[0]).controlled_by(qubits[1]),
+        cirq.CX(*qubits[1:]).controlled_by(qubits[0]),
+        cirq.H(qubits[1]).controlled_by(qubits[0], qubits[2]),
+    )
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (8,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector()
+    )
 
 
 def test_controlled_matrix_gates():
-  qubits = cirq.LineQubit.range(4)
-  m1 = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
-  m2 = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+    qubits = cirq.LineQubit.range(4)
+    m1 = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
+    m2 = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
 
-  cirq_circuit = cirq.Circuit(
-    cirq.MatrixGate(m1).on(qubits[0]).controlled_by(qubits[3]),
-    cirq.MatrixGate(m2).on(*qubits[1:3]).controlled_by(qubits[0]),
-    cirq.MatrixGate(m1).on(qubits[2]).controlled_by(qubits[0], qubits[1],
-                                                    qubits[3]),
-    cirq.MatrixGate(m2).on(qubits[0], qubits[3]).controlled_by(*qubits[1:3]),
-  )
-  qsimSim = qsimcirq.QSimSimulator()
-  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert result.state_vector().shape == (16,)
-  cirqSim = cirq.Simulator()
-  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert cirq.linalg.allclose_up_to_global_phase(
-      result.state_vector(), cirq_result.state_vector())
+    cirq_circuit = cirq.Circuit(
+        cirq.MatrixGate(m1).on(qubits[0]).controlled_by(qubits[3]),
+        cirq.MatrixGate(m2).on(*qubits[1:3]).controlled_by(qubits[0]),
+        cirq.MatrixGate(m1)
+        .on(qubits[2])
+        .controlled_by(qubits[0], qubits[1], qubits[3]),
+        cirq.MatrixGate(m2).on(qubits[0], qubits[3]).controlled_by(*qubits[1:3]),
+    )
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (16,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector()
+    )
 
 
 def test_control_values():
-  qubits = cirq.LineQubit.range(3)
+    qubits = cirq.LineQubit.range(3)
 
-  cirq_circuit = cirq.Circuit(
-    # Controlled by |01) state on qubits 1 and 2
-    cirq.X(qubits[0]).controlled_by(*qubits[1:], control_values=[0, 1]),
-    # Controlled by either |0) or |1) on qubit 0 (i.e., uncontrolled)
-    cirq.X(qubits[1]).controlled_by(qubits[0], control_values=[(0, 1)]),
-    # Controlled by |10) state on qubits 0 and 1
-    cirq.X(qubits[2]).controlled_by(qubits[1], qubits[0],
-                                    control_values=[0, 1]),
-  )
-  qsimSim = qsimcirq.QSimSimulator()
-  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert result.state_vector().shape == (8,)
-  cirqSim = cirq.Simulator()
-  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert cirq.linalg.allclose_up_to_global_phase(
-      result.state_vector(), cirq_result.state_vector())
-
-  qubits = cirq.LineQid.for_qid_shape([2, 3, 2])
-  cirq_circuit = cirq.Circuit(
-    # Controlled by |12) state on qubits 0 and 1
-    # Since qsim does not support qudits (yet), this gate is omitted.
-    cirq.X(qubits[2]).controlled_by(*qubits[:2], control_values=[1, 2]),
-  )
-  qsimSim = qsimcirq.QSimSimulator()
-  with pytest.warns(RuntimeWarning, match='Gate has no valid control value'):
+    cirq_circuit = cirq.Circuit(
+        # Controlled by |01) state on qubits 1 and 2
+        cirq.X(qubits[0]).controlled_by(*qubits[1:], control_values=[0, 1]),
+        # Controlled by either |0) or |1) on qubit 0 (i.e., uncontrolled)
+        cirq.X(qubits[1]).controlled_by(qubits[0], control_values=[(0, 1)]),
+        # Controlled by |10) state on qubits 0 and 1
+        cirq.X(qubits[2]).controlled_by(qubits[1], qubits[0], control_values=[0, 1]),
+    )
+    qsimSim = qsimcirq.QSimSimulator()
     result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert result.state_vector()[0] == 1
+    assert result.state_vector().shape == (8,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector()
+    )
+
+    qubits = cirq.LineQid.for_qid_shape([2, 3, 2])
+    cirq_circuit = cirq.Circuit(
+        # Controlled by |12) state on qubits 0 and 1
+        # Since qsim does not support qudits (yet), this gate is omitted.
+        cirq.X(qubits[2]).controlled_by(*qubits[:2], control_values=[1, 2]),
+    )
+    qsimSim = qsimcirq.QSimSimulator()
+    with pytest.warns(RuntimeWarning, match="Gate has no valid control value"):
+        result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector()[0] == 1
 
 
 def test_decomposable_gate():
-  qubits = cirq.LineQubit.range(4)
+    qubits = cirq.LineQubit.range(4)
 
-  # The Toffoli gate (CCX) decomposes into multiple qsim-supported gates.
-  cirq_circuit = cirq.Circuit(
-      cirq.H(qubits[0]),
-      cirq.H(qubits[1]),
-      cirq.Moment(
-        cirq.CCX(*qubits[:3]),
+    # The Toffoli gate (CCX) decomposes into multiple qsim-supported gates.
+    cirq_circuit = cirq.Circuit(
+        cirq.H(qubits[0]),
+        cirq.H(qubits[1]),
+        cirq.Moment(
+            cirq.CCX(*qubits[:3]),
+            cirq.H(qubits[3]),
+        ),
+        cirq.H(qubits[2]),
         cirq.H(qubits[3]),
-      ),
-      cirq.H(qubits[2]),
-      cirq.H(qubits[3]),
-  )
+    )
 
-  qsimSim = qsimcirq.QSimSimulator()
-  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert result.state_vector().shape == (16,)
-  cirqSim = cirq.Simulator()
-  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-  # Decomposition may result in gates which add a global phase.
-  assert cirq.linalg.allclose_up_to_global_phase(
-      result.state_vector(), cirq_result.state_vector())
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (16,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    # Decomposition may result in gates which add a global phase.
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector()
+    )
 
 
 def test_complicated_decomposition():
-  qubits = cirq.LineQubit.range(4)
+    qubits = cirq.LineQubit.range(4)
 
-  # The QFT gate decomposes cleanly into the qsim gateset.
-  cirq_circuit = cirq.Circuit(
-      cirq.QuantumFourierTransformGate(4).on(*qubits))
+    # The QFT gate decomposes cleanly into the qsim gateset.
+    cirq_circuit = cirq.Circuit(cirq.QuantumFourierTransformGate(4).on(*qubits))
 
-  qsimSim = qsimcirq.QSimSimulator()
-  result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert result.state_vector().shape == (16,)
-  cirqSim = cirq.Simulator()
-  cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
-  # Decomposition may result in gates which add a global phase.
-  assert cirq.linalg.allclose_up_to_global_phase(
-      result.state_vector(), cirq_result.state_vector())
+    qsimSim = qsimcirq.QSimSimulator()
+    result = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert result.state_vector().shape == (16,)
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate(cirq_circuit, qubit_order=qubits)
+    # Decomposition may result in gates which add a global phase.
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result.state_vector(), cirq_result.state_vector()
+    )
 
 
 # Helper class for noisy circuit tests.
 class NoiseStep(cirq.Gate):
-  def __init__(self, matrix, num_qubits=1):
-    self._matrix = matrix
-    self._num_qubits = num_qubits
+    def __init__(self, matrix, num_qubits=1):
+        self._matrix = matrix
+        self._num_qubits = num_qubits
 
-  def _num_qubits_(self):
-    return self._num_qubits
+    def _num_qubits_(self):
+        return self._num_qubits
 
-  def _unitary_(self):
-    # Not necessarily a unitary.
-    return self._matrix
+    def _unitary_(self):
+        # Not necessarily a unitary.
+        return self._matrix
 
-  def __str__(self):
-    return f'NoiseStep({self._matrix})'
+    def __str__(self):
+        return f"NoiseStep({self._matrix})"
 
-  def __repr__(self):
-    return str(self)
+    def __repr__(self):
+        return str(self)
 
 
 def test_mixture_simulation():
-  q0, q1 = cirq.LineQubit.range(2)
-  pflip = cirq.phase_flip(p=0.4)
-  bflip = cirq.bit_flip(p=0.6)
-  cirq_circuit = cirq.Circuit(
-    cirq.X(q0) ** 0.5, cirq.X(q1) ** 0.5,
-    pflip.on(q0),
-    bflip.on(q1),
-  )
+    q0, q1 = cirq.LineQubit.range(2)
+    pflip = cirq.phase_flip(p=0.4)
+    bflip = cirq.bit_flip(p=0.6)
+    cirq_circuit = cirq.Circuit(
+        cirq.X(q0) ** 0.5,
+        cirq.X(q1) ** 0.5,
+        pflip.on(q0),
+        bflip.on(q1),
+    )
 
-  possible_circuits = [
-    cirq.Circuit(cirq.X(q0) ** 0.5, cirq.X(q1) ** 0.5, pf, bf)
-    # Extract the operators from the mixtures to construct trajectories.
-    for pf in [NoiseStep(m).on(q0) for m in cirq.channel(pflip)]
-    for bf in [NoiseStep(m).on(q1) for m in cirq.channel(bflip)]
-  ]
-  possible_states = [
-    cirq.Simulator().simulate(pc).state_vector()
-    for pc in possible_circuits
-  ]
-  # Since some "gates" were non-unitary, we must normalize.
-  possible_states = [ps / np.linalg.norm(ps) for ps in possible_states]
+    possible_circuits = [
+        cirq.Circuit(cirq.X(q0) ** 0.5, cirq.X(q1) ** 0.5, pf, bf)
+        # Extract the operators from the mixtures to construct trajectories.
+        for pf in [NoiseStep(m).on(q0) for m in cirq.channel(pflip)]
+        for bf in [NoiseStep(m).on(q1) for m in cirq.channel(bflip)]
+    ]
+    possible_states = [
+        cirq.Simulator().simulate(pc).state_vector() for pc in possible_circuits
+    ]
+    # Since some "gates" were non-unitary, we must normalize.
+    possible_states = [ps / np.linalg.norm(ps) for ps in possible_states]
 
-  # Minimize flaky tests with a fixed seed.
-  qsimSim = qsimcirq.QSimSimulator(seed=1)
-  result_hist = [0] * len(possible_states)
-  run_count = 100
-  for _ in range(run_count):
-    result = qsimSim.simulate(cirq_circuit, qubit_order=[q0, q1])
-    for i, ps in enumerate(possible_states):
-      if cirq.allclose_up_to_global_phase(result.state_vector(), ps):
-        result_hist[i] += 1
-        break
+    # Minimize flaky tests with a fixed seed.
+    qsimSim = qsimcirq.QSimSimulator(seed=1)
+    result_hist = [0] * len(possible_states)
+    run_count = 100
+    for _ in range(run_count):
+        result = qsimSim.simulate(cirq_circuit, qubit_order=[q0, q1])
+        for i, ps in enumerate(possible_states):
+            if cirq.allclose_up_to_global_phase(result.state_vector(), ps):
+                result_hist[i] += 1
+                break
 
-  # Each observed result should match one of the possible_results.
-  assert sum(result_hist) == run_count
-  # Over 100 runs, it's reasonable to expect all four outcomes.
-  assert all(result_count > 0 for result_count in result_hist)
+    # Each observed result should match one of the possible_results.
+    assert sum(result_hist) == run_count
+    # Over 100 runs, it's reasonable to expect all four outcomes.
+    assert all(result_count > 0 for result_count in result_hist)
 
 
 def test_channel_simulation():
-  q0, q1 = cirq.LineQubit.range(2)
-  # These probabilities are set unreasonably high in order to reduce the number
-  # of runs required to observe every possible operator.
-  amp_damp = cirq.amplitude_damp(gamma=0.5)
-  gen_amp_damp = cirq.generalized_amplitude_damp(p=0.4, gamma=0.6)
-  cirq_circuit = cirq.Circuit(
-    cirq.X(q0) ** 0.5, cirq.X(q1) ** 0.5,
-    amp_damp.on(q0), gen_amp_damp.on(q1),
-  )
+    q0, q1 = cirq.LineQubit.range(2)
+    # These probabilities are set unreasonably high in order to reduce the number
+    # of runs required to observe every possible operator.
+    amp_damp = cirq.amplitude_damp(gamma=0.5)
+    gen_amp_damp = cirq.generalized_amplitude_damp(p=0.4, gamma=0.6)
+    cirq_circuit = cirq.Circuit(
+        cirq.X(q0) ** 0.5,
+        cirq.X(q1) ** 0.5,
+        amp_damp.on(q0),
+        gen_amp_damp.on(q1),
+    )
 
-  possible_circuits = [
-    cirq.Circuit(cirq.X(q0) ** 0.5, cirq.X(q1) ** 0.5, ad, gad)
-    # Extract the operators from the channels to construct trajectories.
-    for ad in [NoiseStep(m).on(q0) for m in cirq.channel(amp_damp)]
-    for gad in [NoiseStep(m).on(q1) for m in cirq.channel(gen_amp_damp)]
-  ]
-  possible_states = [
-    cirq.Simulator().simulate(pc).state_vector()
-    for pc in possible_circuits
-  ]
-  # Since some "gates" were non-unitary, we must normalize.
-  possible_states = [ps / np.linalg.norm(ps) for ps in possible_states]
+    possible_circuits = [
+        cirq.Circuit(cirq.X(q0) ** 0.5, cirq.X(q1) ** 0.5, ad, gad)
+        # Extract the operators from the channels to construct trajectories.
+        for ad in [NoiseStep(m).on(q0) for m in cirq.channel(amp_damp)]
+        for gad in [NoiseStep(m).on(q1) for m in cirq.channel(gen_amp_damp)]
+    ]
+    possible_states = [
+        cirq.Simulator().simulate(pc).state_vector() for pc in possible_circuits
+    ]
+    # Since some "gates" were non-unitary, we must normalize.
+    possible_states = [ps / np.linalg.norm(ps) for ps in possible_states]
 
-  # Minimize flaky tests with a fixed seed.
-  qsimSim = qsimcirq.QSimSimulator(seed=1)
-  result_hist = [0] * len(possible_states)
-  run_count = 200
-  for _ in range(run_count):
-    result = qsimSim.simulate(cirq_circuit, qubit_order=[q0, q1])
-    for i, ps in enumerate(possible_states):
-      if cirq.allclose_up_to_global_phase(result.state_vector(), ps):
-        result_hist[i] += 1
-        break
+    # Minimize flaky tests with a fixed seed.
+    qsimSim = qsimcirq.QSimSimulator(seed=1)
+    result_hist = [0] * len(possible_states)
+    run_count = 200
+    for _ in range(run_count):
+        result = qsimSim.simulate(cirq_circuit, qubit_order=[q0, q1])
+        for i, ps in enumerate(possible_states):
+            if cirq.allclose_up_to_global_phase(result.state_vector(), ps):
+                result_hist[i] += 1
+                break
 
-  # Each observed result should match one of the possible_results.
-  assert sum(result_hist) == run_count
-  # Over 200 runs, it's reasonable to expect all eight outcomes.
-  assert all(result_count > 0 for result_count in result_hist)
+    # Each observed result should match one of the possible_results.
+    assert sum(result_hist) == run_count
+    # Over 200 runs, it's reasonable to expect all eight outcomes.
+    assert all(result_count > 0 for result_count in result_hist)
 
 
 # Helper class for multi-qubit noisy circuit tests.
 class NoiseChannel(cirq.Gate):
-  def __init__(self, *prob_mat_pairs, num_qubits=1):
-    self._prob_op_pairs = [
-      (prob, NoiseStep(m, num_qubits)) for prob, m in prob_mat_pairs
-    ]
-    self._num_qubits = num_qubits
+    def __init__(self, *prob_mat_pairs, num_qubits=1):
+        self._prob_op_pairs = [
+            (prob, NoiseStep(m, num_qubits)) for prob, m in prob_mat_pairs
+        ]
+        self._num_qubits = num_qubits
 
-  def _num_qubits_(self):
-    return self._num_qubits
+    def _num_qubits_(self):
+        return self._num_qubits
 
-  def _channel_(self):
-    return [cirq.unitary(op) for _, op, in self._prob_op_pairs]
+    def _channel_(self):
+        return [cirq.unitary(op) for _, op, in self._prob_op_pairs]
 
-  def steps(self):
-    return [m for _, m in self._prob_op_pairs]
+    def steps(self):
+        return [m for _, m in self._prob_op_pairs]
 
-  def __str__(self):
-    return f'NoiseChannel({self._ops})'
+    def __str__(self):
+        return f"NoiseChannel({self._ops})"
 
-  def __repr__(self):
-    return str(self)
+    def __repr__(self):
+        return str(self)
+
 
 # Helper class for multi-qubit noisy circuit tests.
 class NoiseMixture(NoiseChannel):
-  def __init__(self, *args, **kwargs):
-    super().__init__(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-  def _mixture_(self):
-    return [(prob, cirq.unitary(op)) for prob, op, in self._prob_op_pairs]
+    def _mixture_(self):
+        return [(prob, cirq.unitary(op)) for prob, op, in self._prob_op_pairs]
 
 
-@pytest.mark.parametrize('cx_qubits', [
-  [cirq.LineQubit(0), cirq.LineQubit(1)],
-  [cirq.LineQubit(0), cirq.LineQubit(2)],
-  [cirq.LineQubit(1), cirq.LineQubit(0)],
-  [cirq.LineQubit(1), cirq.LineQubit(2)],
-  [cirq.LineQubit(2), cirq.LineQubit(0)],
-  [cirq.LineQubit(2), cirq.LineQubit(1)],
-])
-@pytest.mark.parametrize('noise_type', [NoiseMixture, NoiseChannel])
+@pytest.mark.parametrize(
+    "cx_qubits",
+    [
+        [cirq.LineQubit(0), cirq.LineQubit(1)],
+        [cirq.LineQubit(0), cirq.LineQubit(2)],
+        [cirq.LineQubit(1), cirq.LineQubit(0)],
+        [cirq.LineQubit(1), cirq.LineQubit(2)],
+        [cirq.LineQubit(2), cirq.LineQubit(0)],
+        [cirq.LineQubit(2), cirq.LineQubit(1)],
+    ],
+)
+@pytest.mark.parametrize("noise_type", [NoiseMixture, NoiseChannel])
 def test_multi_qubit_noise(cx_qubits, noise_type):
-  # Tests that noise across multiple qubits works correctly.
-  qs = cirq.LineQubit.range(3)
-  for q in qs:
-    if q not in cx_qubits:
-      q_no_cx = q
-      break
+    # Tests that noise across multiple qubits works correctly.
+    qs = cirq.LineQubit.range(3)
+    for q in qs:
+        if q not in cx_qubits:
+            q_no_cx = q
+            break
 
-  ambiguous_cx = noise_type(
-    # CX(*cx_qubits)
-    (
-      0.5,  # prob
-      np.asarray([
-        1, 0, 0, 0,
-        0, 0, 0, 0,
-        0, 0, 0, 1,
-        0, 0, 0, 0,
-      ]) / np.sqrt(2),
-    ),
-    # CX(*cx_qubits)
-    (
-      0.5,  # prob
-      np.asarray([
-        0, 0, 0, 0,
-        0, 1, 0, 0,
-        0, 0, 0, 0,
-        0, 0, 1, 0,
-      ]) / np.sqrt(2),
-    ),
-    num_qubits=2,
-  )
-  cirq_circuit = cirq.Circuit(
-    cirq.X(cx_qubits[0]) ** 0.5, cirq.X(q_no_cx),
-    ambiguous_cx.on(*cx_qubits),
-  )
+    # fmt: off
+    ambiguous_cx = noise_type(
+        # CX(*cx_qubits)
+        (
+            0.5,  # prob
+            np.asarray([
+                1, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 1,
+                0, 0, 0, 0,
+            ]) / np.sqrt(2),
+        ),
+        # CX(*cx_qubits)
+        (
+            0.5,  # prob
+            np.asarray([
+                0, 0, 0, 0,
+                0, 1, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 1, 0,
+            ]) / np.sqrt(2),
+        ),
+        num_qubits=2,
+    )
+    # fmt: on
+    cirq_circuit = cirq.Circuit(
+        cirq.X(cx_qubits[0]) ** 0.5,
+        cirq.X(q_no_cx),
+        ambiguous_cx.on(*cx_qubits),
+    )
 
-  possible_circuits = [
-    cirq.Circuit(cirq.X(cx_qubits[0]) ** 0.5, cirq.X(q_no_cx), cx)
-    # Extract the operators from the mixture to construct trajectories.
-    for cx in [step.on(*cx_qubits) for step in ambiguous_cx.steps()]
-  ]
-  possible_states = [
-    cirq.Simulator().simulate(pc).state_vector()
-    for pc in possible_circuits
-  ]
-  # Since some "gates" were non-unitary, we must normalize.
-  possible_states = [ps / np.linalg.norm(ps) for ps in possible_states]
+    possible_circuits = [
+        cirq.Circuit(cirq.X(cx_qubits[0]) ** 0.5, cirq.X(q_no_cx), cx)
+        # Extract the operators from the mixture to construct trajectories.
+        for cx in [step.on(*cx_qubits) for step in ambiguous_cx.steps()]
+    ]
+    possible_states = [
+        cirq.Simulator().simulate(pc).state_vector() for pc in possible_circuits
+    ]
+    # Since some "gates" were non-unitary, we must normalize.
+    possible_states = [ps / np.linalg.norm(ps) for ps in possible_states]
 
-  # Minimize flaky tests with a fixed seed.
-  qsimSim = qsimcirq.QSimSimulator(seed=1)
-  result_hist = [0] * len(possible_states)
-  run_count = 20
-  for _ in range(run_count):
-    result = qsimSim.simulate(cirq_circuit, qubit_order=qs)
-    for i, ps in enumerate(possible_states):
-      if cirq.allclose_up_to_global_phase(result.state_vector(), ps):
-        result_hist[i] += 1
-        break
+    # Minimize flaky tests with a fixed seed.
+    qsimSim = qsimcirq.QSimSimulator(seed=1)
+    result_hist = [0] * len(possible_states)
+    run_count = 20
+    for _ in range(run_count):
+        result = qsimSim.simulate(cirq_circuit, qubit_order=qs)
+        for i, ps in enumerate(possible_states):
+            if cirq.allclose_up_to_global_phase(result.state_vector(), ps):
+                result_hist[i] += 1
+                break
 
-  # Each observed result should match one of the possible_results.
-  assert sum(result_hist) == run_count
-  # Over 20 runs, it's reasonable to expect both outcomes.
-  assert all(result_count > 0 for result_count in result_hist)
+    # Each observed result should match one of the possible_results.
+    assert sum(result_hist) == run_count
+    # Over 20 runs, it's reasonable to expect both outcomes.
+    assert all(result_count > 0 for result_count in result_hist)
 
 
 def test_noise_aggregation():
-  q0 = cirq.LineQubit(0)
-  # damp_prob is set high to minimize test variance.
-  # Even with this setting, estimation of states and expectation values from
-  # noisy circuits is highly variable, so this test uses wide tolerances.
-  damp_prob = 0.4
-  circuit = cirq.Circuit(
-    cirq.X(q0), cirq.amplitude_damp(gamma=damp_prob).on(q0),
-  )
-  psum1 = cirq.Z(q0)
-  psum2 = cirq.X(q0)
+    q0 = cirq.LineQubit(0)
+    # damp_prob is set high to minimize test variance.
+    # Even with this setting, estimation of states and expectation values from
+    # noisy circuits is highly variable, so this test uses wide tolerances.
+    damp_prob = 0.4
+    circuit = cirq.Circuit(
+        cirq.X(q0),
+        cirq.amplitude_damp(gamma=damp_prob).on(q0),
+    )
+    psum1 = cirq.Z(q0)
+    psum2 = cirq.X(q0)
 
-  # Test expectation value aggregation over repetitions of a noisy circuit.
-  # Repetitions are handled in C++, so overhead costs are minimal.
-  qsim_simulator = qsimcirq.QSimSimulator(qsim_options={"r": 10000}, seed=1)
-  qsim_evs = qsim_simulator.simulate_expectation_values(circuit, [psum1, psum2])
-  assert len(qsim_evs) == 2
+    # Test expectation value aggregation over repetitions of a noisy circuit.
+    # Repetitions are handled in C++, so overhead costs are minimal.
+    qsim_simulator = qsimcirq.QSimSimulator(qsim_options={"r": 10000}, seed=1)
+    qsim_evs = qsim_simulator.simulate_expectation_values(circuit, [psum1, psum2])
+    assert len(qsim_evs) == 2
 
-  # <Z> = (-1) * (probability of |1>) + 1 * (probability of |0>)
-  # For damp_prob = 0.4, <Z> == -0.2
-  damped_zval = damp_prob - (1 - damp_prob)
-  expected_evs = [damped_zval, 0]
-  assert cirq.approx_eq(qsim_evs, expected_evs, atol=0.05)
+    # <Z> = (-1) * (probability of |1>) + 1 * (probability of |0>)
+    # For damp_prob = 0.4, <Z> == -0.2
+    damped_zval = damp_prob - (1 - damp_prob)
+    expected_evs = [damped_zval, 0]
+    assert cirq.approx_eq(qsim_evs, expected_evs, atol=0.05)
 
 
 def test_multi_qubit_fusion():
-  q0, q1, q2, q3 = cirq.LineQubit.range(4)
-  qubits = [q0, q1, q2, q3]
-  cirq_circuit = cirq.Circuit(
-    cirq.CX(q0, q1), cirq.X(q2)**0.5, cirq.Y(q3)**0.5,
-    cirq.CX(q0, q2), cirq.T(q1), cirq.T(q3),
-    cirq.CX(q1, q2), cirq.X(q3)**0.5, cirq.Y(q0)**0.5,
-    cirq.CX(q1, q3), cirq.T(q0), cirq.T(q2),
-    cirq.CX(q2, q3), cirq.X(q0)**0.5, cirq.Y(q1)**0.5,
-  )
+    q0, q1, q2, q3 = cirq.LineQubit.range(4)
+    qubits = [q0, q1, q2, q3]
+    cirq_circuit = cirq.Circuit(
+        cirq.CX(q0, q1),
+        cirq.X(q2) ** 0.5,
+        cirq.Y(q3) ** 0.5,
+        cirq.CX(q0, q2),
+        cirq.T(q1),
+        cirq.T(q3),
+        cirq.CX(q1, q2),
+        cirq.X(q3) ** 0.5,
+        cirq.Y(q0) ** 0.5,
+        cirq.CX(q1, q3),
+        cirq.T(q0),
+        cirq.T(q2),
+        cirq.CX(q2, q3),
+        cirq.X(q0) ** 0.5,
+        cirq.Y(q1) ** 0.5,
+    )
 
-  qsimSim = qsimcirq.QSimSimulator(qsim_options={'f': 2})
-  result_2q_fusion = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    qsimSim = qsimcirq.QSimSimulator(qsim_options={"f": 2})
+    result_2q_fusion = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
 
-  qsimSim = qsimcirq.QSimSimulator(qsim_options={'f': 4})
-  result_4q_fusion = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
-  assert cirq.linalg.allclose_up_to_global_phase(
-      result_2q_fusion.state_vector(), result_4q_fusion.state_vector())
+    qsimSim = qsimcirq.QSimSimulator(qsim_options={"f": 4})
+    result_4q_fusion = qsimSim.simulate(cirq_circuit, qubit_order=qubits)
+    assert cirq.linalg.allclose_up_to_global_phase(
+        result_2q_fusion.state_vector(), result_4q_fusion.state_vector()
+    )
 
 
-@pytest.mark.parametrize('mode', ['noiseless', 'noisy'])
+@pytest.mark.parametrize("mode", ["noiseless", "noisy"])
 def test_cirq_qsim_simulate_random_unitary(mode: str):
 
-  q0, q1 = cirq.LineQubit.range(2)
-  qsimSim = qsimcirq.QSimSimulator(qsim_options={'t': 16, 'v': 0})
-  for iter in range(10):
-      random_circuit = cirq.testing.random_circuit(qubits=[q0, q1],
-                                                    n_moments=8,
-                                                    op_density=0.99,
-                                                    random_state=iter)
+    q0, q1 = cirq.LineQubit.range(2)
+    qsimSim = qsimcirq.QSimSimulator(qsim_options={"t": 16, "v": 0})
+    for iter in range(10):
+        random_circuit = cirq.testing.random_circuit(
+            qubits=[q0, q1], n_moments=8, op_density=0.99, random_state=iter
+        )
 
-      cirq.ConvertToCzAndSingleGates().optimize_circuit(random_circuit) # cannot work with params
-      cirq.ExpandComposite().optimize_circuit(random_circuit)
-      if mode == 'noisy':
-        random_circuit.append(NoiseTrigger().on(q0))
+        cirq.ConvertToCzAndSingleGates().optimize_circuit(
+            random_circuit
+        )  # cannot work with params
+        cirq.ExpandComposite().optimize_circuit(random_circuit)
+        if mode == "noisy":
+            random_circuit.append(NoiseTrigger().on(q0))
 
-      result = qsimSim.simulate(random_circuit, qubit_order=[q0, q1])
-      assert result.state_vector().shape == (4,)
+        result = qsimSim.simulate(random_circuit, qubit_order=[q0, q1])
+        assert result.state_vector().shape == (4,)
 
-      cirqSim = cirq.Simulator()
-      cirq_result = cirqSim.simulate(random_circuit, qubit_order=[q0, q1])
-      # When using rotation gates such as S, qsim may add a global phase relative
-      # to other simulators. This is fine, as the result is equivalent.
-      assert cirq.linalg.allclose_up_to_global_phase(
-          result.state_vector(),
-          cirq_result.state_vector(),
-          atol = 1.e-6
-      )
+        cirqSim = cirq.Simulator()
+        cirq_result = cirqSim.simulate(random_circuit, qubit_order=[q0, q1])
+        # When using rotation gates such as S, qsim may add a global phase relative
+        # to other simulators. This is fine, as the result is equivalent.
+        assert cirq.linalg.allclose_up_to_global_phase(
+            result.state_vector(), cirq_result.state_vector(), atol=1.0e-6
+        )
 
 
 def test_cirq_qsimh_simulate():
-  # Pick qubits.
-  a, b = [cirq.GridQubit(0, 0), cirq.GridQubit(0, 1)]
+    # Pick qubits.
+    a, b = [cirq.GridQubit(0, 0), cirq.GridQubit(0, 1)]
 
-  # Create a circuit
-  cirq_circuit = cirq.Circuit(cirq.CNOT(a, b), cirq.CNOT(b, a), cirq.X(a))
+    # Create a circuit
+    cirq_circuit = cirq.Circuit(cirq.CNOT(a, b), cirq.CNOT(b, a), cirq.X(a))
 
-  qsimh_options = {'k': [0], 'w': 0, 'p': 1, 'r': 1}
-  qsimhSim = qsimcirq.QSimhSimulator(qsimh_options)
-  result = qsimhSim.compute_amplitudes(
-      cirq_circuit, bitstrings=[0b00, 0b01, 0b10, 0b11])
-  assert np.allclose(result, [0j, 0j, (1 + 0j), 0j])
+    qsimh_options = {"k": [0], "w": 0, "p": 1, "r": 1}
+    qsimhSim = qsimcirq.QSimhSimulator(qsimh_options)
+    result = qsimhSim.compute_amplitudes(
+        cirq_circuit, bitstrings=[0b00, 0b01, 0b10, 0b11]
+    )
+    assert np.allclose(result, [0j, 0j, (1 + 0j), 0j])
 
 
 def test_cirq_qsim_params():
-  qubit = cirq.GridQubit(0,0)
+    qubit = cirq.GridQubit(0, 0)
 
-  circuit = cirq.Circuit(cirq.X(qubit)**sympy.Symbol("beta"))
-  params = cirq.ParamResolver({'beta': 0.5})
+    circuit = cirq.Circuit(cirq.X(qubit) ** sympy.Symbol("beta"))
+    params = cirq.ParamResolver({"beta": 0.5})
 
-  simulator = cirq.Simulator()
-  cirq_result = simulator.simulate(circuit, param_resolver = params)
+    simulator = cirq.Simulator()
+    cirq_result = simulator.simulate(circuit, param_resolver=params)
 
-  qsim_simulator = qsimcirq.QSimSimulator()
-  qsim_result = qsim_simulator.simulate(circuit, param_resolver = params)
+    qsim_simulator = qsimcirq.QSimSimulator()
+    qsim_result = qsim_simulator.simulate(circuit, param_resolver=params)
 
-  assert cirq.linalg.allclose_up_to_global_phase(
-      qsim_result.state_vector(), cirq_result.state_vector())
+    assert cirq.linalg.allclose_up_to_global_phase(
+        qsim_result.state_vector(), cirq_result.state_vector()
+    )
 
 
 def test_cirq_qsim_all_supported_gates():
-  q0 = cirq.GridQubit(1, 1)
-  q1 = cirq.GridQubit(1, 0)
-  q2 = cirq.GridQubit(0, 1)
-  q3 = cirq.GridQubit(0, 0)
+    q0 = cirq.GridQubit(1, 1)
+    q1 = cirq.GridQubit(1, 0)
+    q2 = cirq.GridQubit(0, 1)
+    q3 = cirq.GridQubit(0, 0)
 
-  circuit = cirq.Circuit(
-    cirq.Moment([
-      cirq.H(q0),
-      cirq.H(q1),
-      cirq.H(q2),
-      cirq.H(q3),
-    ]),
-    cirq.Moment([
-      cirq.T(q0),
-      cirq.T(q1),
-      cirq.T(q2),
-      cirq.T(q3),
-    ]),
-    cirq.Moment([
-      cirq.CZPowGate(exponent=0.7, global_shift=0.2)(q0, q1),
-      cirq.CXPowGate(exponent=1.2, global_shift=0.4)(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.XPowGate(exponent=0.3, global_shift=1.1)(q0),
-      cirq.YPowGate(exponent=0.4, global_shift=1)(q1),
-      cirq.ZPowGate(exponent=0.5, global_shift=0.9)(q2),
-      cirq.HPowGate(exponent=0.6, global_shift=0.8)(q3),
-    ]),
-    cirq.Moment([
-      cirq.CX(q0, q2),
-      cirq.CZ(q1, q3),
-    ]),
-    cirq.Moment([
-      cirq.X(q0),
-      cirq.Y(q1),
-      cirq.Z(q2),
-      cirq.S(q3),
-    ]),
-    cirq.Moment([
-      cirq.XXPowGate(exponent=0.4, global_shift=0.7)(q0, q1),
-      cirq.YYPowGate(exponent=0.8, global_shift=0.5)(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.I(q0),
-      cirq.I(q1),
-      cirq.IdentityGate(2)(q2, q3)
-    ]),
-    cirq.Moment([
-      cirq.rx(0.7)(q0),
-      cirq.ry(0.2)(q1),
-      cirq.rz(0.4)(q2),
-      cirq.PhasedXPowGate(
-          phase_exponent=0.8, exponent=0.6, global_shift=0.3)(q3),
-    ]),
-    cirq.Moment([
-      cirq.ZZPowGate(exponent=0.3, global_shift=1.3)(q0, q2),
-      cirq.ISwapPowGate(exponent=0.6, global_shift=1.2)(q1, q3),
-    ]),
-    cirq.Moment([
-      cirq.XPowGate(exponent=0.1, global_shift=0.9)(q0),
-      cirq.YPowGate(exponent=0.2, global_shift=1)(q1),
-      cirq.ZPowGate(exponent=0.3, global_shift=1.1)(q2),
-      cirq.HPowGate(exponent=0.4, global_shift=1.2)(q3),
-    ]),
-    cirq.Moment([
-      cirq.SwapPowGate(exponent=0.2, global_shift=0.9)(q0, q1),
-      cirq.PhasedISwapPowGate(phase_exponent = 0.8, exponent=0.6)(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.PhasedXZGate(
-          x_exponent=0.2, z_exponent=0.3, axis_phase_exponent=1.4)(q0),
-      cirq.T(q1),
-      cirq.H(q2),
-      cirq.S(q3),
-    ]),
-    cirq.Moment([
-      cirq.SWAP(q0, q2),
-      cirq.XX(q1, q3),
-    ]),
-    cirq.Moment([
-      cirq.rx(0.8)(q0),
-      cirq.ry(0.9)(q1),
-      cirq.rz(1.2)(q2),
-      cirq.T(q3),
-    ]),
-    cirq.Moment([
-      cirq.YY(q0, q1),
-      cirq.ISWAP(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.T(q0),
-      cirq.Z(q1),
-      cirq.Y(q2),
-      cirq.X(q3),
-    ]),
-    cirq.Moment([
-      cirq.FSimGate(0.3, 1.7)(q0, q2),
-      cirq.ZZ(q1, q3),
-    ]),
-    cirq.Moment([
-      cirq.ry(1.3)(q0),
-      cirq.rz(0.4)(q1),
-      cirq.rx(0.7)(q2),
-      cirq.S(q3),
-    ]),
-    cirq.Moment([
-      cirq.IdentityGate(4).on(q0, q1, q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.CCZPowGate(exponent=0.7, global_shift=0.3)(q2, q0, q1),
-    ]),
-    cirq.Moment([
-      cirq.CCXPowGate(exponent=0.4, global_shift=0.6)(
-        q3, q1, q0).controlled_by(q2, control_values=[0]),
-    ]),
-    cirq.Moment([
-      cirq.rx(0.3)(q0),
-      cirq.ry(0.5)(q1),
-      cirq.rz(0.7)(q2),
-      cirq.rx(0.9)(q3),
-    ]),
-    cirq.Moment([
-      cirq.TwoQubitDiagonalGate([0.1, 0.2, 0.3, 0.4])(q0, q1),
-    ]),
-    cirq.Moment([
-      cirq.ThreeQubitDiagonalGate([0.5, 0.6, 0.7, 0.8,
-                                    0.9, 1, 1.2, 1.3])(q1, q2, q3),
-    ]),
-    cirq.Moment([
-        cirq.CSwapGate()(q0, q3, q1),
-    ]),
-    cirq.Moment([
-      cirq.rz(0.6)(q0),
-      cirq.rx(0.7)(q1),
-      cirq.ry(0.8)(q2),
-      cirq.rz(0.9)(q3),
-    ]),
-    cirq.Moment([
-      cirq.TOFFOLI(q3, q2, q0),
-    ]),
-    cirq.Moment([
-      cirq.FREDKIN(q1, q3, q2),
-    ]),
-    cirq.Moment([
-      cirq.MatrixGate(np.array([[0, -0.5 - 0.5j, -0.5 - 0.5j, 0],
-                                [0.5 - 0.5j, 0, 0, -0.5 + 0.5j],
-                                [0.5 - 0.5j, 0, 0, 0.5 - 0.5j],
-                                [0, -0.5 - 0.5j, 0.5 + 0.5j, 0]]))(q0, q1),
-      cirq.MatrixGate(np.array([[0.5 - 0.5j, 0, 0, -0.5 + 0.5j],
-                                [0, 0.5 - 0.5j, -0.5 + 0.5j, 0],
-                                [0, -0.5 + 0.5j, -0.5 + 0.5j, 0],
-                                [0.5 - 0.5j, 0, 0, 0.5 - 0.5j]]))(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.MatrixGate(np.array([[1, 0], [0, 1j]]))(q0),
-      cirq.MatrixGate(np.array([[0, -1j], [1j, 0]]))(q1),
-      cirq.MatrixGate(np.array([[0, 1], [1, 0]]))(q2),
-      cirq.MatrixGate(np.array([[1, 0], [0, -1]]))(q3),
-    ]),
-    cirq.Moment([
-      cirq.riswap(0.7)(q0, q1),
-      cirq.givens(1.2)(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.H(q0),
-      cirq.H(q1),
-      cirq.H(q2),
-      cirq.H(q3),
-    ]),
-  )
+    circuit = cirq.Circuit(
+        cirq.Moment(
+            cirq.H(q0),
+            cirq.H(q1),
+            cirq.H(q2),
+            cirq.H(q3),
+        ),
+        cirq.Moment(
+            cirq.T(q0),
+            cirq.T(q1),
+            cirq.T(q2),
+            cirq.T(q3),
+        ),
+        cirq.Moment(
+            cirq.CZPowGate(exponent=0.7, global_shift=0.2)(q0, q1),
+            cirq.CXPowGate(exponent=1.2, global_shift=0.4)(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.XPowGate(exponent=0.3, global_shift=1.1)(q0),
+            cirq.YPowGate(exponent=0.4, global_shift=1)(q1),
+            cirq.ZPowGate(exponent=0.5, global_shift=0.9)(q2),
+            cirq.HPowGate(exponent=0.6, global_shift=0.8)(q3),
+        ),
+        cirq.Moment(
+            cirq.CX(q0, q2),
+            cirq.CZ(q1, q3),
+        ),
+        cirq.Moment(
+            cirq.X(q0),
+            cirq.Y(q1),
+            cirq.Z(q2),
+            cirq.S(q3),
+        ),
+        cirq.Moment(
+            cirq.XXPowGate(exponent=0.4, global_shift=0.7)(q0, q1),
+            cirq.YYPowGate(exponent=0.8, global_shift=0.5)(q2, q3),
+        ),
+        cirq.Moment(cirq.I(q0), cirq.I(q1), cirq.IdentityGate(2)(q2, q3)),
+        cirq.Moment(
+            cirq.rx(0.7)(q0),
+            cirq.ry(0.2)(q1),
+            cirq.rz(0.4)(q2),
+            cirq.PhasedXPowGate(phase_exponent=0.8, exponent=0.6, global_shift=0.3)(q3),
+        ),
+        cirq.Moment(
+            cirq.ZZPowGate(exponent=0.3, global_shift=1.3)(q0, q2),
+            cirq.ISwapPowGate(exponent=0.6, global_shift=1.2)(q1, q3),
+        ),
+        cirq.Moment(
+            cirq.XPowGate(exponent=0.1, global_shift=0.9)(q0),
+            cirq.YPowGate(exponent=0.2, global_shift=1)(q1),
+            cirq.ZPowGate(exponent=0.3, global_shift=1.1)(q2),
+            cirq.HPowGate(exponent=0.4, global_shift=1.2)(q3),
+        ),
+        cirq.Moment(
+            cirq.SwapPowGate(exponent=0.2, global_shift=0.9)(q0, q1),
+            cirq.PhasedISwapPowGate(phase_exponent=0.8, exponent=0.6)(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.PhasedXZGate(x_exponent=0.2, z_exponent=0.3, axis_phase_exponent=1.4)(
+                q0
+            ),
+            cirq.T(q1),
+            cirq.H(q2),
+            cirq.S(q3),
+        ),
+        cirq.Moment(
+            cirq.SWAP(q0, q2),
+            cirq.XX(q1, q3),
+        ),
+        cirq.Moment(
+            cirq.rx(0.8)(q0),
+            cirq.ry(0.9)(q1),
+            cirq.rz(1.2)(q2),
+            cirq.T(q3),
+        ),
+        cirq.Moment(
+            cirq.YY(q0, q1),
+            cirq.ISWAP(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.T(q0),
+            cirq.Z(q1),
+            cirq.Y(q2),
+            cirq.X(q3),
+        ),
+        cirq.Moment(
+            cirq.FSimGate(0.3, 1.7)(q0, q2),
+            cirq.ZZ(q1, q3),
+        ),
+        cirq.Moment(
+            cirq.ry(1.3)(q0),
+            cirq.rz(0.4)(q1),
+            cirq.rx(0.7)(q2),
+            cirq.S(q3),
+        ),
+        cirq.Moment(
+            cirq.IdentityGate(4).on(q0, q1, q2, q3),
+        ),
+        cirq.Moment(
+            cirq.CCZPowGate(exponent=0.7, global_shift=0.3)(q2, q0, q1),
+        ),
+        cirq.Moment(
+            cirq.CCXPowGate(exponent=0.4, global_shift=0.6)(q3, q1, q0).controlled_by(
+                q2, control_values=[0]
+            ),
+        ),
+        cirq.Moment(
+            cirq.rx(0.3)(q0),
+            cirq.ry(0.5)(q1),
+            cirq.rz(0.7)(q2),
+            cirq.rx(0.9)(q3),
+        ),
+        cirq.Moment(
+            cirq.TwoQubitDiagonalGate([0.1, 0.2, 0.3, 0.4])(q0, q1),
+        ),
+        cirq.Moment(
+            cirq.ThreeQubitDiagonalGate([0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.2, 1.3])(
+                q1, q2, q3
+            ),
+        ),
+        cirq.Moment(
+            cirq.CSwapGate()(q0, q3, q1),
+        ),
+        cirq.Moment(
+            cirq.rz(0.6)(q0),
+            cirq.rx(0.7)(q1),
+            cirq.ry(0.8)(q2),
+            cirq.rz(0.9)(q3),
+        ),
+        cirq.Moment(
+            cirq.TOFFOLI(q3, q2, q0),
+        ),
+        cirq.Moment(
+            cirq.FREDKIN(q1, q3, q2),
+        ),
+        cirq.Moment(
+            cirq.MatrixGate(
+                np.array(
+                    [
+                        [0, -0.5 - 0.5j, -0.5 - 0.5j, 0],
+                        [0.5 - 0.5j, 0, 0, -0.5 + 0.5j],
+                        [0.5 - 0.5j, 0, 0, 0.5 - 0.5j],
+                        [0, -0.5 - 0.5j, 0.5 + 0.5j, 0],
+                    ]
+                )
+            )(q0, q1),
+            cirq.MatrixGate(
+                np.array(
+                    [
+                        [0.5 - 0.5j, 0, 0, -0.5 + 0.5j],
+                        [0, 0.5 - 0.5j, -0.5 + 0.5j, 0],
+                        [0, -0.5 + 0.5j, -0.5 + 0.5j, 0],
+                        [0.5 - 0.5j, 0, 0, 0.5 - 0.5j],
+                    ]
+                )
+            )(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.MatrixGate(np.array([[1, 0], [0, 1j]]))(q0),
+            cirq.MatrixGate(np.array([[0, -1j], [1j, 0]]))(q1),
+            cirq.MatrixGate(np.array([[0, 1], [1, 0]]))(q2),
+            cirq.MatrixGate(np.array([[1, 0], [0, -1]]))(q3),
+        ),
+        cirq.Moment(
+            cirq.riswap(0.7)(q0, q1),
+            cirq.givens(1.2)(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.H(q0),
+            cirq.H(q1),
+            cirq.H(q2),
+            cirq.H(q3),
+        ),
+    )
 
-  simulator = cirq.Simulator()
-  cirq_result = simulator.simulate(circuit)
+    simulator = cirq.Simulator()
+    cirq_result = simulator.simulate(circuit)
 
-  qsim_simulator = qsimcirq.QSimSimulator()
-  qsim_result = qsim_simulator.simulate(circuit)
+    qsim_simulator = qsimcirq.QSimSimulator()
+    qsim_result = qsim_simulator.simulate(circuit)
 
-  assert cirq.linalg.allclose_up_to_global_phase(
-      qsim_result.state_vector(), cirq_result.state_vector())
+    assert cirq.linalg.allclose_up_to_global_phase(
+        qsim_result.state_vector(), cirq_result.state_vector()
+    )
 
 
 def test_cirq_qsim_global_shift():
-  q0 = cirq.GridQubit(1, 1)
-  q1 = cirq.GridQubit(1, 0)
-  q2 = cirq.GridQubit(0, 1)
-  q3 = cirq.GridQubit(0, 0)
+    q0 = cirq.GridQubit(1, 1)
+    q1 = cirq.GridQubit(1, 0)
+    q2 = cirq.GridQubit(0, 1)
+    q3 = cirq.GridQubit(0, 0)
 
-  circuit = cirq.Circuit(
-    cirq.Moment([
-      cirq.H(q0),
-      cirq.H(q1),
-      cirq.H(q2),
-      cirq.H(q3),
-    ]),
-    cirq.Moment([
-      cirq.CXPowGate(exponent=1, global_shift=0.7)(q0, q1),
-      cirq.CZPowGate(exponent=1, global_shift=0.9)(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.XPowGate(exponent=1, global_shift=1.1)(q0),
-      cirq.YPowGate(exponent=1, global_shift=1)(q1),
-      cirq.ZPowGate(exponent=1, global_shift=0.9)(q2),
-      cirq.HPowGate(exponent=1, global_shift=0.8)(q3),
-    ]),
-    cirq.Moment([
-      cirq.XXPowGate(exponent=1, global_shift=0.2)(q0, q1),
-      cirq.YYPowGate(exponent=1, global_shift=0.3)(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.ZPowGate(exponent=0.25, global_shift=0.4)(q0),
-      cirq.ZPowGate(exponent=0.5, global_shift=0.5)(q1),
-      cirq.YPowGate(exponent=1, global_shift=0.2)(q2),
-      cirq.ZPowGate(exponent=1, global_shift=0.3)(q3),
-    ]),
-    cirq.Moment([
-      cirq.ZZPowGate(exponent=1, global_shift=0.2)(q0, q1),
-      cirq.SwapPowGate(exponent=1, global_shift=0.3)(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.XPowGate(exponent=1, global_shift=0)(q0),
-      cirq.YPowGate(exponent=1, global_shift=0)(q1),
-      cirq.ZPowGate(exponent=1, global_shift=0)(q2),
-      cirq.HPowGate(exponent=1, global_shift=0)(q3),
-    ]),
-    cirq.Moment([
-      cirq.ISwapPowGate(exponent=1, global_shift=0.3)(q0, q1),
-      cirq.ZZPowGate(exponent=1, global_shift=0.5)(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.ZPowGate(exponent=0.5, global_shift=0)(q0),
-      cirq.ZPowGate(exponent=0.25, global_shift=0)(q1),
-      cirq.XPowGate(exponent=0.9, global_shift=0)(q2),
-      cirq.YPowGate(exponent=0.8, global_shift=0)(q3),
-    ]),
-    cirq.Moment([
-      cirq.CZPowGate(exponent=0.3, global_shift=0)(q0, q1),
-      cirq.CXPowGate(exponent=0.4, global_shift=0)(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.ZPowGate(exponent=1.3, global_shift=0)(q0),
-      cirq.HPowGate(exponent=0.8, global_shift=0)(q1),
-      cirq.XPowGate(exponent=0.9, global_shift=0)(q2),
-      cirq.YPowGate(exponent=0.4, global_shift=0)(q3),
-    ]),
-    cirq.Moment([
-      cirq.XXPowGate(exponent=0.8, global_shift=0)(q0, q1),
-      cirq.YYPowGate(exponent=0.6, global_shift=0)(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.HPowGate(exponent=0.7, global_shift=0)(q0),
-      cirq.ZPowGate(exponent=0.2, global_shift=0)(q1),
-      cirq.YPowGate(exponent=0.3, global_shift=0)(q2),
-      cirq.XPowGate(exponent=0.7, global_shift=0)(q3),
-    ]),
-    cirq.Moment([
-      cirq.ZZPowGate(exponent=0.1, global_shift=0)(q0, q1),
-      cirq.SwapPowGate(exponent=0.6, global_shift=0)(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.XPowGate(exponent=0.4, global_shift=0)(q0),
-      cirq.YPowGate(exponent=0.3, global_shift=0)(q1),
-      cirq.ZPowGate(exponent=0.2, global_shift=0)(q2),
-      cirq.HPowGate(exponent=0.1, global_shift=0)(q3),
-    ]),
-    cirq.Moment([
-      cirq.ISwapPowGate(exponent=1.3, global_shift=0)(q0, q1),
-      cirq.CXPowGate(exponent=0.5, global_shift=0)(q2, q3),
-    ]),
-    cirq.Moment([
-      cirq.H(q0),
-      cirq.H(q1),
-      cirq.H(q2),
-      cirq.H(q3),
-    ]),
-  )
+    circuit = cirq.Circuit(
+        cirq.Moment(
+            cirq.H(q0),
+            cirq.H(q1),
+            cirq.H(q2),
+            cirq.H(q3),
+        ),
+        cirq.Moment(
+            cirq.CXPowGate(exponent=1, global_shift=0.7)(q0, q1),
+            cirq.CZPowGate(exponent=1, global_shift=0.9)(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.XPowGate(exponent=1, global_shift=1.1)(q0),
+            cirq.YPowGate(exponent=1, global_shift=1)(q1),
+            cirq.ZPowGate(exponent=1, global_shift=0.9)(q2),
+            cirq.HPowGate(exponent=1, global_shift=0.8)(q3),
+        ),
+        cirq.Moment(
+            cirq.XXPowGate(exponent=1, global_shift=0.2)(q0, q1),
+            cirq.YYPowGate(exponent=1, global_shift=0.3)(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.ZPowGate(exponent=0.25, global_shift=0.4)(q0),
+            cirq.ZPowGate(exponent=0.5, global_shift=0.5)(q1),
+            cirq.YPowGate(exponent=1, global_shift=0.2)(q2),
+            cirq.ZPowGate(exponent=1, global_shift=0.3)(q3),
+        ),
+        cirq.Moment(
+            cirq.ZZPowGate(exponent=1, global_shift=0.2)(q0, q1),
+            cirq.SwapPowGate(exponent=1, global_shift=0.3)(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.XPowGate(exponent=1, global_shift=0)(q0),
+            cirq.YPowGate(exponent=1, global_shift=0)(q1),
+            cirq.ZPowGate(exponent=1, global_shift=0)(q2),
+            cirq.HPowGate(exponent=1, global_shift=0)(q3),
+        ),
+        cirq.Moment(
+            cirq.ISwapPowGate(exponent=1, global_shift=0.3)(q0, q1),
+            cirq.ZZPowGate(exponent=1, global_shift=0.5)(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.ZPowGate(exponent=0.5, global_shift=0)(q0),
+            cirq.ZPowGate(exponent=0.25, global_shift=0)(q1),
+            cirq.XPowGate(exponent=0.9, global_shift=0)(q2),
+            cirq.YPowGate(exponent=0.8, global_shift=0)(q3),
+        ),
+        cirq.Moment(
+            cirq.CZPowGate(exponent=0.3, global_shift=0)(q0, q1),
+            cirq.CXPowGate(exponent=0.4, global_shift=0)(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.ZPowGate(exponent=1.3, global_shift=0)(q0),
+            cirq.HPowGate(exponent=0.8, global_shift=0)(q1),
+            cirq.XPowGate(exponent=0.9, global_shift=0)(q2),
+            cirq.YPowGate(exponent=0.4, global_shift=0)(q3),
+        ),
+        cirq.Moment(
+            cirq.XXPowGate(exponent=0.8, global_shift=0)(q0, q1),
+            cirq.YYPowGate(exponent=0.6, global_shift=0)(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.HPowGate(exponent=0.7, global_shift=0)(q0),
+            cirq.ZPowGate(exponent=0.2, global_shift=0)(q1),
+            cirq.YPowGate(exponent=0.3, global_shift=0)(q2),
+            cirq.XPowGate(exponent=0.7, global_shift=0)(q3),
+        ),
+        cirq.Moment(
+            cirq.ZZPowGate(exponent=0.1, global_shift=0)(q0, q1),
+            cirq.SwapPowGate(exponent=0.6, global_shift=0)(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.XPowGate(exponent=0.4, global_shift=0)(q0),
+            cirq.YPowGate(exponent=0.3, global_shift=0)(q1),
+            cirq.ZPowGate(exponent=0.2, global_shift=0)(q2),
+            cirq.HPowGate(exponent=0.1, global_shift=0)(q3),
+        ),
+        cirq.Moment(
+            cirq.ISwapPowGate(exponent=1.3, global_shift=0)(q0, q1),
+            cirq.CXPowGate(exponent=0.5, global_shift=0)(q2, q3),
+        ),
+        cirq.Moment(
+            cirq.H(q0),
+            cirq.H(q1),
+            cirq.H(q2),
+            cirq.H(q3),
+        ),
+    )
 
-  simulator = cirq.Simulator()
-  cirq_result = simulator.simulate(circuit)
+    simulator = cirq.Simulator()
+    cirq_result = simulator.simulate(circuit)
 
-  qsim_simulator = qsimcirq.QSimSimulator()
-  qsim_result = qsim_simulator.simulate(circuit)
+    qsim_simulator = qsimcirq.QSimSimulator()
+    qsim_result = qsim_simulator.simulate(circuit)
 
-  assert cirq.linalg.allclose_up_to_global_phase(
-      qsim_result.state_vector(), cirq_result.state_vector())
+    assert cirq.linalg.allclose_up_to_global_phase(
+        qsim_result.state_vector(), cirq_result.state_vector()
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ absl-py
 
 # Build and test requirements
 
-black
-flynt
+black==20.8b1
+flynt~=0.60
 pybind11
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,7 @@ absl-py
 
 # Build and test requirements
 
+black
+flynt
 pybind11
 pytest

--- a/setup.py
+++ b/setup.py
@@ -10,86 +10,87 @@ from distutils.version import LooseVersion
 
 
 class CMakeExtension(Extension):
-
-  def __init__(self, name, sourcedir=''):
-    Extension.__init__(self, name, sources=[])
-    self.sourcedir = os.path.abspath(sourcedir)
+    def __init__(self, name, sourcedir=""):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
 
 
 class CMakeBuild(build_ext):
+    def run(self):
+        try:
+            out = subprocess.check_output(["cmake", "--version"])
+        except OSError:
+            raise RuntimeError(
+                "CMake must be installed to build the following extensions: "
+                + ", ".join(e.name for e in self.extensions)
+            )
 
-  def run(self):
-    try:
-      out = subprocess.check_output(['cmake', '--version'])
-    except OSError:
-      raise RuntimeError(
-          'CMake must be installed to build the following extensions: ' +
-          ', '.join(e.name for e in self.extensions))
+        if platform.system() == "Windows":
+            cmake_version = LooseVersion(
+                re.search(r"version\s*([\d.]+)", out.decode()).group(1)
+            )
+            if cmake_version < "3.1.0":
+                raise RuntimeError("CMake >= 3.1.0 is required on Windows")
 
-    if platform.system() == 'Windows':
-      cmake_version = LooseVersion(
-          re.search(r'version\s*([\d.]+)', out.decode()).group(1))
-      if cmake_version < '3.1.0':
-        raise RuntimeError('CMake >= 3.1.0 is required on Windows')
+        for ext in self.extensions:
+            self.build_extension(ext)
 
-    for ext in self.extensions:
-      self.build_extension(ext)
+    def build_extension(self, ext):
+        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+        cmake_args = [
+            "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
+            "-DPYTHON_EXECUTABLE=" + sys.executable,
+        ]
 
-  def build_extension(self, ext):
-    extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-    cmake_args = [
-        '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-        '-DPYTHON_EXECUTABLE=' + sys.executable
-    ]
+        cfg = "Debug" if self.debug else "Release"
+        build_args = ["--config", cfg]
 
-    cfg = 'Debug' if self.debug else 'Release'
-    build_args = ['--config', cfg]
+        if platform.system() == "Windows":
+            cmake_args += [f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}"]
+            if sys.maxsize > 2 ** 32:
+                cmake_args += ["-A", "x64"]
+            build_args += ["--", "/m"]
+        else:
+            cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
+            build_args += ["--", "-j2"]
 
-    if platform.system() == 'Windows':
-      cmake_args += [
-          '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)
-      ]
-      if sys.maxsize > 2**32:
-        cmake_args += ['-A', 'x64']
-      build_args += ['--', '/m']
-    else:
-      cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
-      build_args += ['--', '-j2']
-
-    env = os.environ.copy()
-    env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(
-        env.get('CXXFLAGS', ''), self.distribution.get_version())
-    if not os.path.exists(self.build_temp):
-      os.makedirs(self.build_temp)
-    subprocess.check_call(
-        ['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-    subprocess.check_call(
-        ['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
+        env = os.environ.copy()
+        env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(
+            env.get("CXXFLAGS", ""), self.distribution.get_version()
+        )
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+        subprocess.check_call(
+            ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env
+        )
+        subprocess.check_call(
+            ["cmake", "--build", "."] + build_args, cwd=self.build_temp
+        )
 
 
-requirements = open('requirements.txt').readlines()
+requirements = open("requirements.txt").readlines()
 
-description = ('Schrödinger and Schrödinger-Feynman simulators for quantum circuits.')
+description = "Schrödinger and Schrödinger-Feynman simulators for quantum circuits."
 
 # README file as long_description.
-long_description = open('README.md', encoding='utf-8').read()
+long_description = open("README.md", encoding="utf-8").read()
 
-__version__ = '0.9.2'
+__version__ = "0.9.2"
 
 setup(
-    name='qsimcirq',
+    name="qsimcirq",
     version=__version__,
-    author='Vamsi Krishna Devabathini',
-    author_email='devabathini92@gmail.com',
-    python_requires='>=3.3.0',
+    author="Vamsi Krishna Devabathini",
+    author_email="devabathini92@gmail.com",
+    python_requires=">=3.3.0",
     install_requires=requirements,
-    license='Apache 2',
+    license="Apache 2",
     description=description,
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    ext_modules=[CMakeExtension('qsimcirq/qsim')],
+    long_description_content_type="text/markdown",
+    ext_modules=[CMakeExtension("qsimcirq/qsim")],
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
-    packages=['qsimcirq'],
-    package_data={'qsimcirq': ['py.typed']},
+    packages=["qsimcirq"],
+    package_data={"qsimcirq": ["py.typed"]},
 )


### PR DESCRIPTION
Fixes #328.

Copied `check/format-incremental` from Cirq, made it executable, and applied it to all python files. Other manual changes:

- Added `black` and `flynt` to the requirements file
- Removed excess square-brackets from `cirq.Moment` constructors in the test
- Labeled numpy arrays with `fmt: off` to preserve squareness