### PR TITLE
Intermediate expectation values.

### DIFF
--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -594,7 +594,7 @@ class SimulatorHelper {
     // Aggregate expectation values for noisy circuits.
     for (unsigned i = 0; i < opsums_and_qubit_counts.size(); ++i) {
       auto& counts = std::get<1>(opsums_and_qubit_counts[i]);
-      results[i] = std::vector<std::complex<double>>(counts.size(), 0);
+      results[i].resize(counts.size(), 0);
     }
     for (unsigned rep = 0; rep < helper.noisy_reps; ++rep) {
       // Init outside of simulation to enable stepping.

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -729,18 +729,15 @@ class SimulatorHelper {
     if (is_noisy) {
       std::vector<uint64_t> stat;
       auto params = get_noisy_params();
-      NoisyCircuit<Gate> subncircuit;
-      subncircuit.num_qubits = ncircuit.num_qubits;
-      subncircuit.channels = std::vector<Channel<Gate>>(
-        ncircuit.channels.begin() + begin,
-        ncircuit.channels.begin() + end
-      );
-
       Simulator simulator = factory.CreateSimulator();
       StateSpace state_space = factory.CreateStateSpace();
 
-      result = NoisyRunner::RunOnce(params, subncircuit, seed, state_space,
-                                    simulator, scratch, state, stat);
+      result = NoisyRunner::RunOnce(
+        params, ncircuit.num_qubits,
+        ncircuit.channels.begin() + begin,
+        ncircuit.channels.begin() + end,
+        seed, state_space, simulator, scratch, state, stat
+      );
     } else {
       Circuit<Gate> subcircuit;
       subcircuit.num_qubits = circuit.num_qubits;

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -273,25 +273,6 @@ void control_last_gate(const std::vector<unsigned>& qubits,
   MakeControlledGate(qubits, values, circuit->gates.back());
 }
 
-void compose_circuits(Circuit<Cirq::GateCirq<float>>* target,
-                      Circuit<Cirq::GateCirq<float>>* suffix) {
-  // Consumes 'suffix' and composes it onto the end of 'target'.
-  // After calling this method, 'suffix' should be discarded.
-  unsigned target_time = 0;
-  for (const auto& gate : target->gates) {
-    if (gate.time >= target_time) {
-      // Target duration is the max gate time, plus one.
-      target_time = gate.time + 1;
-    }
-  }
-  for (auto& gate : suffix->gates) {
-    gate.time += target_time;
-  }
-  target->gates.insert(target->gates.end(),
-                       std::make_move_iterator(suffix->gates.begin()),
-                       std::make_move_iterator(suffix->gates.end()));
-}
-
 template <typename Gate>
 Channel<Gate> create_single_gate_channel(Gate gate) {
   auto gate_kind = KrausOperator<Gate>::kNormal;
@@ -359,33 +340,6 @@ void add_channel(const unsigned time,
     });
   }
   ncircuit->channels.push_back(channel);
-}
-
-void compose_noisy_circuits(NoisyCircuit<Cirq::GateCirq<float>>* target,
-                            NoisyCircuit<Cirq::GateCirq<float>>* suffix) {
-  // Consumes 'suffix' and composes it onto the end of 'target'.
-  // After calling this method, 'suffix' should be discarded.
-  unsigned target_time = 0;
-  for (const auto& channel : target->channels) {
-    for (const auto& kraus_op : channel) {
-      for (const auto& op : kraus_op.ops) {
-        if (op.time >= target_time) {
-          // Target duration is the max gate time, plus one.
-          target_time = op.time + 1;
-        }
-      }
-    }
-  }
-  for (auto& channel : suffix->channels) {
-    for (auto& kraus_op : channel) {
-      for (auto& op : kraus_op.ops) {
-        op.time += target_time;
-      }
-    }
-  }
-  target->channels.insert(target->channels.end(),
-                          std::make_move_iterator(suffix->channels.begin()),
-                          std::make_move_iterator(suffix->channels.end()));
 }
 
 void add_gate_to_opstring(const Cirq::GateKind gate_kind,

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -638,7 +638,6 @@ class SimulatorHelper {
     }
 
     // Aggregate expectation values for noisy circuits.
-    // TODO: split over steps
     for (unsigned i = 0; i < opsums_and_qubit_counts.size(); ++i) {
       auto& counts = std::get<1>(opsums_and_qubit_counts[i]);
       results[i] = std::vector<std::complex<double>>(counts.size(), 0);

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -47,6 +47,9 @@ void control_last_gate(const std::vector<unsigned>& qubits,
                        const std::vector<unsigned>& values,
                        qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit);
 
+void compose_circuits(qsim::Circuit<qsim::Cirq::GateCirq<float>>* target,
+                      qsim::Circuit<qsim::Cirq::GateCirq<float>>* suffix);
+
 // Methods for mutating noisy circuits.
 void add_gate_channel(
     const qsim::Cirq::GateKind gate_kind,
@@ -74,6 +77,10 @@ void add_channel(const unsigned time,
                  const std::vector<std::tuple<float, std::vector<float>, bool>>&
                      prob_matrix_unitary_triples,
                  qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* ncircuit);
+
+void compose_noisy_circuits(
+  qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* target,
+  qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* suffix);
 
 // Method for populating opstrings.
 void add_gate_to_opstring(
@@ -361,6 +368,8 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options);
             "Adds a matrix-defined gate to the given circuit.");                      \
       m.def("control_last_gate", &control_last_gate,                                  \
             "Applies controls to the final gate of a circuit.");                      \
+      m.def("compose_circuits", &compose_circuits,                                    \
+            "Composes target and suffix circuits into a single circuit.");            \
                                                                                       \
       m.def("add_gate_channel", &add_gate_channel,                                    \
             "Adds a gate to the given noisy circuit.");                               \
@@ -373,6 +382,8 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options);
                                                                                       \
       m.def("add_channel", &add_channel,                                              \
             "Adds a channel to the given noisy circuit.");                            \
+      m.def("compose_noisy_circuits", &compose_noisy_circuits,                        \
+            "Composes target and suffix noisy circuits into a single noisy circuit.");\
                                                                                       \
       m.def("add_gate_to_opstring", &add_gate_to_opstring,                            \
             "Adds a gate to the given opstring.");

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -116,6 +116,24 @@ std::vector<std::complex<double>> qsim_simulate_expectation_values(
                               qsim::Cirq::GateCirq<float>>>,
                           unsigned>>& opsums_and_qubit_counts,
     const py::array_t<float> &input_vector);
+std::vector<std::vector<std::complex<double>>>
+qsim_simulate_moment_expectation_values(
+    const py::dict &options,
+    const std::vector<std::tuple<uint64_t, std::vector<
+      std::tuple<
+        std::vector<qsim::OpString<qsim::Cirq::GateCirq<float>>>,
+        unsigned
+    >>>>& opsums_and_qubit_counts,
+    uint64_t input_state);
+std::vector<std::vector<std::complex<double>>>
+qsim_simulate_moment_expectation_values(
+    const py::dict &options,
+    const std::vector<std::tuple<uint64_t, std::vector<
+      std::tuple<
+        std::vector<qsim::OpString<qsim::Cirq::GateCirq<float>>>,
+        unsigned
+    >>>>& opsums_and_qubit_counts,
+    const py::array_t<float> &input_vector);
 std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<
@@ -129,6 +147,24 @@ std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
                           std::vector<qsim::OpString<
                               qsim::Cirq::GateCirq<float>>>,
                           unsigned>>& opsums_and_qubit_counts,
+    const py::array_t<float> &input_vector);
+std::vector<std::vector<std::complex<double>>>
+qtrajectory_simulate_moment_expectation_values(
+    const py::dict &options,
+    const std::vector<std::tuple<uint64_t, std::vector<
+      std::tuple<
+        std::vector<qsim::OpString<qsim::Cirq::GateCirq<float>>>,
+        unsigned
+    >>>>& opsums_and_qubit_counts,
+    uint64_t input_state);
+std::vector<std::vector<std::complex<double>>>
+qtrajectory_simulate_moment_expectation_values(
+    const py::dict &options,
+    const std::vector<std::tuple<uint64_t, std::vector<
+      std::tuple<
+        std::vector<qsim::OpString<qsim::Cirq::GateCirq<float>>>,
+        unsigned
+    >>>>& opsums_and_qubit_counts,
     const py::array_t<float> &input_vector);
 
 // Hybrid simulator.
@@ -186,6 +222,25 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options);
               &qsim_simulate_expectation_values),                                     \
             "Call the qsim simulator for expectation value simulation");              \
                                                                                       \
