### PR TITLE
Replace star imports to fix mypy issue.

### DIFF
--- a/qsimcirq/__init__.py
+++ b/qsimcirq/__init__.py
@@ -1,5 +1,3 @@
-from .qsim_circuit import *
-from .qsim_simulator import *
-from .qsimh_simulator import *
-
-
+from .qsim_circuit import add_op_to_opstring, add_op_to_circuit, QSimCircuit
+from .qsim_simulator import QSimSimulatorState, QSimSimulatorTrialResult, QSimSimulator
+from .qsimh_simulator import QSimhSimulator


### PR DESCRIPTION
Currently, import `*` from these modules breaks `mypy`, either because `__all__` is missing or due to another internal bug.

Aside from fixing the mypy issue, replacing these with explicit exports is better practice anyway as it delineates a public vs private API.

Note that this is a subtle functionality change if anyone was relying on internal methods such as `qsim_simulator._needs_trajectories` or if they were relying on cirq/numpy imports via the `qsim` namespace. I feel strongly that we should discourage both use cases, but I can be convinced to add a temporary shim.

Fixes #349