### PR TITLE
Unpin qsimcirq version in noisy_qsimcirq doc

### DIFF
--- a/docs/tutorials/noisy_qsimcirq.ipynb
+++ b/docs/tutorials/noisy_qsimcirq.ipynb
@@ -98,7 +98,7 @@
     "try:\n",
     "    import qsimcirq\n",
     "except ImportError:\n",
-    "    !pip install qsimcirq==0.9.5 --quiet\n",
+    "    !pip install qsimcirq --quiet\n",
     "    import qsimcirq"
    ]
   },


### PR DESCRIPTION
I suspect this has been broken for a while - qsimcirq 0.9.5 is likely incompatible with the latest Cirq version.