### PR TITLE
Fix windows release flow by omitting build for cp35

### DIFF
--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -31,7 +31,7 @@ jobs:
             name: win_amd64
             architecture: x64
             cibw:
-              build: "cp*win_amd64"
+              build: "cp36-win_amd64 cp37-win_amd64 cp38-win_amd64 cp39-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"


### PR DESCRIPTION
Fix for the issue described in https://github.com/quantumlib/qsim/issues/407