### PR TITLE
Fix GPU install process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.11)
-project(qsim)
+project(qsim LANGUAGES CXX CUDA)
 
 ADD_SUBDIRECTORY(pybind_interface/sse)
 ADD_SUBDIRECTORY(pybind_interface/avx512)
 ADD_SUBDIRECTORY(pybind_interface/avx2)
 ADD_SUBDIRECTORY(pybind_interface/basic)
+ADD_SUBDIRECTORY(pybind_interface/cuda)
 ADD_SUBDIRECTORY(pybind_interface/decide)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,15 @@
 cmake_minimum_required(VERSION 3.11)
-project(qsim LANGUAGES CXX CUDA)
+
+execute_process(COMMAND which nvcc OUTPUT_VARIABLE has_nvcc)
+if(has_nvcc STREQUAL "")
+    project(qsim)
+else()
+    project(qsim LANGUAGES CXX CUDA)
+    ADD_SUBDIRECTORY(pybind_interface/cuda)
+endif()
 
 ADD_SUBDIRECTORY(pybind_interface/sse)
 ADD_SUBDIRECTORY(pybind_interface/avx512)
 ADD_SUBDIRECTORY(pybind_interface/avx2)
 ADD_SUBDIRECTORY(pybind_interface/basic)
-ADD_SUBDIRECTORY(pybind_interface/cuda)
 ADD_SUBDIRECTORY(pybind_interface/decide)

--- a/pybind_interface/cuda/CMakeLists.txt
+++ b/pybind_interface/cuda/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.11)
-project(qsim)
+project(qsim LANGUAGES CXX CUDA)
 
 IF (WIN32)
     set(CMAKE_CXX_FLAGS "/O2 /openmp")
@@ -26,4 +26,15 @@ if(NOT pybind11_POPULATED)
   FetchContent_Populate(pybind11)
   add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
 endif()
-pybind11_add_module(qsim_cuda pybind_main_cuda.cpp)
+
+find_package(PythonLibs 3.6 REQUIRED)
+find_package(CUDA REQUIRED)
+
+include_directories(${PYTHON_INCLUDE_DIRS} ${pybind11_SOURCE_DIR}/include)
+
+cuda_add_library(qsim_cuda MODULE pybind_main_cuda.cpp)
+set_target_properties(qsim_cuda PROPERTIES
+       PREFIX "${PYTHON_MODULE_PREFIX}"
+       SUFFIX "${PYTHON_MODULE_EXTENSION}"
+)
+set_source_files_properties(pybind_main_cuda.cpp PROPERTIES LANGUAGE CUDA)

--- a/pybind_interface/decide/CMakeLists.txt
+++ b/pybind_interface/decide/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.11)
-project(qsim LANGUAGES CXX CUDA)
+
+execute_process(COMMAND which nvcc OUTPUT_VARIABLE has_nvcc)
+if(has_nvcc STREQUAL "")
+  project(qsim)
+else()
+  project(qsim LANGUAGES CXX CUDA)
+endif()
 
 IF (WIN32)
     set(CMAKE_CXX_FLAGS "/O2 /openmp")
@@ -26,14 +32,18 @@ if(NOT pybind11_POPULATED)
   add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
 endif()
 
-find_package(PythonLibs 3.6 REQUIRED)
-find_package(CUDA REQUIRED)
+if(has_nvcc STREQUAL "")
+  pybind11_add_module(qsim_decide decide.cpp)
+else()
+  find_package(PythonLibs 3.6 REQUIRED)
+  find_package(CUDA REQUIRED)
 
-include_directories(${PYTHON_INCLUDE_DIRS} ${pybind11_SOURCE_DIR}/include)
+  include_directories(${PYTHON_INCLUDE_DIRS} ${pybind11_SOURCE_DIR}/include)
 
-cuda_add_library(qsim_decide MODULE decide.cpp)
-set_target_properties(qsim_decide PROPERTIES
-      PREFIX "${PYTHON_MODULE_PREFIX}"
-      SUFFIX "${PYTHON_MODULE_EXTENSION}"
-)
-set_source_files_properties(decide.cpp PROPERTIES LANGUAGE CUDA)
+  cuda_add_library(qsim_decide MODULE decide.cpp)
+  set_target_properties(qsim_decide PROPERTIES
+        PREFIX "${PYTHON_MODULE_PREFIX}"
+        SUFFIX "${PYTHON_MODULE_EXTENSION}"
+  )
+  set_source_files_properties(decide.cpp PROPERTIES LANGUAGE CUDA)
+endif()

--- a/pybind_interface/decide/CMakeLists.txt
+++ b/pybind_interface/decide/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.11)
-project(qsim)
+project(qsim LANGUAGES CXX CUDA)
 
 IF (WIN32)
     set(CMAKE_CXX_FLAGS "/O2 /openmp")
@@ -25,4 +25,15 @@ if(NOT pybind11_POPULATED)
   FetchContent_Populate(pybind11)
   add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
 endif()
-pybind11_add_module(qsim_decide decide.cpp)
+
+find_package(PythonLibs 3.6 REQUIRED)
+find_package(CUDA REQUIRED)
+
+include_directories(${PYTHON_INCLUDE_DIRS} ${pybind11_SOURCE_DIR}/include)
+
+cuda_add_library(qsim_decide MODULE decide.cpp)
+set_target_properties(qsim_decide PROPERTIES
+      PREFIX "${PYTHON_MODULE_PREFIX}"
+      SUFFIX "${PYTHON_MODULE_EXTENSION}"
+)
+set_source_files_properties(decide.cpp PROPERTIES LANGUAGE CUDA)

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ class CMakeBuild(build_ext):
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = [
+            "-DCMAKE_CUDA_COMPILER=nvcc",
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
             "-DPYTHON_EXECUTABLE=" + sys.executable,
         ]
@@ -102,6 +103,7 @@ setup(
         CMakeExtension("qsimcirq/qsim_avx2"),
         CMakeExtension("qsimcirq/qsim_sse"),
         CMakeExtension("qsimcirq/qsim_basic"),
+        CMakeExtension("qsimcirq/qsim_cuda"),
         CMakeExtension("qsimcirq/qsim_decide"),
     ],
     cmdclass=dict(build_ext=CMakeBuild),


### PR DESCRIPTION
The previous cmake process didn't properly install `qsimcirq.qsim_gpu`, which meant users had to rely on `make` and only work inside the qsim directory. This PR updates the cmake to support installing GPU.

Tested on:

- [x] Linux, no GPU
- [x] Linux with GPU
- [x] Windows, no GPU
- [x] MacOS, no GPU