### PR TITLE
Set flush-to-zero and denormals-are-zeros flags.

### DIFF
--- a/apps/qsim_amplitudes.cc
+++ b/apps/qsim_amplitudes.cc
@@ -34,7 +34,7 @@
 constexpr char usage[] = "usage:\n  ./qsim_amplitudes -c circuit_file "
                          "-d times_to_save_results -i input_files "
                          "-o output_files -s seed -t num_threads "
-                         "-f max_fused_size -v verbosity\n";
+                         "-f max_fused_size -v verbosity -z\n";
 
 struct Options {
   std::string circuit_file;
@@ -45,6 +45,7 @@ struct Options {
   unsigned num_threads = 1;
   unsigned max_fused_size = 2;
   unsigned verbosity = 0;
+  bool denormals_are_zeros = false;
 };
 
 Options GetOptions(int argc, char* argv[]) {
@@ -56,7 +57,7 @@ Options GetOptions(int argc, char* argv[]) {
     return std::atoi(word.c_str());
   };
 
-  while ((k = getopt(argc, argv, "c:d:i:s:o:t:f:v:")) != -1) {
+  while ((k = getopt(argc, argv, "c:d:i:s:o:t:f:v:z")) != -1) {
     switch (k) {
       case 'c':
         opt.circuit_file = optarg;
@@ -81,6 +82,9 @@ Options GetOptions(int argc, char* argv[]) {
         break;
       case 'v':
         opt.verbosity = std::atoi(optarg);
+        break;
+      case 'z':
+        opt.denormals_are_zeros = true;
         break;
       default:
         qsim::IO::errorf(usage);
@@ -160,6 +164,10 @@ int main(int argc, char* argv[]) {
   if (!CircuitQsimParser<IOFile>::FromFile(maxtime, opt.circuit_file,
                                            circuit)) {
     return 1;
+  }
+
+  if (opt.denormals_are_zeros) {
+    SetFlushToZeroAndDenormalsAreZeros();
   }
 
   struct Factory {

--- a/apps/qsim_base.cc
+++ b/apps/qsim_base.cc
@@ -26,6 +26,11 @@
 #include "../lib/io_file.h"
 #include "../lib/run_qsim.h"
 #include "../lib/simmux.h"
+#include "../lib/util.h"
+
+constexpr char usage[] = "usage:\n  ./qsim_base -c circuit -d maxtime "
+                         "-s seed -t threads -f max_fused_size "
+                         "-v verbosity -z\n";
 
 struct Options {
   std::string circuit_file;
@@ -34,18 +39,15 @@ struct Options {
   unsigned num_threads = 1;
   unsigned max_fused_size = 2;
   unsigned verbosity = 0;
+  bool denormals_are_zeros = false;
 };
 
 Options GetOptions(int argc, char* argv[]) {
-  constexpr char usage[] = "usage:\n  ./qsim_base -c circuit -d maxtime "
-                           "-s seed -t threads -f max_fused_size "
-                           "-v verbosity\n";
-
   Options opt;
 
   int k;
 
-  while ((k = getopt(argc, argv, "c:d:s:t:f:v:")) != -1) {
+  while ((k = getopt(argc, argv, "c:d:s:t:f:v:z")) != -1) {
     switch (k) {
       case 'c':
         opt.circuit_file = optarg;
@@ -65,6 +67,9 @@ Options GetOptions(int argc, char* argv[]) {
       case 'v':
         opt.verbosity = std::atoi(optarg);
         break;
+      case 'z':
+        opt.denormals_are_zeros = true;
+        break;
       default:
         qsim::IO::errorf(usage);
         exit(1);
@@ -77,6 +82,7 @@ Options GetOptions(int argc, char* argv[]) {
 bool ValidateOptions(const Options& opt) {
   if (opt.circuit_file.empty()) {
     qsim::IO::errorf("circuit file is not provided.\n");
+    qsim::IO::errorf(usage);
     return false;
   }
 
@@ -112,6 +118,10 @@ int main(int argc, char* argv[]) {
   if (!CircuitQsimParser<IOFile>::FromFile(opt.maxtime, opt.circuit_file,
                                            circuit)) {
     return 1;
+  }
+
+  if (opt.denormals_are_zeros) {
+    SetFlushToZeroAndDenormalsAreZeros();
   }
 
   struct Factory {

--- a/apps/qsim_von_neumann.cc
+++ b/apps/qsim_von_neumann.cc
@@ -28,6 +28,11 @@
 #include "../lib/io_file.h"
 #include "../lib/run_qsim.h"
 #include "../lib/simmux.h"
+#include "../lib/util.h"
+
+constexpr char usage[] = "usage:\n  ./qsim_von_neumann -c circuit -d maxtime "
+                         "-s seed -t threads -f max_fused_size "
+                         "-v verbosity -z\n";
 
 struct Options {
   std::string circuit_file;
@@ -36,18 +41,15 @@ struct Options {
   unsigned num_threads = 1;
   unsigned max_fused_size = 2;
   unsigned verbosity = 0;
+  bool denormals_are_zeros = false;
 };
 
 Options GetOptions(int argc, char* argv[]) {
-  constexpr char usage[] = "usage:\n  ./qsim_von_neumann -c circuit -d maxtime "
-                           "-s seed -t threads -f max_fused_size "
-                           "-v verbosity\n";
-
   Options opt;
 
   int k;
 
-  while ((k = getopt(argc, argv, "c:d:s:t:f:v:")) != -1) {
+  while ((k = getopt(argc, argv, "c:d:s:t:f:v:z")) != -1) {
     switch (k) {
       case 'c':
         opt.circuit_file = optarg;
@@ -67,6 +69,9 @@ Options GetOptions(int argc, char* argv[]) {
       case 'v':
         opt.verbosity = std::atoi(optarg);
         break;
+      case 'z':
+        opt.denormals_are_zeros = true;
+        break;
       default:
         qsim::IO::errorf(usage);
         exit(1);
@@ -79,6 +84,7 @@ Options GetOptions(int argc, char* argv[]) {
 bool ValidateOptions(const Options& opt) {
   if (opt.circuit_file.empty()) {
     qsim::IO::errorf("circuit file is not provided.\n");
+    qsim::IO::errorf(usage);
     return false;
   }
 
@@ -97,6 +103,10 @@ int main(int argc, char* argv[]) {
   if (!CircuitQsimParser<IOFile>::FromFile(opt.maxtime, opt.circuit_file,
                                            circuit)) {
     return 1;
+  }
+
+  if (opt.denormals_are_zeros) {
+    SetFlushToZeroAndDenormalsAreZeros();
   }
 
   struct Factory {

--- a/apps/qsimh_amplitudes.cc
+++ b/apps/qsimh_amplitudes.cc
@@ -35,7 +35,7 @@ constexpr char usage[] = "usage:\n  ./qsimh_amplitudes -c circuit_file "
                          "-d maxtime -k part1_qubits "
                          "-w prefix -p num_prefix_gates -r num_root_gates "
                          "-i input_file -o output_file -t num_threads "
-                         "-v verbosity\n";
+                         "-v verbosity -z\n";
 
 struct Options {
   std::string circuit_file;
@@ -48,6 +48,7 @@ struct Options {
   unsigned num_root_gatexs = 0;
   unsigned num_threads = 1;
   unsigned verbosity = 0;
+  bool denormals_are_zeros = false;
 };
 
 Options GetOptions(int argc, char* argv[]) {
@@ -59,7 +60,7 @@ Options GetOptions(int argc, char* argv[]) {
     return std::atoi(word.c_str());
   };
 
-  while ((k = getopt(argc, argv, "c:d:k:w:p:r:i:o:t:v:")) != -1) {
+  while ((k = getopt(argc, argv, "c:d:k:w:p:r:i:o:t:v:z")) != -1) {
     switch (k) {
       case 'c':
         opt.circuit_file = optarg;
@@ -90,6 +91,9 @@ Options GetOptions(int argc, char* argv[]) {
         break;
       case 'v':
         opt.verbosity = std::atoi(optarg);
+        break;
+      case 'z':
+        opt.denormals_are_zeros = true;
         break;
       default:
         qsim::IO::errorf(usage);
@@ -179,6 +183,10 @@ int main(int argc, char* argv[]) {
     return 1;
   }
   auto parts = GetParts(circuit.num_qubits, opt.part1);
+
+  if (opt.denormals_are_zeros) {
+    SetFlushToZeroAndDenormalsAreZeros();
+  }
 
   std::vector<Bitstring> bitstrings;
   auto num_qubits = circuit.num_qubits;

--- a/apps/qsimh_base.cc
+++ b/apps/qsimh_base.cc
@@ -34,7 +34,7 @@
 constexpr char usage[] = "usage:\n  ./qsimh_base -c circuit_file "
                          "-d maximum_time -k part1_qubits "
                          "-w prefix -p num_prefix_gates -r num_root_gates "
-                         "-t num_threads -v verbosity\n";
+                         "-t num_threads -v verbosity -z\n";
 
 struct Options {
   std::string circuit_file;
@@ -45,6 +45,7 @@ struct Options {
   unsigned num_root_gatexs = 0;
   unsigned num_threads = 1;
   unsigned verbosity = 0;
+  bool denormals_are_zeros = false;
 };
 
 Options GetOptions(int argc, char* argv[]) {
@@ -56,7 +57,7 @@ Options GetOptions(int argc, char* argv[]) {
     return std::atoi(word.c_str());
   };
 
-  while ((k = getopt(argc, argv, "c:d:k:w:p:r:t:v:")) != -1) {
+  while ((k = getopt(argc, argv, "c:d:k:w:p:r:t:v:z")) != -1) {
     switch (k) {
       case 'c':
         opt.circuit_file = optarg;
@@ -81,6 +82,9 @@ Options GetOptions(int argc, char* argv[]) {
         break;
       case 'v':
         opt.verbosity = std::atoi(optarg);
+        break;
+      case 'z':
+        opt.denormals_are_zeros = true;
         break;
       default:
         qsim::IO::errorf(usage);
@@ -141,6 +145,10 @@ int main(int argc, char* argv[]) {
     return 1;
   }
   auto parts = GetParts(circuit.num_qubits, opt.part1);
+
+  if (opt.denormals_are_zeros) {
+    SetFlushToZeroAndDenormalsAreZeros();
+  }
 
   uint64_t num_bitstrings =
       std::min(uint64_t{8}, uint64_t{1} << circuit.num_qubits);

--- a/docs/cirq_interface.md
+++ b/docs/cirq_interface.md
@@ -117,6 +117,18 @@ the circuit once for each repetition unless all measurements are terminal. This
 ensures that nondeterminism from intermediate measurements is properly
 reflected in the results.
 
+In rare cases when the state vector and the gate matrices have many zero
+entries (denormal numbers), a significant performance slowdown can occur.
+Set the `denormals_are_zeros` option to `True` to prevent this issue
+potentially at the cost of a tiny precision loss:
+
+```
+# equivalent to {'t': 8, 'v': 0, 'z': True}
+qsim_options = qsimcirq.QSimOptions(cpu_threads=8, verbosity=0, denormals_are_zeros=True)
+my_sim = qsimcirq.QSimSimulator(qsim_options)
+myres = my_sim.simulate(program=my_circuit)
+```
+
 #### QSimhSimulator
 
 `QSimhSimulator` uses a hybrid Schrödinger-Feynman simulator. This limits it to

--- a/docs/cirq_interface.md
+++ b/docs/cirq_interface.md
@@ -117,10 +117,10 @@ the circuit once for each repetition unless all measurements are terminal. This
 ensures that nondeterminism from intermediate measurements is properly
 reflected in the results.
 
-In rare cases when the state vector and the gate matrices have many zero
-entries (denormal numbers), a significant performance slowdown can occur.
-Set the `denormals_are_zeros` option to `True` to prevent this issue
-potentially at the cost of a tiny precision loss:
+In rare cases when the state vector and gate matrices have many zero entries
+(denormal numbers), a significant performance slowdown can occur. Set
+the `denormals_are_zeros` option to `True` to prevent this issue potentially
+at the cost of a tiny precision loss:
 
 ```
 # equivalent to {'t': 8, 'v': 0, 'z': True}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,7 +13,7 @@ Sample circuits are provided in
 ## qsim_base usage
 
 ```
-./qsim_base.x -c circuit_file -d maxtime -t num_threads -f max_fused_size -v verbosity
+./qsim_base.x -c circuit_file -d maxtime -t num_threads -f max_fused_size -v verbosity -z
 ```
 
 | Flag | Description |
@@ -23,6 +23,7 @@ Sample circuits are provided in
 |`-t num_threads` | number of threads to use|
 |`-f max_fused_size` | maximum fused gate size|
 |`-v verbosity` | verbosity level (0,1,>1)|
+|`-z | set flush-to-zero and denormals-are-zeros MXCSR control flags|
 
 qsim_base computes all the amplitudes and just prints the first eight of them
 (or a smaller number for 1- or 2-qubit circuits).
@@ -35,7 +36,7 @@ Example:
 ## qsim_von_neumann usage
 
 ```
-./qsim_von_neumann.x -c circuit_file -d maxtime -t num_threads -f max_fused_size -v verbosity
+./qsim_von_neumann.x -c circuit_file -d maxtime -t num_threads -f max_fused_size -v verbosity -z
 ```
 
 
@@ -46,6 +47,7 @@ Example:
 |`-t num_threads` | number of threads to use|
 |`-f max_fused_size` | maximum fused gate size|
 |`-v verbosity` | verbosity level (0,1,>1)|
+|`-z | set flush-to-zero and denormals-are-zeros MXCSR control flags|
 
 qsim_von_neumann computes all the amplitudes and calculates the von Neumann
 entropy. Note that this can be quite slow for large circuits and small thread
@@ -64,18 +66,19 @@ Example:
                     -i input_files \
                     -o output_files \
                     -f max_fused_size \
-                    -t num_threads -v verbosity
+                    -t num_threads -v verbosity -z
 ```
 
 | Flag | Description |
 |-------|------------|
 |`-c circuit_file` | circuit file to run|
-|`-d times_to_save_results`  | comma-separated list of circuit times to save results at|
+|`-d times_to_save_results` | comma-separated list of circuit times to save results at|
 |`-i input_files` | comma-separated list of bitstring input files|
 |`-o output_files` | comma-separated list of amplitude output files|
 |`-t num_threads` | number of threads to use|
 |`-f max_fused_size` | maximum fused gate size|
 |`-v verbosity` | verbosity level (0,1,>1)|
+|`-z | set flush-to-zero and denormals-are-zeros MXCSR control flags|
 
 qsim_amplitudes reads input files of bitstrings, computes the corresponding
 amplitudes at specified times and writes them to output files.
@@ -97,20 +100,20 @@ Example:
                -w prefix \
                -p num_prefix_gates \
                -r num_root_gates \
-               -t num_threads -v verbosity
+               -t num_threads -v verbosity -z
 ```
 
 | Flag | Description |
 |-------|------------|
 |`-c circuit_file` | circuit file to run|
 |`-d maxtime` | maximum time |
-|`-k part1_qubits` |  comma-separated list of qubit indices for part 1 |
+|`-k part1_qubits` |  comma-separated list of qubit indices for part 1|
 |`-w prefix`| prefix value |
 |`-p num_prefix_gates` | number of prefix gates|
 |`-r num_root_gates` | number of root gates|
 |`-t num_threads` | number of threads to use|
 |`-v verbosity` | verbosity level (0,>0)|
-
+|`-z | set flush-to-zero and denormals-are-zeros MXCSR control flags|
 
 qsimh_base just computes and just prints the first eight amplitudes. The hybrid
 Schrödinger-Feynman method is used. The lattice is split into two parts.
@@ -176,14 +179,14 @@ maximum "time".
                      -p num_prefix_gates \
                      -r num_root_gates \
                      -i input_file -o output_file \
-                     -t num_threads -v verbosity
+                     -t num_threads -v verbosity -z
 ```
 
 | Flag | Description |
 |-------|------------|
 |`-c circuit_file` | circuit file to run|
 |`-d maxtime` | maximum time |
-|`-k part1_qubits` |  comma-separated list of qubit indices for part 1 |
+|`-k part1_qubits` | comma-separated list of qubit indices for part 1|
 |`-w prefix`| prefix value |
 |`-p num_prefix_gates` | number of prefix gates|
 |`-r num_root_gates` | number of root gates|
@@ -191,6 +194,7 @@ maximum "time".
 |`-o output_file` | amplitude output file|
 |`-t num_threads` | number of threads to use|
 |`-v verbosity` | verbosity level (0,>0)|
+|`-z | set flush-to-zero and denormals-are-zeros MXCSR control flags|
 
 qsimh_amplitudes reads the input file of bitstrings, computes the corresponding
 amplitudes and writes them to the output file. The hybrid Schrödinger-Feynman

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,7 +23,7 @@ Sample circuits are provided in
 |`-t num_threads` | number of threads to use|
 |`-f max_fused_size` | maximum fused gate size|
 |`-v verbosity` | verbosity level (0,1,>1)|
-|`-z | set flush-to-zero and denormals-are-zeros MXCSR control flags|
+|`-z` | set flush-to-zero and denormals-are-zeros MXCSR control flags|
 
 qsim_base computes all the amplitudes and just prints the first eight of them
 (or a smaller number for 1- or 2-qubit circuits).
@@ -47,7 +47,7 @@ Example:
 |`-t num_threads` | number of threads to use|
 |`-f max_fused_size` | maximum fused gate size|
 |`-v verbosity` | verbosity level (0,1,>1)|
-|`-z | set flush-to-zero and denormals-are-zeros MXCSR control flags|
+|`-z` | set flush-to-zero and denormals-are-zeros MXCSR control flags|
 
 qsim_von_neumann computes all the amplitudes and calculates the von Neumann
 entropy. Note that this can be quite slow for large circuits and small thread
@@ -78,7 +78,7 @@ Example:
 |`-t num_threads` | number of threads to use|
 |`-f max_fused_size` | maximum fused gate size|
 |`-v verbosity` | verbosity level (0,1,>1)|
-|`-z | set flush-to-zero and denormals-are-zeros MXCSR control flags|
+|`-z` | set flush-to-zero and denormals-are-zeros MXCSR control flags|
 
 qsim_amplitudes reads input files of bitstrings, computes the corresponding
 amplitudes at specified times and writes them to output files.
@@ -113,7 +113,7 @@ Example:
 |`-r num_root_gates` | number of root gates|
 |`-t num_threads` | number of threads to use|
 |`-v verbosity` | verbosity level (0,>0)|
-|`-z | set flush-to-zero and denormals-are-zeros MXCSR control flags|
+|`-z` | set flush-to-zero and denormals-are-zeros MXCSR control flags|
 
 qsimh_base just computes and just prints the first eight amplitudes. The hybrid
 Schrödinger-Feynman method is used. The lattice is split into two parts.
@@ -194,7 +194,7 @@ maximum "time".
 |`-o output_file` | amplitude output file|
 |`-t num_threads` | number of threads to use|
 |`-v verbosity` | verbosity level (0,>0)|
-|`-z | set flush-to-zero and denormals-are-zeros MXCSR control flags|
+|`-z` | set flush-to-zero and denormals-are-zeros MXCSR control flags|
 
 qsimh_amplitudes reads the input file of bitstrings, computes the corresponding
 amplitudes and writes them to the output file. The hybrid Schrödinger-Feynman

--- a/lib/util.h
+++ b/lib/util.h
@@ -15,6 +15,10 @@
 #ifndef UTIL_H_
 #define UTIL_H_
 
+#ifdef __SSE__
+# include <immintrin.h>
+#endif
+
 #include <algorithm>
 #include <chrono>
 #include <random>
@@ -82,6 +86,23 @@ inline std::vector<DistrRealType> GenerateRandomValues(
   rs.emplace_back(max_value);
 
   return rs;
+}
+
+// This function sets flush-to-zero and denormals-are-zeros MXCSR control
+// flags. This prevents rare cases of performance slowdown potentially at
+// the cost of a tiny precision loss.
+void SetFlushToZeroAndDenormalsAreZeros() {
+#ifdef __SSE2__
+  _mm_setcsr(_mm_getcsr() | 0x8040);
+#endif
+}
+
+// This function clears flush-to-zero and denormals-are-zeros MXCSR control
+// flags.
+void ClearFlushToZeroAndDenormalsAreZeros() {
+#ifdef __SSE2__
+  _mm_setcsr(_mm_getcsr() & ~unsigned{0x8040});
+#endif
 }
 
 }  // namespace qsim

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -383,12 +383,14 @@ std::vector<std::complex<float>> qsim_simulate(const py::dict &options) {
                             Factory>;
 
   bool use_gpu;
+  bool denormals_are_zeros;
   unsigned num_sim_threads;
   unsigned num_state_threads = 0;
   unsigned num_dblocks = 0;
   Runner::Parameter param;
   try {
     use_gpu = parseOptions<unsigned>(options, "g\0");
+    denormals_are_zeros = parseOptions<unsigned>(options, "z\0");
     if (use_gpu) {
       num_sim_threads = parseOptions<unsigned>(options, "gsmt\0");
       num_state_threads = parseOptions<unsigned>(options, "gsst\0");
@@ -403,6 +405,13 @@ std::vector<std::complex<float>> qsim_simulate(const py::dict &options) {
     IO::errorf(exp.what());
     return {};
   }
+
+  if (denormals_are_zeros) {
+    SetFlushToZeroAndDenormalsAreZeros();
+  } else {
+    ClearFlushToZeroAndDenormalsAreZeros();
+  }
+
   Runner::Run(
     param, Factory(num_sim_threads, num_state_threads, num_dblocks), circuit,
     measure);
@@ -436,6 +445,7 @@ std::vector<std::complex<float>> qtrajectory_simulate(const py::dict &options) {
 
   Runner::Parameter param;
   bool use_gpu;
+  bool denormals_are_zeros;
   unsigned num_sim_threads;
   unsigned num_state_threads = 0;
   unsigned num_dblocks = 0;
@@ -443,6 +453,7 @@ std::vector<std::complex<float>> qtrajectory_simulate(const py::dict &options) {
 
   try {
     use_gpu = parseOptions<unsigned>(options, "g\0");
+    denormals_are_zeros = parseOptions<unsigned>(options, "z\0");
     if (use_gpu) {
       num_sim_threads = parseOptions<unsigned>(options, "gsmt\0");
       num_state_threads = parseOptions<unsigned>(options, "gsst\0");
@@ -469,6 +480,12 @@ std::vector<std::complex<float>> qtrajectory_simulate(const py::dict &options) {
       amplitudes.push_back(state_space.GetAmpl(state, b));
     }
   };
+
+  if (denormals_are_zeros) {
+    SetFlushToZeroAndDenormalsAreZeros();
+  } else {
+    ClearFlushToZeroAndDenormalsAreZeros();
+  }
 
   if (!Runner::RunBatch(param, ncircuit, seed, seed + 1, state_space,
                         simulator, measure)) {
@@ -544,6 +561,7 @@ class SimulatorHelper {
       : state_space(Factory(1, 1, 1).CreateStateSpace()),
         state(StateSpace::Null()),
         scratch(StateSpace::Null()) {
+    bool denormals_are_zeros;
     is_valid = false;
     is_noisy = noisy;
     try {
@@ -557,6 +575,7 @@ class SimulatorHelper {
       }
 
       use_gpu = parseOptions<unsigned>(options, "g\0");
+      denormals_are_zeros = parseOptions<unsigned>(options, "z\0");
       if (use_gpu) {
         num_sim_threads = parseOptions<unsigned>(options, "gsmt\0");
         num_state_threads = parseOptions<unsigned>(options, "gsst\0");
@@ -572,6 +591,12 @@ class SimulatorHelper {
         num_sim_threads, num_state_threads, num_dblocks).CreateStateSpace();
       state = state_space.Create(num_qubits);
       is_valid = true;
+
+      if (denormals_are_zeros) {
+        SetFlushToZeroAndDenormalsAreZeros();
+      } else {
+        ClearFlushToZeroAndDenormalsAreZeros();
+      }
     } catch (const std::invalid_argument &exp) {
       // If this triggers, is_valid is false.
       IO::errorf(exp.what());
@@ -609,6 +634,7 @@ class SimulatorHelper {
     bool result = false;
 
     Factory factory(num_sim_threads, num_state_threads, num_dblocks);
+
     if (is_noisy) {
       std::vector<uint64_t> stat;
       auto params = get_noisy_params();
@@ -772,12 +798,14 @@ std::vector<unsigned> qsim_sample(const py::dict &options) {
                             Factory>;
 
   bool use_gpu;
+  bool denormals_are_zeros;
   unsigned num_sim_threads;
   unsigned num_state_threads = 0;
   unsigned num_dblocks = 0;
   Runner::Parameter param;
   try {
     use_gpu = parseOptions<unsigned>(options, "g\0");
+    denormals_are_zeros = parseOptions<unsigned>(options, "z\0");
     if (use_gpu) {
       num_sim_threads = parseOptions<unsigned>(options, "gsmt\0");
       num_state_threads = parseOptions<unsigned>(options, "gsst\0");
@@ -798,6 +826,12 @@ std::vector<unsigned> qsim_sample(const py::dict &options) {
   StateSpace state_space = factory.CreateStateSpace();
   State state = state_space.Create(circuit.num_qubits);
   state_space.SetStateZero(state);
+
+  if (denormals_are_zeros) {
+    SetFlushToZeroAndDenormalsAreZeros();
+  } else {
+    ClearFlushToZeroAndDenormalsAreZeros();
+  }
 
   if (!Runner::Run(param, factory, circuit, state, results)) {
     IO::errorf("qsim sampling of the circuit errored out.\n");
@@ -830,6 +864,7 @@ std::vector<unsigned> qtrajectory_sample(const py::dict &options) {
 
   Runner::Parameter param;
   bool use_gpu;
+  bool denormals_are_zeros;
   unsigned num_sim_threads;
   unsigned num_state_threads = 0;
   unsigned num_dblocks = 0;
@@ -837,6 +872,7 @@ std::vector<unsigned> qtrajectory_sample(const py::dict &options) {
 
   try {
     use_gpu = parseOptions<unsigned>(options, "g\0");
+    denormals_are_zeros = parseOptions<unsigned>(options, "z\0");
     if (use_gpu) {
       num_sim_threads = parseOptions<unsigned>(options, "gsmt\0");
       num_state_threads = parseOptions<unsigned>(options, "gsst\0");
@@ -882,6 +918,12 @@ std::vector<unsigned> qtrajectory_sample(const py::dict &options) {
       }
     }
   };
+
+  if (denormals_are_zeros) {
+    SetFlushToZeroAndDenormalsAreZeros();
+  } else {
+    ClearFlushToZeroAndDenormalsAreZeros();
+  }
 
   if (!Runner::RunBatch(param, ncircuit, seed, seed + 1,
                         state_space, simulator, measure)) {

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -142,6 +142,9 @@ class QSimOptions:
         gpu_data_blocks: number of data blocks to use on GPU. Below 16 data
             blocks, performance is noticeably reduced.
         verbosity: Logging verbosity.
+        denormals_are_zeros: if true, set flush-to-zero and denormals-are-zeros
+            MXCSR control flags. This prevents rare cases of performance
+            slowdown potentially at the cost of a tiny precision loss.
     """
 
     max_fused_gate_size: int = 2
@@ -152,6 +155,7 @@ class QSimOptions:
     gpu_state_threads: int = 512
     gpu_data_blocks: int = 16
     verbosity: int = 0
+    denormals_are_zeros: bool = False
 
     def as_dict(self):
         """Generates an options dict from this object.
@@ -167,6 +171,7 @@ class QSimOptions:
             "gsst": self.gpu_state_threads,
             "gdb": self.gpu_data_blocks,
             "v": self.verbosity,
+            "z": self.denormals_are_zeros,
         }
 
 

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -1485,11 +1485,21 @@ def test_cirq_qsim_global_shift():
     cirq_result = simulator.simulate(circuit)
 
     qsim_simulator = qsimcirq.QSimSimulator()
-    qsim_result = qsim_simulator.simulate(circuit)
+    qsim_result1 = qsim_simulator.simulate(circuit)
 
     assert cirq.linalg.allclose_up_to_global_phase(
-        qsim_result.state_vector(), cirq_result.state_vector()
+        qsim_result1.state_vector(), cirq_result.state_vector()
     )
+
+    qsim_simulator.qsim_options["u"] = True
+    qsim_result2 = qsim_simulator.simulate(circuit)
+
+    assert (qsim_result1.state_vector() == qsim_result2.state_vector()).all()
+
+    qsim_simulator.qsim_options["u"] = False
+    qsim_result3 = qsim_simulator.simulate(circuit)
+
+    assert (qsim_result1.state_vector() == qsim_result3.state_vector()).all()
 
 
 @pytest.mark.parametrize("mode", ["noiseless", "noisy"])

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -1491,12 +1491,12 @@ def test_cirq_qsim_global_shift():
         qsim_result1.state_vector(), cirq_result.state_vector()
     )
 
-    qsim_simulator.qsim_options["u"] = True
+    qsim_simulator.qsim_options["z"] = True
     qsim_result2 = qsim_simulator.simulate(circuit)
 
     assert (qsim_result1.state_vector() == qsim_result2.state_vector()).all()
 
-    qsim_simulator.qsim_options["u"] = False
+    qsim_simulator.qsim_options["z"] = False
     qsim_result3 = qsim_simulator.simulate(circuit)
 
     assert (qsim_result1.state_vector() == qsim_result3.state_vector()).all()

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -265,6 +265,7 @@ cc_library(
         "//lib:gate_appl",
         "//lib:gates_qsim",
         "//lib:io",
+        "//lib:util",
     ],
     testonly = 1,
 )


### PR DESCRIPTION
This PR introduces the possibility of setting the flush-to-zero and denormals-are-zeros MXCSR control flags. This prevents rare cases of performance slowdown (the state vector and gate matrices have many zero entries or denormal numbers) potentially at the cost of a tiny precision loss.