### PR TITLE
Fix controlled-gate qubit limit.

### DIFF
--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -195,7 +195,7 @@ def add_op_to_circuit(
             # This gate has no valid control, and will be omitted.
             return
 
-        if qsim_gate.num_qubits() > 4:
+        if qsim_gate.num_qubits() - qsim_gate.num_controls() > 4:
             raise NotImplementedError(
                 f"Received control gate on {gate.num_qubits()} target qubits; "
                 + "only up to 4-qubit gates are supported."


### PR DESCRIPTION
The error for too many qubits in a controlled gate suggests that the intent was to limit the number of _target_ qubits to 4, not the number of _total_ qubits. This PR brings the code in line with this description.