+      m.def("qsim_simulate_moment_expectation_values",                                \
+            static_cast<std::vector<std::vector<std::complex<double>>>(*)(            \
+                const py::dict&,                                                      \
+                const std::vector<std::tuple<uint64_t, std::vector<                   \
+                  std::tuple<std::vector<OpString>, unsigned>                         \
+                >>>&,                                                                 \
+                uint64_t)>(                                                           \
+              &qsim_simulate_moment_expectation_values),                              \
+            "Call the qsim simulator for step-by-step expectation value simulation"); \
+      m.def("qsim_simulate_moment_expectation_values",                                \
+            static_cast<std::vector<std::vector<std::complex<double>>>(*)(            \
+                const py::dict&,                                                      \
+                const std::vector<std::tuple<uint64_t, std::vector<                   \
+                  std::tuple<std::vector<OpString>, unsigned>                         \
+                >>>&,                                                                 \
+                const py::array_t<float>&)>(                                          \
+              &qsim_simulate_moment_expectation_values),                              \
+            "Call the qsim simulator for step-by-step expectation value simulation"); \
+                                                                                      \
       m.def("qtrajectory_simulate_expectation_values",                                \
             static_cast<std::vector<std::complex<double>>(*)(                         \
                 const py::dict&,                                                      \
@@ -201,9 +256,31 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options);
               &qtrajectory_simulate_expectation_values),                              \
             "Call the qtrajectory simulator for expectation value simulation");       \
                                                                                       \
