### PR TITLE
Add project url to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ exec(open("qsimcirq/_version.py").read())
 setup(
     name="qsimcirq",
     version=__version__,
+    url="https://github.com/quantumlib/qsim",
     author="Vamsi Krishna Devabathini",
     author_email="devabathini92@gmail.com",
     python_requires=">=3.3.0",


### PR DESCRIPTION
This will show up in the pypi page for [qsimcirq](https://pypi.org/project/qsimcirq/) and provide a link back to github (see the [cirq](https://pypi.org/project/cirq/) page for an example, there's a "Homepage" link under "Project Links" on the sidebar).