### PR TITLE
Align with Cirq 0.13.1

### DIFF
--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -305,7 +305,7 @@ class QSimSimulator(
         current_index = 0
         for op in measurement_ops:
             gate = op.gate
-            key = protocols.measurement_key(gate)
+            key = protocols.measurement_key_name(gate)
             meas_ops[key] = op
             if key in bounds:
                 raise ValueError(f"Duplicate MeasurementGate with key {key}")


### PR DESCRIPTION
The Cirq 0.13.1 release removed `protocols.measurement_key`, which broke qsim. This PR fixes that.