+      m.def("qtrajectory_simulate_moment_expectation_values",                         \
+            static_cast<std::vector<std::vector<std::complex<double>>>(*)(            \
+                const py::dict&,                                                      \
+                const std::vector<std::tuple<uint64_t, std::vector<                   \
+                  std::tuple<std::vector<OpString>, unsigned>                         \
+                >>>&,                                                                 \
+                uint64_t)>(                                                           \
+              &qtrajectory_simulate_moment_expectation_values),                       \
+            "Call the qtrajectory simulator for step-by-step "                        \
+            "expectation value simulation");                                          \
+      m.def("qtrajectory_simulate_moment_expectation_values",                         \
+            static_cast<std::vector<std::vector<std::complex<double>>>(*)(            \
+                const py::dict&,                                                      \
+                const std::vector<std::tuple<uint64_t, std::vector<                   \
+                  std::tuple<std::vector<OpString>, unsigned>                         \
+                >>>&,                                                                 \
+                const py::array_t<float>&)>(                                          \
+              &qtrajectory_simulate_moment_expectation_values),                       \
+            "Call the qtrajectory simulator for step-by-step "                        \
+            "expectation value simulation");                                          \
+                                                                                      \
       /* Method for hybrid simulation */                                              \
       m.def("qsimh_simulate", &qsimh_simulate, "Call the qsimh simulator");           \
                                                                                       \
+      using KrausOperator = qsim::KrausOperator<GateCirq>;                            \
       using GateKind = qsim::Cirq::GateKind;                                          \
       using Circuit = qsim::Circuit<GateCirq>;                                        \
       using NoisyCircuit = qsim::NoisyCircuit<GateCirq>;                              \
@@ -222,6 +299,12 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options);
         .def(py::init<>())                                                            \
         .def_readwrite("weight", &OpString::weight)                                   \
         .def_readwrite("ops", &OpString::ops);                                        \
+                                                                                      \
+      py::class_<KrausOperator>(m, "KrausOperator")                                   \
+        .def(py::init<>());                                                           \
+                                                                                      \
+      py::class_<GateCirq>(m, "GateCirq")                                             \
+        .def(py::init<>());                                                           \
                                                                                       \
       py::enum_<GateKind>(m, "GateKind")                                              \
         .value("kI1", GateKind::kI1)                                                  \
