### PR TITLE
Import and use cirq instead of submodules

### DIFF
--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import warnings
+from typing import Dict, Union
 
 import cirq
+import numpy as np
+
 from . import qsim
-from typing import Dict, Union
 
 
 # List of parameter names that appear in valid Cirq protos.
@@ -300,7 +301,7 @@ class QSimCircuit(cirq.Circuit):
             return _cirq_gate_kind(op.gate) != None
 
         def to_matrix(op: cirq.ops.GateOperation):
-            mat = cirq.protocols.unitary(op.gate, None)
+            mat = cirq.unitary(op.gate, None)
             if mat is None:
                 return NotImplemented
 

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -214,7 +214,7 @@ class QSimSimulator(
                 'Keys {"c", "i", "s"} are reserved for internal use and cannot be '
                 "used in QSimCircuit instantiation."
             )
-        self._prng = cirq.parse_random_state(seed)
+        self._prng = cirq.value.parse_random_state(seed)
         self.qsim_options = QSimOptions().as_dict()
         self.qsim_options.update(qsim_options)
         self.noise = cirq.NoiseModel.from_noise_model_like(noise)

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -18,9 +18,6 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import cirq
 
-# TODO: import from cirq directly when fix is released
-from cirq.sim.simulator import SimulatesExpectationValues
-
 import numpy as np
 
 from . import qsim, qsim_gpu, qsim_custatevec
@@ -174,7 +171,7 @@ class QSimSimulator(
     cirq.SimulatesSamples,
     cirq.SimulatesAmplitudes,
     cirq.SimulatesFinalState,
-    SimulatesExpectationValues,
+    cirq.SimulatesExpectationValues,
 ):
     def __init__(
         self,

--- a/qsimcirq/qsimh_simulator.py
+++ b/qsimcirq/qsimh_simulator.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Sequence
+from typing import Sequence
 
-from cirq import study, ops, protocols, circuits, value, SimulatesAmplitudes
+import cirq
 
 from . import qsim
 import qsimcirq.qsim_circuit as qsimc
 
 
-class QSimhSimulator(SimulatesAmplitudes):
+class QSimhSimulator(cirq.SimulatesAmplitudes):
     def __init__(self, qsimh_options: dict = {}):
         """Creates a new QSimhSimulator using the given options.
 
@@ -41,10 +41,10 @@ class QSimhSimulator(SimulatesAmplitudes):
 
     def compute_amplitudes_sweep(
         self,
-        program: circuits.Circuit,
+        program: cirq.Circuit,
         bitstrings: Sequence[int],
-        params: study.Sweepable,
-        qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = cirq.QubitOrder.DEFAULT,
     ) -> Sequence[Sequence[complex]]:
 
         if not isinstance(program, qsimc.QSimCircuit):
@@ -58,12 +58,12 @@ class QSimhSimulator(SimulatesAmplitudes):
 
         options = {"i": "\n".join(bitstrings)}
         options.update(self.qsimh_options)
-        param_resolvers = study.to_resolvers(params)
+        param_resolvers = cirq.to_resolvers(params)
 
         trials_results = []
         for prs in param_resolvers:
 
-            solved_circuit = protocols.resolve_parameters(program, prs)
+            solved_circuit = cirq.resolve_parameters(program, prs)
 
             options["c"] = solved_circuit.translate_cirq_to_qsim(qubit_order)
 


### PR DESCRIPTION
Since qsimcirq is external to cirq, we can refer to names from the top-level `cirq` namespace.