### PR TITLE
Add CI check for Python formatting.

### DIFF
--- a/.github/workflows/python_format.yml
+++ b/.github/workflows/python_format.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    paths:
+      # Only check formatting when python files are changed.
+      - '**/*.py'
+
+jobs:
+  format:
+    name: Format check
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+          architecture: 'x64'
+      - name: Install flynt
+        run: cat requirements.txt | grep flynt | xargs pip install
+      - name: Install black
+        run: cat requirements.txt | grep black | xargs pip install
+      - name: Format
+        run: check/format-incremental


### PR DESCRIPTION
This check should only trigger on changes to `*.py` files. Fixes #328 (for real this time).