@@ -346,6 +429,26 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options);
               &qsim_simulate_expectation_values),                                     \
             "Call the qsim simulator for expectation value simulation");              \
                                                                                       \
+      m.def("qsim_simulate_moment_expectation_values",                                \
+            static_cast<std::vector<std::vector<std::complex<double>>>(*)(            \
+                const py::dict&,                                                      \
+                const std::vector<std::tuple<uint64_t, std::vector<                   \
+                  std::tuple<std::vector<OpString>, unsigned>                         \
+                >>>&,                                                                 \
+                uint64_t)>(                                                           \
+              &qsim_simulate_moment_expectation_values),                              \
+            "Call the qsim simulator for step-by-step expectation value simulation"); \
+      m.def("qsim_simulate_moment_expectation_values",                                \
+            static_cast<std::vector<std::vector<std::complex<double>>>(*)(            \
+                const py::dict&,                                                      \
+                const std::vector<std::tuple<uint64_t, std::vector<                   \
+                  std::tuple<std::vector<OpString>, unsigned>                         \
+                >>>&,                                                                 \
+                const py::array_t<float>&)>(                                          \
+              &qsim_simulate_moment_expectation_values),                              \
+            "Call the qsim simulator for step-by-step expectation value simulation"); \
+                                                                                      \
+                                                                                      \
       m.def("qtrajectory_simulate_expectation_values",                                \
             static_cast<std::vector<std::complex<double>>(*)(                         \
                 const py::dict&,                                                      \
@@ -360,6 +463,27 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options);
                 const py::array_t<float>&)>(                                          \
               &qtrajectory_simulate_expectation_values),                              \
             "Call the qtrajectory simulator for expectation value simulation");       \
+                                                                                      \
+      m.def("qtrajectory_simulate_moment_expectation_values",                         \
+            static_cast<std::vector<std::vector<std::complex<double>>>(*)(            \
+                const py::dict&,                                                      \
+                const std::vector<std::tuple<uint64_t, std::vector<                   \
+                  std::tuple<std::vector<OpString>, unsigned>                         \
+                >>>&,                                                                 \
+                uint64_t)>(                                                           \
+              &qtrajectory_simulate_moment_expectation_values),                       \
+            "Call the qtrajectory simulator for step-by-step "                        \
+            "expectation value simulation");                                          \
+      m.def("qtrajectory_simulate_moment_expectation_values",                         \
+            static_cast<std::vector<std::vector<std::complex<double>>>(*)(            \
+                const py::dict&,                                                      \
+                const std::vector<std::tuple<uint64_t, std::vector<                   \
+                  std::tuple<std::vector<OpString>, unsigned>                         \
+                >>>&,                                                                 \
+                const py::array_t<float>&)>(                                          \
+              &qtrajectory_simulate_moment_expectation_values),                       \
+            "Call the qtrajectory simulator for step-by-step "                        \
+            "expectation value simulation");                                          \
                                                                                       \
       /* Method for hybrid simulation */                                              \
       m.def("qsimh_simulate", &qsimh_simulate, "Call the qsimh simulator");

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -280,7 +280,6 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options);
       /* Method for hybrid simulation */                                              \
       m.def("qsimh_simulate", &qsimh_simulate, "Call the qsimh simulator");           \
                                                                                       \
-      using KrausOperator = qsim::KrausOperator<GateCirq>;                            \
       using GateKind = qsim::Cirq::GateKind;                                          \
       using Circuit = qsim::Circuit<GateCirq>;                                        \
       using NoisyCircuit = qsim::NoisyCircuit<GateCirq>;                              \
@@ -299,12 +298,6 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options);
         .def(py::init<>())                                                            \
         .def_readwrite("weight", &OpString::weight)                                   \
         .def_readwrite("ops", &OpString::ops);                                        \
-                                                                                      \
-      py::class_<KrausOperator>(m, "KrausOperator")                                   \
-        .def(py::init<>());                                                           \
-                                                                                      \
-      py::class_<GateCirq>(m, "GateCirq")                                             \
-        .def(py::init<>());                                                           \
                                                                                       \
       py::enum_<GateKind>(m, "GateKind")                                              \
         .value("kI1", GateKind::kI1)                                                  \

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -47,9 +47,6 @@ void control_last_gate(const std::vector<unsigned>& qubits,
                        const std::vector<unsigned>& values,
                        qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit);
 
