### PR TITLE
Refactor statespace.

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -323,10 +323,7 @@ cc_library(
 cc_library(
     name = "statespace",
     hdrs = ["statespace.h"],
-    deps = [
-        ":util",
-        ":vectorspace",
-    ],
+    deps = [":util"],
 )
 
 cc_library(
@@ -335,6 +332,7 @@ cc_library(
     deps = [
         ":statespace",
         ":util",
+        ":vectorspace",
     ],
 )
 
@@ -344,6 +342,7 @@ cc_library(
     deps = [
         ":statespace",
         ":util",
+        ":vectorspace",
     ],
 )
 
@@ -353,6 +352,7 @@ cc_library(
     deps = [
         ":statespace",
         ":util",
+        ":vectorspace",
     ],
 )
 
@@ -362,6 +362,7 @@ cc_library(
     deps = [
         ":statespace",
         ":util",
+        ":vectorspace",
     ],
 )
 
@@ -468,31 +469,42 @@ cc_library(
 cc_library(
     name = "unitaryspace",
     hdrs = ["unitaryspace.h"],
-    deps = [":vectorspace"],
 )
 
 cc_library(
     name = "unitaryspace_avx",
     hdrs = ["unitaryspace_avx.h"],
-    deps = [":unitaryspace"],
+    deps = [
+        ":unitaryspace",
+        ":vectorspace",
+    ],
 )
 
 cc_library(
     name = "unitaryspace_avx512",
     hdrs = ["unitaryspace_avx512.h"],
-    deps = [":unitaryspace"],
+    deps = [
+        ":unitaryspace",
+        ":vectorspace",
+    ],
 )
 
 cc_library(
     name = "unitaryspace_basic",
     hdrs = ["unitaryspace_basic.h"],
-    deps = [":unitaryspace"],
+    deps = [
+        ":unitaryspace",
+        ":vectorspace",
+    ],
 )
 
 cc_library(
     name = "unitaryspace_sse",
     hdrs = ["unitaryspace_sse.h"],
-    deps = [":unitaryspace"],
+    deps = [
+        ":unitaryspace",
+        ":vectorspace",
+    ],
 )
 
 ### Unitary calculator libraries ###
@@ -502,7 +514,7 @@ cc_library(
     hdrs = ["unitary_calculator_avx.h"],
     deps = [
         ":bits",
-        ":unitaryspace_avx"
+        ":unitaryspace_avx",
     ],
 )
 
@@ -511,7 +523,7 @@ cc_library(
     hdrs = ["unitary_calculator_avx512.h"],
     deps = [
         ":bits",
-        ":unitaryspace_avx512"
+        ":unitaryspace_avx512",
     ],
 )
 
@@ -520,7 +532,7 @@ cc_library(
     hdrs = ["unitary_calculator_basic.h"],
     deps = [
         ":bits",
-        ":unitaryspace_basic"
+        ":unitaryspace_basic",
     ],
 )
 
@@ -529,7 +541,7 @@ cc_library(
     hdrs = ["unitary_calculator_sse.h"],
     deps = [
         ":bits",
-        ":unitaryspace_sse"
+        ":unitaryspace_sse",
     ],
 )
 

--- a/lib/statespace.h
+++ b/lib/statespace.h
@@ -21,18 +21,19 @@
 #include <vector>
 
 #include "util.h"
-#include "vectorspace.h"
 
 namespace qsim {
 
 /**
  * Abstract class containing context and routines for general state-vector
- * manipulations. "AVX", "Basic", and "SSE" implementations are provided.
+ * manipulations. "AVX", "AVX512", "Basic", and "SSE" implementations are
+ * provided.
  */
-template <typename Impl, typename For, typename FP>
-class StateSpace : public VectorSpace<Impl, For, FP> {
+template <typename Impl,
+          template<typename...> class VectorSpace, typename... VSTypeParams>
+class StateSpace : public VectorSpace<Impl, VSTypeParams...> {
  private:
-  using Base = VectorSpace<Impl, For, FP>;
+  using Base = VectorSpace<Impl, VSTypeParams...>;
 
  public:
   using fp_type = typename Base::fp_type;
@@ -66,8 +67,8 @@ class StateSpace : public VectorSpace<Impl, For, FP> {
     bool valid;
   };
 
-  template <typename... ForArgs>
-  StateSpace(ForArgs&&... args) : Base(args...) {}
+  template <typename... Args>
+  StateSpace(Args&&... args) : Base(args...) {}
 
   double Norm(const State& state) const {
     auto partial_norms = static_cast<const Impl&>(*this).PartialNorms(state);

--- a/lib/statespace_avx.h
+++ b/lib/statespace_avx.h
@@ -25,6 +25,7 @@
 
 #include "statespace.h"
 #include "util.h"
+#include "vectorspace.h"
 
 namespace qsim {
 
@@ -64,9 +65,10 @@ inline double HorizontalSumAVX(__m256 s) {
  * into an AVX register.
  */
 template <typename For>
-class StateSpaceAVX : public StateSpace<StateSpaceAVX<For>, For, float> {
+class StateSpaceAVX :
+    public StateSpace<StateSpaceAVX<For>, VectorSpace, For, float> {
  private:
-  using Base = StateSpace<StateSpaceAVX<For>, For, float>;
+  using Base = StateSpace<StateSpaceAVX<For>, VectorSpace, For, float>;
 
  public:
   using State = typename Base::State;

--- a/lib/statespace_avx512.h
+++ b/lib/statespace_avx512.h
@@ -25,6 +25,7 @@
 
 #include "statespace.h"
 #include "util.h"
+#include "vectorspace.h"
 
 namespace qsim {
 
@@ -76,8 +77,12 @@ inline double HorizontalSumAVX512(__m512 s) {
  * be loaded into an AVX512 register.
  */
 template <typename For>
-struct StateSpaceAVX512 : public StateSpace<StateSpaceAVX512<For>, For, float> {
-  using Base = StateSpace<StateSpaceAVX512<For>, For, float>;
+class StateSpaceAVX512 :
+    public StateSpace<StateSpaceAVX512<For>, VectorSpace, For, float> {
+ private:
+  using Base = StateSpace<StateSpaceAVX512<For>, VectorSpace, For, float>;
+
+ public:
   using State = typename Base::State;
   using fp_type = typename Base::fp_type;
 

--- a/lib/statespace_basic.h
+++ b/lib/statespace_basic.h
@@ -22,6 +22,7 @@
 
 #include "statespace.h"
 #include "util.h"
+#include "vectorspace.h"
 
 namespace qsim {
 
@@ -31,9 +32,10 @@ namespace qsim {
  * followed by one imaginary amplitude.
  */
 template <typename For, typename FP>
-class StateSpaceBasic : public StateSpace<StateSpaceBasic<For, FP>, For, FP> {
+class StateSpaceBasic :
+    public StateSpace<StateSpaceBasic<For, FP>, VectorSpace, For, FP> {
  private:
-  using Base = StateSpace<StateSpaceBasic<For, FP>, For, FP>;
+  using Base = StateSpace<StateSpaceBasic<For, FP>, VectorSpace, For, FP>;
 
  public:
   using State = typename Base::State;

--- a/lib/statespace_sse.h
+++ b/lib/statespace_sse.h
@@ -25,6 +25,7 @@
 
 #include "statespace.h"
 #include "util.h"
+#include "vectorspace.h"
 
 namespace qsim {
 
@@ -61,9 +62,10 @@ inline double HorizontalSumSSE(__m128 s) {
  * into an SSE register.
  */
 template <typename For>
-class StateSpaceSSE : public StateSpace<StateSpaceSSE<For>, For, float> {
+class StateSpaceSSE :
+    public StateSpace<StateSpaceSSE<For>, VectorSpace, For, float> {
  private:
-  using Base = StateSpace<StateSpaceSSE<For>, For, float>;
+  using Base = StateSpace<StateSpaceSSE<For>, VectorSpace, For, float>;
 
  public:
   using State = typename Base::State;

--- a/lib/unitaryspace.h
+++ b/lib/unitaryspace.h
@@ -17,20 +17,19 @@
 
 #include <cstdint>
 
-#include "vectorspace.h"
-
 namespace qsim {
 
 namespace unitary {
 
 /**
  * Abstract class containing routines for general unitary matrix manipulations.
- * "AVX", "Basic", and "SSE" implementations are provided.
+ * "AVX", "AVX512", "Basic", and "SSE" implementations are provided.
  */
-template <typename Impl, typename For, typename FP>
-class UnitarySpace : public VectorSpace<Impl, For, FP> {
+template <typename Impl,
+          template<typename...> class VectorSpace, typename... VSTypeParams>
+class UnitarySpace : public VectorSpace<Impl, VSTypeParams...> {
  private:
-  using Base = VectorSpace<Impl, For, FP>;
+  using Base = VectorSpace<Impl, VSTypeParams...>;
 
  public:
   using fp_type = typename Base::fp_type;

--- a/lib/unitaryspace_avx.h
+++ b/lib/unitaryspace_avx.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 
 #include "unitaryspace.h"
+#include "vectorspace.h"
 
 namespace qsim {
 
@@ -35,9 +36,10 @@ namespace unitary {
  * into an AVX register.
  */
 template <typename For>
-struct UnitarySpaceAVX : public UnitarySpace<UnitarySpaceAVX<For>, For, float> {
+struct UnitarySpaceAVX :
+    public UnitarySpace<UnitarySpaceAVX<For>, VectorSpace, For, float> {
  private:
-  using Base = UnitarySpace<UnitarySpaceAVX<For>, For, float>;
+  using Base = UnitarySpace<UnitarySpaceAVX<For>, VectorSpace, For, float>;
 
  public:
   using Unitary = typename Base::Unitary;

--- a/lib/unitaryspace_avx512.h
+++ b/lib/unitaryspace_avx512.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 
 #include "unitaryspace.h"
+#include "vectorspace.h"
 
 namespace qsim {
 
@@ -36,9 +37,9 @@ namespace unitary {
  */
 template <typename For>
 struct UnitarySpaceAVX512 :
-    public UnitarySpace<UnitarySpaceAVX512<For>, For, float> {
+    public UnitarySpace<UnitarySpaceAVX512<For>, VectorSpace, For, float> {
  private:
-  using Base = UnitarySpace<UnitarySpaceAVX512<For>, For, float>;
+  using Base = UnitarySpace<UnitarySpaceAVX512<For>, VectorSpace, For, float>;
 
  public:
   using Unitary = typename Base::Unitary;

--- a/lib/unitaryspace_basic.h
+++ b/lib/unitaryspace_basic.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 
 #include "unitaryspace.h"
+#include "vectorspace.h"
 
 namespace qsim {
 
@@ -32,9 +33,9 @@ namespace unitary {
  */
 template <typename For, typename FP>
 struct UnitarySpaceBasic
-    : public UnitarySpace<UnitarySpaceBasic<For, FP>, For, FP> {
+    : public UnitarySpace<UnitarySpaceBasic<For, FP>, VectorSpace, For, FP> {
  private:
-  using Base = UnitarySpace<UnitarySpaceBasic<For, FP>, For, FP>;
+  using Base = UnitarySpace<UnitarySpaceBasic<For, FP>, VectorSpace, For, FP>;
 
  public:
   using Unitary = typename Base::Unitary;

--- a/lib/unitaryspace_sse.h
+++ b/lib/unitaryspace_sse.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 
 #include "unitaryspace.h"
+#include "vectorspace.h"
 
 namespace qsim {
 
@@ -35,9 +36,10 @@ namespace unitary {
  * into an SSE register.
  */
 template <typename For>
-struct UnitarySpaceSSE : public UnitarySpace<UnitarySpaceSSE<For>, For, float> {
+struct UnitarySpaceSSE :
+    public UnitarySpace<UnitarySpaceSSE<For>, VectorSpace, For, float> {
  private:
-  using Base = UnitarySpace<UnitarySpaceSSE<For>, For, float>;
+  using Base = UnitarySpace<UnitarySpaceSSE<For>, VectorSpace, For, float>;
 
  public:
   using Unitary = typename Base::Unitary;

--- a/lib/vectorspace.h
+++ b/lib/vectorspace.h
@@ -28,9 +28,9 @@ namespace qsim {
 
 namespace detail {
 
-inline void do_not_free(void*) noexcept {}
+inline void do_not_free(void*) {}
 
-inline void free(void* ptr) noexcept {
+inline void free(void* ptr) {
 #ifdef _WIN32
   _aligned_free(ptr);
 #else
@@ -47,7 +47,7 @@ class VectorSpace {
   using fp_type = FP;
 
  private:
-  using Pointer = std::unique_ptr<fp_type, decltype(&free)>;
+  using Pointer = std::unique_ptr<fp_type, decltype(&detail::free)>;
 
  public:
   class Vector {


### PR DESCRIPTION
`VectorSpace` is provided as a template parameter for `StateSpace` and `UnitarySpace`.