### PR TITLE
Limit Cirq dependency to cirq-core.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements for the python 3 version of cirq.
 
-cirq
+cirq-core
 numpy~=1.16
 typing_extensions
 absl-py


### PR DESCRIPTION
This reduces install times when pip-installing qsimcirq.