-void compose_circuits(qsim::Circuit<qsim::Cirq::GateCirq<float>>* target,
-                      qsim::Circuit<qsim::Cirq::GateCirq<float>>* suffix);
-
 // Methods for mutating noisy circuits.
 void add_gate_channel(
     const qsim::Cirq::GateKind gate_kind,
@@ -77,10 +74,6 @@ void add_channel(const unsigned time,
                  const std::vector<std::tuple<float, std::vector<float>, bool>>&
                      prob_matrix_unitary_triples,
                  qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* ncircuit);
-
-void compose_noisy_circuits(
-  qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* target,
-  qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* suffix);
 
 // Method for populating opstrings.
 void add_gate_to_opstring(
@@ -368,8 +361,6 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options);
             "Adds a matrix-defined gate to the given circuit.");                      \
       m.def("control_last_gate", &control_last_gate,                                  \
             "Applies controls to the final gate of a circuit.");                      \
-      m.def("compose_circuits", &compose_circuits,                                    \
-            "Composes target and suffix circuits into a single circuit.");            \
                                                                                       \
       m.def("add_gate_channel", &add_gate_channel,                                    \
             "Adds a gate to the given noisy circuit.");                               \
@@ -382,8 +373,6 @@ std::vector<std::complex<float>> qsimh_simulate(const py::dict &options);
                                                                                       \
       m.def("add_channel", &add_channel,                                              \
             "Adds a channel to the given noisy circuit.");                            \
-      m.def("compose_noisy_circuits", &compose_noisy_circuits,                        \
-            "Composes target and suffix noisy circuits into a single noisy circuit.");\
                                                                                       \
       m.def("add_gate_to_opstring", &add_gate_to_opstring,                            \
             "Adds a gate to the given opstring.");

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -310,6 +310,7 @@ class QSimCircuit(cirq.Circuit):
 
         qubit_to_index_dict = {q: i for i, q in enumerate(ordered_qubits)}
         time_offset = 0
