### PR TITLE
MPS Implementation p1.

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -557,3 +557,11 @@ cc_library(
         ":unitary_calculator_sse",
     ],
 )
+
+### All MPS headers ###
+
+cc_library(
+    name = "mps_statespace",
+    hdrs = ["mps_statespace.h"],
+    deps = [],
+)

--- a/lib/mps_statespace.h
+++ b/lib/mps_statespace.h
@@ -83,16 +83,16 @@ class MPSStateSpace {
   static MPS CreateMPS(unsigned num_qubits, unsigned bond_dim) {
     auto end_sizes = 2 * 4 * bond_dim;
     auto internal_sizes = 4 * bond_dim * bond_dim * num_qubits;
-    // use two extra "internal style" blocks past the end of the
+    // Use two extra "internal style" blocks past the end of the
     //   working allocation for scratch space. Needed for gate
     //   application.
     auto size = sizeof(fp_type) * (end_sizes + internal_sizes);
 
 #ifdef _WIN32
     Pointer ptr{(fp_type*)_aligned_malloc(size, 64), &detail::free};
-    bool is_null = ptr.get() != nullptr return MPS{std::move(ptr),
-                                                   is_null ? num_qubits : 0,
-                                                   is_null ? bond_dim : 0};
+    bool is_null = ptr.get() != nullptr;
+    return MPS{std::move(ptr), is_null ? num_qubits : 0,
+               is_null ? bond_dim : 0};
 #else
     void* p = nullptr;
     if (posix_memalign(&p, 64, size) == 0) {
@@ -122,7 +122,7 @@ class MPSStateSpace {
   }
 
   // Copies the state contents of one MPS to another.
-  //  ignores scratch data.
+  //  Ignores scratch data.
   bool CopyMPS(const MPS& src, MPS& dest) const {
     if ((src.num_qubits() != dest.num_qubits()) ||
         src.bond_dim() != dest.bond_dim()) {

--- a/lib/mps_statespace.h
+++ b/lib/mps_statespace.h
@@ -122,7 +122,7 @@ class MPSStateSpace {
   }
 
   // Copies the state contents of one MPS to another.
-  //  Ignores scratch data.
+  // Ignores scratch data.
   bool CopyMPS(const MPS& src, MPS& dest) const {
     if ((src.num_qubits() != dest.num_qubits()) ||
         src.bond_dim() != dest.bond_dim()) {

--- a/lib/mps_statespace.h
+++ b/lib/mps_statespace.h
@@ -1,0 +1,154 @@
+// Copyright 2019 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MPS_STATESPACE_H_
+#define MPS_STATESPACE_H_
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+
+namespace detail {
+
+inline void do_not_free(void*) {}
+
+inline void free(void* ptr) {
+#ifdef _WIN32
+  _aligned_free(ptr);
+#else
+  ::free(ptr);
+#endif
+}
+
+}  // namespace detail
+
+namespace qsim {
+
+namespace mps {
+/**
+ * Class containing context and routines for fixed bond dimension
+ * truncated Matrix Product State (MPS) simulation.
+ */
+template <typename For, typename fp_type = float>
+class MPSStateSpace {
+ private:
+ public:
+  using Pointer = std::unique_ptr<fp_type, decltype(&detail::free)>;
+
+  // Store MPS tensors with the following shape:
+  // [2, bond_dim], [bond_dim, 2, bond_dim], ... , [bond_dim, 2].
+  class MPS {
+   public:
+    MPS() = delete;
+
+    MPS(Pointer&& ptr, unsigned num_qubits, unsigned bond_dim)
+        : ptr_(std::move(ptr)), num_qubits_(num_qubits), bond_dim_(bond_dim) {}
+
+    fp_type* get() { return ptr_.get(); }
+
+    const fp_type* get() const { return ptr_.get(); }
+
+    fp_type* release() {
+      num_qubits_ = 0;
+      return ptr_.release();
+    }
+
+    unsigned num_qubits() const { return num_qubits_; }
+
+    unsigned bond_dim() const { return bond_dim_; }
+
+   private:
+    Pointer ptr_;
+    unsigned num_qubits_;
+    unsigned bond_dim_;
+  };
+
+  // Note: ForArgs are currently unused.
+  template <typename... ForArgs>
+  MPSStateSpace(ForArgs&&... args) : for_(args...) {}
+
+  // Requires num_qubits >= 2 and bond_dim >= 2.
+  static MPS CreateMPS(unsigned num_qubits, unsigned bond_dim) {
+    auto end_sizes = 2 * 4 * bond_dim;
+    auto internal_sizes = 4 * bond_dim * bond_dim * num_qubits;
+    // use two extra "internal style" blocks past the end of the
+    //   working allocation for scratch space. Needed for gate
+    //   application.
+    auto size = sizeof(fp_type) * (end_sizes + internal_sizes);
+
+#ifdef _WIN32
+    Pointer ptr{(fp_type*)_aligned_malloc(size, 64), &detail::free};
+    bool is_null = ptr.get() != nullptr return MPS{std::move(ptr),
+                                                   is_null ? num_qubits : 0,
+                                                   is_null ? bond_dim : 0};
+#else
+    void* p = nullptr;
+    if (posix_memalign(&p, 64, size) == 0) {
+      return MPS{Pointer{(fp_type*)p, &detail::free}, num_qubits, bond_dim};
+    } else {
+      return MPS{Pointer{nullptr, &detail::free}, 0, 0};
+    }
+#endif
+  }
+
+  unsigned Size(const MPS& state) const {
+    auto end_sizes = 2 * 4 * state.bond_dim();
+    auto internal_sizes = 4 * state.bond_dim() * state.bond_dim();
+    return end_sizes + internal_sizes * (state.num_qubits() - 2);
+  }
+
+  unsigned RawSize(const MPS& state) const {
+    return sizeof(fp_type) * Size(state);
+  }
+
+  // Get the pointer offset to the beginning of an MPS block.
+  unsigned GetBlockOffset(const MPS& state, unsigned i) const {
+    if (i == 0) {
+      return 0;
+    }
+    return 4 * state.bond_dim() * (1 + state.bond_dim() * (i - 1));
+  }
+
+  // Copies the state contents of one MPS to another.
+  //  ignores scratch data.
+  bool CopyMPS(const MPS& src, MPS& dest) const {
+    if ((src.num_qubits() != dest.num_qubits()) ||
+        src.bond_dim() != dest.bond_dim()) {
+      return false;
+    }
+    auto size = RawSize(src);
+    memcpy(dest.get(), src.get(), size);
+    return true;
+  }
+
+  // Set the MPS to the |0> state.
+  void SetMPSZero(MPS& state) const {
+    auto size = Size(state);
+    memset(state.get(), 0, sizeof(fp_type) * size);
+    auto block_size = 4 * state.bond_dim() * state.bond_dim();
+    state.get()[0] = 1.0;
+    for (unsigned i = 4 * state.bond_dim(); i < size; i += block_size) {
+      state.get()[i] = 1.0;
+    }
+  }
+
+ protected:
+  For for_;
+};
+
+}  // namespace mps
+}  // namespace qsim
+
+#endif  // MPS_STATESPACE_H_

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -556,3 +556,17 @@ cc_test(
         "//lib:vectorspace",
     ],
 )
+
+cc_test(
+    name = "mps_statespace_test",
+    srcs = ["mps_statespace_test.cc"],
+    copts = select({
+        ":windows": windows_copts,
+        "//conditions:default": [],
+    }),
+    deps = [
+        "@com_google_googletest//:gtest_main",
+        "//lib:mps_statespace",
+        "//lib:formux",
+    ],
+)

--- a/tests/mps_statespace_test.cc
+++ b/tests/mps_statespace_test.cc
@@ -78,3 +78,8 @@ TEST(MPSStateSpaceTest, Copy) {
 }  // namespace
 }  // namespace mps
 }  // namespace qsim
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/mps_statespace_test.cc
+++ b/tests/mps_statespace_test.cc
@@ -1,0 +1,80 @@
+// Copyright 2019 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../lib/mps_statespace.h"
+
+#include "../lib/formux.h"
+#include "gtest/gtest.h"
+
+namespace qsim {
+
+namespace mps {
+
+namespace {
+
+TEST(MPSStateSpaceTest, Create) {
+  auto ss = MPSStateSpace<For, float>(1);
+  auto mps = ss.CreateMPS(5, 8);
+  EXPECT_EQ(mps.num_qubits(), 5);
+  EXPECT_EQ(mps.bond_dim(), 8);
+}
+
+TEST(MPSStateSpaceTest, BlockOffset) {
+  auto ss = MPSStateSpace<For, float>(1);
+  auto mps = ss.CreateMPS(5, 8);
+  for (int i = 0; i < ss.Size(mps); i++) {
+    mps.get()[i] = i;
+  }
+
+  ASSERT_EQ(ss.GetBlockOffset(mps, 0), 0);
+  ASSERT_EQ(ss.GetBlockOffset(mps, 1), 32);
+  ASSERT_EQ(ss.GetBlockOffset(mps, 2), 256 + 32);
+  ASSERT_EQ(ss.GetBlockOffset(mps, 3), 512 + 32);
+  ASSERT_EQ(ss.GetBlockOffset(mps, 4), 768 + 32);
+}
+
+TEST(MPSStateSpaceTest, SetZero) {
+  auto ss = MPSStateSpace<For, float>(1);
+  auto mps = ss.CreateMPS(4, 8);
+  for (int i = 0; i < ss.Size(mps); i++) {
+    mps.get()[i] = i;
+  }
+  ss.SetMPSZero(mps);
+  for (int i = 0; i < ss.Size(mps); i++) {
+    auto expected = 0.0;
+    if (i == 0 || i == 32 || i == 256 + 32 || i == 512 + 32) {
+      expected = 1;
+    }
+    EXPECT_NEAR(mps.get()[i], expected, 1e-5);
+  }
+}
+
+TEST(MPSStateSpaceTest, Copy) {
+  auto ss = MPSStateSpace<For, float>(1);
+  auto mps = ss.CreateMPS(10, 8);
+  auto mps2 = ss.CreateMPS(10, 8);
+  auto mps3 = ss.CreateMPS(10, 4);
+  for (int i = 0; i < ss.Size(mps); i++) {
+    mps.get()[i] = i;
+  }
+  ASSERT_FALSE(ss.CopyMPS(mps, mps3));
+  ss.CopyMPS(mps, mps2);
+  for (int i = 0; i < ss.Size(mps); i++) {
+    EXPECT_NEAR(mps.get()[i], mps2.get()[i], 1e-5);
+  }
+}
+
+}  // namespace
+}  // namespace mps
+}  // namespace qsim


### PR DESCRIPTION
First step in adding the MPS design discussed in the simulator meetings. This PR adds the bare bones `mps_statespace.h` file. Once this is reviewed and in, the next step will be to put in `mps_simulator.h` (Which I'm planning to use Eigen3 for instead of writing out the intrinsics by hand) starting with single qubit functionality + tests and then building up to two qubit functionality + tests.