### PR TITLE
Update version to 0.9.4 and Python version to 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,14 +75,14 @@ description = "Schrödinger and Schrödinger-Feynman simulators for quantum circ
 # README file as long_description.
 long_description = open("README.md", encoding="utf-8").read()
 
-__version__ = "0.9.3"
+__version__ = "0.9.4"
 
 setup(
     name="qsimcirq",
     version=__version__,
     author="Vamsi Krishna Devabathini",
     author_email="devabathini92@gmail.com",
-    python_requires=">=3.3.0",
+    python_requires=">=3.6.0",
     install_requires=requirements,
     license="Apache 2",
     description=description,


### PR DESCRIPTION
See #351: Python versions before 3.6 were already unsupported due to f-string usage, but adding f-strings to `setup.py` made this issue visible by breaking the release pipeline. Requiring Python 3.6 aligns with Cirq.