+        gate_count = 0
         moment_indices = []
         for moment in self:
             ops_by_gate = [
@@ -325,10 +326,10 @@ class QSimCircuit(cirq.Circuit):
                         continue
                     qsim_op = gate_ops[gi]
                     time = time_offset + gi
-                    gate_kind = _cirq_gate_kind(qsim_op.gate)
                     add_op_to_circuit(qsim_op, time, qubit_to_index_dict, qsim_circuit)
+                    gate_count += 1
             time_offset += moment_length
-            moment_indices.append(len(qsim_circuit.gates))
+            moment_indices.append(gate_count)
 
         return qsim_circuit, moment_indices
 
@@ -363,6 +364,7 @@ class QSimCircuit(cirq.Circuit):
 
         qubit_to_index_dict = {q: i for i, q in enumerate(ordered_qubits)}
         time_offset = 0
+        gate_count = 0
         moment_indices = []
         for moment in self:
             moment_length = 0
@@ -397,8 +399,8 @@ class QSimCircuit(cirq.Circuit):
                         continue
                     qsim_op = gate_ops[gi]
                     time = time_offset + gi
-                    gate_kind = _cirq_gate_kind(qsim_op.gate)
                     add_op_to_circuit(qsim_op, time, qubit_to_index_dict, qsim_ncircuit)
+                    gate_count += 1
                 # Handle mixture output.
                 for mixture in ops_by_mix:
                     mixdata = []
@@ -410,6 +412,7 @@ class QSimCircuit(cirq.Circuit):
                         mixdata.append((prob, mat.view(np.float32), unitary))
                     qubits = [qubit_to_index_dict[q] for q in mixture.qubits]
                     qsim.add_channel(time_offset, qubits, mixdata, qsim_ncircuit)
+                    gate_count += 1
                 # Handle channel output.
                 for channel in ops_by_channel:
                     chdata = []
@@ -423,7 +426,8 @@ class QSimCircuit(cirq.Circuit):
                         chdata.append((lower_bound_prob, mat.view(np.float32), unitary))
                     qubits = [qubit_to_index_dict[q] for q in channel.qubits]
                     qsim.add_channel(time_offset, qubits, chdata, qsim_ncircuit)
+                    gate_count += 1
             time_offset += moment_length
-            moment_indices.append(len(qsim_ncircuit.channels))
+            moment_indices.append(gate_count)
 
         return qsim_ncircuit, moment_indices

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -872,6 +872,8 @@ class QSimSimulator(
             corresponding to moment boundaries.
         """
         reindex = [0]
+        full_circuit = qsim.NoisyCircuit() if is_noisy else qsim.Circuit()
+        full_circuit.num_qubits = len(circuit.all_qubits())
         for moment in circuit:
             subc = self._translate_circuit(
                 qsimc.QSimCircuit(cirq.Circuit(moment)),
@@ -879,6 +881,9 @@ class QSimSimulator(
                 qubit_order,
             )
             reindex.append(len(subc.channels if is_noisy else subc.gates) + reindex[-1])
+            if is_noisy:
+                qsim.compose_noisy_circuits(full_circuit, subc)
+            else:
+                qsim.compose_circuits(full_circuit, subc)
 
-        full_circuit = self._translate_circuit(circuit, translator_fn_name, qubit_order)
         return full_circuit, reindex[1:]

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -14,7 +14,8 @@
 
 from collections import deque
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from xml.etree.ElementPath import ops
 
 import cirq
 
@@ -595,7 +596,7 @@ class QSimSimulator(
         Args:
             program: The circuit to simulate.
             observables: An observable or list of observables.
-            param_resolver: Parameters to run with the program.
+            params: Parameters to run with the program.
             qubit_order: Determines the canonical ordering of the qubits. This
                 is often used in specifying the initial state, i.e. the
                 ordering of the computational basis states.
@@ -698,6 +699,144 @@ class QSimSimulator(
 
         return results
 
+    def simulate_moment_expectation_values(
+        self,
+        program: cirq.Circuit,
+        indexed_observables: Union[
+            Dict[int, Union[cirq.PauliSumLike, List[cirq.PauliSumLike]]],
+            cirq.PauliSumLike,
+            List[cirq.PauliSumLike],
+        ],
+        param_resolver: cirq.ParamResolver,
+        qubit_order: cirq.QubitOrderOrList = cirq.QubitOrder.DEFAULT,
+        initial_state: Any = None,
+    ) -> List[List[float]]:
+        """Calculates expectation values at each moment of a circuit.
+
+        Args:
+            program: The circuit to simulate.
+            indexed_observables: A map of moment indices to an observable
+                or list of observables to calculate after that moment. As a
+                convenience, users can instead pass in a single observable
+                or observable list to calculate after ALL moments.
+            param_resolver: Parameters to run with the program.
+            qubit_order: Determines the canonical ordering of the qubits. This
+                is often used in specifying the initial state, i.e. the
+                ordering of the computational basis states.
+            initial_state: The initial state for the simulation. The form of
+                this state depends on the simulation implementation. See
+                documentation of the implementing class for details.
+            permit_terminal_measurements: If the provided circuit ends with
+                measurement(s), this method will generate an error unless this
+                is set to True. This is meant to prevent measurements from
+                ruining expectation value calculations.
+
+        Returns:
+            A list of expectation values for each moment m in the circuit,
+            where value `n` corresponds to `indexed_observables[m][n]`.
+
+        Raises:
+            ValueError if 'program' has terminal measurement(s) and
+            'permit_terminal_measurements' is False. (Note: We cannot test this
+            until Cirq's `are_any_measurements_terminal` is released.)
+        """
+        if not isinstance(indexed_observables, Dict):
+            if not isinstance(indexed_observables, List):
+                indexed_observables = [
+                    (i, [indexed_observables]) for i, _ in enumerate(program)
+                ]
+            else:
+                indexed_observables = [
+                    (i, indexed_observables) for i, _ in enumerate(program)
+                ]
+        else:
+            indexed_observables = [
+                (i, obs) if isinstance(obs, List) else (i, [obs])
+                for i, obs in indexed_observables.items()
+            ]
+        indexed_observables.sort(key=lambda x: x[0])
+        psum_pairs = [
+            (i, [cirq.PauliSum.wrap(pslike) for pslike in obs_list])
+            for i, obs_list in indexed_observables
+        ]
+
+        all_qubits = program.all_qubits()
+        cirq_order = cirq.QubitOrder.as_qubit_order(qubit_order).order_for(all_qubits)
+        qsim_order = list(reversed(cirq_order))
+        num_qubits = len(qsim_order)
+        qubit_map = {qubit: index for index, qubit in enumerate(qsim_order)}
+
+        opsums_and_qcount_map = {}
+        for i, psumlist in psum_pairs:
+            opsums_and_qcount_map[i] = []
+            for psum in psumlist:
+                opsum = []
+                opsum_qubits = set()
+                for pstr in psum:
+                    opstring = qsim.OpString()
+                    opstring.weight = pstr.coefficient
+                    for q, pauli in pstr.items():
+                        op = pauli.on(q)
+                        opsum_qubits.add(q)
+                        qsimc.add_op_to_opstring(op, qubit_map, opstring)
+                    opsum.append(opstring)
+                opsums_and_qcount_map[i].append((opsum, len(opsum_qubits)))
+
+        if initial_state is None:
+            initial_state = 0
+        if not isinstance(initial_state, (int, np.ndarray)):
+            raise TypeError("initial_state must be an int or state vector.")
+
+        # Add noise to the circuit if a noise model was provided.
+        program = qsimc.QSimCircuit(
+            self.noise.noisy_moments(program, sorted(all_qubits))
+            if self.noise is not cirq.NO_NOISE
+            else program,
+            device=program.device,
+        )
+
+        options = {}
+        options.update(self.qsim_options)
+
+        param_resolver = cirq.to_resolvers(param_resolver)
+        if isinstance(initial_state, np.ndarray):
+            if initial_state.dtype != np.complex64:
+                raise TypeError(f"initial_state vector must have dtype np.complex64.")
+            input_vector = initial_state.view(np.float32)
+            if len(input_vector) != 2 ** num_qubits * 2:
+                raise ValueError(
+                    f"initial_state vector size must match number of qubits."
+                    f"Expected: {2**num_qubits * 2} Received: {len(input_vector)}"
+                )
+
+        is_noisy = _needs_trajectories(program)
+        if is_noisy:
+            translator_fn_name = "translate_cirq_to_qtrajectory"
+            ev_simulator_fn = (
+                self._sim_module.qtrajectory_simulate_moment_expectation_values
+            )
+        else:
+            translator_fn_name = "translate_cirq_to_qsim"
+            ev_simulator_fn = self._sim_module.qsim_simulate_moment_expectation_values
+
+        solved_circuit = cirq.resolve_parameters(program, param_resolver)
+        options["c"], opsum_reindex = self._translate_moments(
+            solved_circuit,
+            translator_fn_name,
+            cirq_order,
+            is_noisy,
+        )
+        opsums_and_qubit_counts = []
+        for m, opsum_qc in opsums_and_qcount_map.items():
+            pair = (opsum_reindex[m], opsum_qc)
+            opsums_and_qubit_counts.append(pair)
+        options["s"] = self.get_seed()
+
+        if isinstance(initial_state, int):
+            return ev_simulator_fn(options, opsums_and_qubit_counts, initial_state)
+        elif isinstance(initial_state, np.ndarray):
+            return ev_simulator_fn(options, opsums_and_qubit_counts, input_vector)
+
     def _translate_circuit(
         self,
         circuit: Any,
@@ -718,3 +857,28 @@ class QSimSimulator(
             self._translated_circuits.append((circuit, translated_circuit))
 
         return translated_circuit
+
+    def _translate_moments(
+        self,
+        circuit: Any,
+        translator_fn_name: str,
+        qubit_order: cirq.QubitOrderOrList,
+        is_noisy: bool,
+    ):
+        """Translates a circuit by moments.
+
+        Returns:
+            A tuple containing the translated circuit and the gate indices
+            corresponding to moment boundaries.
+        """
+        reindex = [0]
+        for moment in circuit:
+            subc = self._translate_circuit(
+                qsimc.QSimCircuit(cirq.Circuit(moment)),
+                translator_fn_name,
+                qubit_order,
+            )
+            reindex.append(len(subc.channels if is_noisy else subc.gates) + reindex[-1])
+
+        full_circuit = self._translate_circuit(circuit, translator_fn_name, qubit_order)
+        return full_circuit, reindex[1:]

--- a/qsimcirq/qsimh_simulator.py
+++ b/qsimcirq/qsimh_simulator.py
@@ -65,7 +65,7 @@ class QSimhSimulator(cirq.SimulatesAmplitudes):
 
             solved_circuit = cirq.resolve_parameters(program, prs)
 
-            options["c"] = solved_circuit.translate_cirq_to_qsim(qubit_order)
+            options["c"], _ = solved_circuit.translate_cirq_to_qsim(qubit_order)
 
             options.update(self.qsimh_options)
             amplitudes = qsim.qsimh_simulate(options)

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -488,7 +488,7 @@ def test_moment_expectation_values(mode: str):
         circuit, psum, params
     )
     # Omit noise trigger element
-    results = [r[0] for r in qsim_result][:20]
+    results = [r[0] for r in qsim_result][:steps]
     assert np.allclose(
         [result.real for result in results],
         [np.cos(np.pi * (i + 1) / 20) for i in range(steps)],

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -471,6 +471,60 @@ def test_expectation_values(mode: str):
     assert cirq.approx_eq(qsim_result, cirq_result, atol=1e-6)
 
 
+@pytest.mark.parametrize("mode", ["noiseless", "noisy"])
+def test_moment_expectation_values(mode: str):
+    # Perform a single-pass Rabi oscillation, measuring Z at each step.
+    q0 = cirq.LineQubit(0)
+    steps = 20
+    circuit = cirq.Circuit(*[cirq.X(q0) ** 0.05 for _ in range(steps)])
+    psum = cirq.Z(q0)
+    params = {}
+
+    if mode == "noisy":
+        circuit.append(NoiseTrigger().on(q0))
+
+    qsim_simulator = qsimcirq.QSimSimulator()
+    qsim_result = qsim_simulator.simulate_moment_expectation_values(
+        circuit, psum, params
+    )
+    # Omit noise trigger element
+    results = [r[0] for r in qsim_result][:20]
+    assert np.allclose(
+        [result.real for result in results],
+        [np.cos(np.pi * (i + 1) / 20) for i in range(steps)],
+        atol=1e-6,
+    )
+
+
+@pytest.mark.parametrize("mode", ["noiseless", "noisy"])
+def test_select_moment_expectation_values(mode: str):
+    # Measure different observables after specified steps.
+    q0, q1 = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.Moment(cirq.X(q0), cirq.H(q1)),
+        cirq.Moment(cirq.H(q0), cirq.Z(q1)),
+        cirq.Moment(cirq.Z(q0), cirq.H(q1)),
+        cirq.Moment(cirq.H(q0), cirq.X(q1)),
+    )
+    psum_map = {
+        0: cirq.Z(q0),
+        1: [cirq.X(q0), cirq.Z(q1)],
+        3: [cirq.Z(q0), cirq.Z(q1)],
+    }
+    params = {}
+
+    if mode == "noisy":
+        circuit.append(NoiseTrigger().on(q0))
+
+    qsim_simulator = qsimcirq.QSimSimulator()
+    qsim_result = qsim_simulator.simulate_moment_expectation_values(
+        circuit, psum_map, params
+    )
+    expected_results = [[-1], [-1, 0], [1, 1]]
+    for i, result in enumerate(qsim_result):
+        assert np.allclose(result, expected_results[i])
+
+
 def test_expectation_values_terminal_measurement_check():
     a, b = [
         cirq.GridQubit(0, 0),


### PR DESCRIPTION
Adds `simulate_moment_expectation_values` to the QSimSimulator API.

This method accepts a dict of (moment index: observable list), and calculates the requested observables at the specified moments. Special-case behavior is provided for calculating the same observable (or list of observables) at every moment.