### PR TITLE
Reuse quantum trajectory results.

### DIFF
--- a/lib/qtrajectory.h
+++ b/lib/qtrajectory.h
@@ -62,12 +62,14 @@ class QuantumTrajectorySimulator {
      * operators are sampled for each channel and there are no measurements
      * in the computational basis. This can be used to speed up simulations
      * of circuits with weak noise and without measurements by reusing
-     * the primary trajectory results. It is the client's responsibility
-     * to collect the primary trajectory results and to reuse them. There is
-     * an additional condition for RunBatch. In this case, the deferred
-     * operators after the main loop are still applied for the first occurence
-     * of the primary trajectory. The primary Kraus operators should have
-     * the highest sampling probabilities to achieve the highest speedup.
+     * the primary trajectory results. There is an additional condition for
+     * RunBatch. In this case, the deferred operators after the main loop are
+     * still applied for the first occurence of the primary trajectory.
+     * The primary Kraus operators should have the highest sampling
+     * probabilities to achieve the highest speedup.
+     *
+     * It is the client's responsibility to collect the primary trajectory
+     * results and to reuse them.
      */
     bool apply_last_deferred_ops = true;
   };

--- a/lib/qtrajectory.h
+++ b/lib/qtrajectory.h
@@ -56,12 +56,18 @@ class QuantumTrajectorySimulator {
      */
     bool normalize_before_mea_gates = true;
     /**
-     * If false, do not apply deferred operators after the main loop.
-     * This can be used to speed up simulations of circuits with weak noise
-     * and without measurements by reusing the results for the "primary" noise
-     * realization, that is the noise realization in which the  "primary"
-     * (highest probability) Kraus operators are sampled in each channel.
-     * The primary Kraus operators should be first in their respective channels.
+     * If false, do not apply deferred operators after the main loop for
+     * the "primary" noise trajectory, that is the trajectory in which
+     * the primary (the first operators in their respective channels) Kraus
+     * operators are sampled for each channel and there are no measurements
+     * in the computational basis. This can be used to speed up simulations
+     * of circuits with weak noise and without measurements by reusing
+     * the primary trajectory results. It is the client's responsibility
+     * to collect the primary trajectory results and to reuse them. There is
+     * an additional condition for RunBatch. In this case, the deferred
+     * operators after the main loop are still applied for the first occurence
+     * of the primary trajectory. The primary Kraus operators should have
+     * the highest sampling probabilities to achieve the highest speedup.
      */
     bool apply_last_deferred_ops = true;
   };
@@ -75,7 +81,7 @@ class QuantumTrajectorySimulator {
      */
     std::vector<uint64_t> samples;
     /**
-     * True if the "primary" noise realization is sampled, false otherwise.
+     * True if the "primary" noise trajectory is sampled, false otherwise.
      */
     bool primary;
   };

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -481,8 +481,7 @@ std::vector<std::complex<float>> qtrajectory_simulate(const py::dict &options) {
   StateSpace state_space = factory.CreateStateSpace();
 
   auto measure = [&bitstrings, &ncircuit, &amplitudes, &state_space](
-                  unsigned k, const State &state,
-                  std::vector<uint64_t>& stat) {
+                  unsigned k, const State &state, Runner::Stat& stat) {
     for (const auto &b : bitstrings) {
       amplitudes.push_back(state_space.GetAmpl(state, b));
     }
@@ -711,7 +710,7 @@ class SimulatorHelper {
     bool result = false;
 
     if (is_noisy) {
-      std::vector<uint64_t> stat;
+      NoisyRunner::Stat stat;
       auto params = get_noisy_params();
 
       Simulator simulator = factory.CreateSimulator();
@@ -730,7 +729,7 @@ class SimulatorHelper {
     bool result = false;
 
     if (is_noisy) {
-      std::vector<uint64_t> stat;
+      NoisyRunner::Stat stat;
       auto params = get_noisy_params();
       Simulator simulator = factory.CreateSimulator();
       StateSpace state_space = factory.CreateStateSpace();
@@ -1051,24 +1050,23 @@ std::vector<unsigned> qtrajectory_sample(const py::dict &options) {
   std::vector<std::vector<unsigned>> results;
 
   auto measure = [&results, &ncircuit, &state_space](
-                  unsigned k, const State &state,
-                  std::vector<uint64_t>& stat) {
+                  unsigned k, const State& state, Runner::Stat& stat) {
     // Converts stat (which matches the MeasurementResult 'bits' field) into
     // bitstrings matching the MeasurementResult 'bitstring' field.
     unsigned idx = 0;
     for (const auto& channel : ncircuit.channels) {
       if (channel[0].kind != gate::kMeasurement)
         continue;
-      for (const auto &op : channel[0].ops) {
+      for (const auto& op : channel[0].ops) {
         std::vector<unsigned> bitstring;
-        uint64_t val = stat[idx];
-        for (const auto &q : op.qubits) {
+        uint64_t val = stat.samples[idx];
+        for (const auto& q : op.qubits) {
           bitstring.push_back((val >> q) & 1);
         }
         results.push_back(bitstring);
 
         idx += 1;
-        if (idx >= stat.size())
+        if (idx >= stat.samples.size())
           return;
       }
     }

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -217,6 +217,7 @@ cc_library(
         "//lib:channel",
         "//lib:channels_cirq",
         "//lib:circuit_noisy",
+        "//lib:expect",
         "//lib:fuser_mqubit",
         "//lib:gate_appl",
         "//lib:gates_cirq",

--- a/tests/channels_cirq_test.cc
+++ b/tests/channels_cirq_test.cc
@@ -68,10 +68,10 @@ void RunBatch(const NoisyCircuit<Gate>& ncircuit,
   unsigned num_threads = 1;
 
   auto measure = [](uint64_t r, const State& state,
-                    const std::vector<uint64_t>& stat,
+                    const QTSimulator::Stat& stat,
                     std::vector<unsigned>& histogram) {
-    ASSERT_EQ(stat.size(), 1);
-    ++histogram[stat[0]];
+    ASSERT_EQ(stat.samples.size(), 1);
+    ++histogram[stat.samples[0]];
   };
 
   std::vector<unsigned> histogram(1 << num_qubits, 0);

--- a/tests/qtrajectory_avx_test.cc
+++ b/tests/qtrajectory_avx_test.cc
@@ -44,6 +44,10 @@ TEST(QTrajectoryAVXTest, GenDump) {
   TestGenDump(qsim::Factory<SequentialFor>());
 }
 
+TEST(QTrajectoryAVXTest, ReusingResults) {
+  TestReusingResults(qsim::Factory<SequentialFor>());
+}
+
 TEST(QTrajectoryAVXTest, CollectKopStat) {
   TestCollectKopStat(qsim::Factory<SequentialFor>());
 }

--- a/tests/qtrajectory_cuda_test.cu
+++ b/tests/qtrajectory_cuda_test.cu
@@ -58,6 +58,14 @@ TEST(QTrajectoryCUDATest, GenDump) {
   TestGenDump(factory);
 }
 
+TEST(QTrajectoryCUDATest, ReusingResults) {
+  using Factory = qsim::Factory<float>;
+  Factory::StateSpace::Parameter param1;
+  Factory::Simulator::Parameter param2;
+  Factory factory(param1, param2);
+  TestReusingResults(factory);
+}
+
 TEST(QTrajectoryCUDATest, CollectKopStat) {
   using Factory = qsim::Factory<float>;
   Factory::StateSpace::Parameter param1;

--- a/tests/qtrajectory_custatevec_test.cu
+++ b/tests/qtrajectory_custatevec_test.cu
@@ -59,6 +59,10 @@ TEST(QTrajectoryCuStateVecTest, GenDump) {
   TestGenDump(qsim::Factory<float>());
 }
 
+TEST(QTrajectoryCuStateVecTest, ReusingResults) {
+  TestReusingResults(qsim::Factory<float>());
+}
+
 TEST(QTrajectoryCuStateVecTest, CollectKopStat) {
   TestCollectKopStat(qsim::Factory<float>());
 }

--- a/tests/qtrajectory_testfixture.h
+++ b/tests/qtrajectory_testfixture.h
@@ -24,6 +24,7 @@
 #include "../lib/channel.h"
 #include "../lib/channels_cirq.h"
 #include "../lib/circuit_noisy.h"
+#include "../lib/expect.h"
 #include "../lib/fuser_mqubit.h"
 #include "../lib/gate_appl.h"
 #include "../lib/gates_cirq.h"
@@ -238,9 +239,66 @@ void AddGenAmplDumpNoise2Alt(
   }
 }
 
+template <typename Gate>
+void AddAmplDumpNoise1(
+    unsigned time, unsigned q, double g, NoisyCircuit<Gate>& ncircuit) {
+  using fp_type = typename Gate::fp_type;
+
+  double p1 = 1 - g;
+  double p2 = 0;
+
+  fp_type r = std::sqrt(p1);
+  fp_type s = std::sqrt(g);
+
+  auto normal = KrausOperator<Gate>::kNormal;
+
+  using M = Cirq::MatrixGate1<fp_type>;
+
+  ncircuit.channels.push_back(
+      {{normal, 0, p1, {M::Create(time, q, {1, 0, 0, 0, 0, 0, r, 0})}},
+       {normal, 0, p2, {M::Create(time, q, {0, 0, s, 0, 0, 0, 0, 0})}}});
+
+  for (auto& kop : ncircuit.channels.back()) {
+    kop.CalculateKdKMatrix();
+  }
+}
+
+template <typename Gate>
+void AddAmplDumpNoise2(
+    unsigned time, double g, NoisyCircuit<Gate>& ncircuit) {
+  using fp_type = typename Gate::fp_type;
+
+  double p1 = 1 - g;
+  double p2 = 0;
+
+  fp_type r = std::sqrt(p1);
+  fp_type s = std::sqrt(g);
+
+  auto normal = KrausOperator<Gate>::kNormal;
+
+  using M = Cirq::MatrixGate1<fp_type>;
+
+  ncircuit.channels.push_back(
+      {{normal, 0, p1, {M::Create(time, 0, {1, 0, 0, 0, 0, 0, r, 0})}},
+       {normal, 0, p2, {M::Create(time, 0, {0, 0, s, 0, 0, 0, 0, 0})}}});
+
+  for (auto& kop : ncircuit.channels.back()) {
+    kop.CalculateKdKMatrix();
+  }
+
+  ncircuit.channels.push_back(
+      {{normal, 0, p1, {M::Create(time, 1, {1, 0, 0, 0, 0, 0, r, 0})}},
+       {normal, 0, p2, {M::Create(time, 1, {0, 0, s, 0, 0, 0, 0, 0})}}});
+
+  for (auto& kop : ncircuit.channels.back()) {
+    kop.CalculateKdKMatrix();
+  }
+}
+
 template <typename Gate, typename AddNoise1, typename AddNoise2>
 NoisyCircuit<Gate> GenerateNoisyCircuit(
-    double p, AddNoise1&& add_noise1, AddNoise2&& add_noise2) {
+    double p, AddNoise1&& add_noise1, AddNoise2&& add_noise2,
+    bool add_measurement = true) {
   using fp_type = typename Gate::fp_type;
 
   NoisyCircuit<Gate> ncircuit;
@@ -273,9 +331,12 @@ NoisyCircuit<Gate> GenerateNoisyCircuit(
   add_noise1(9, 1, p, ncircuit);
   ncircuit.channels.push_back({{normal, 1, 1.0, {IS::Create(10, 0, 1)}}});
   add_noise2(11, p, ncircuit);
-  ncircuit.channels.push_back({{KrausOperator<Gate>::kMeasurement, 1, 1.0,
-                              {gate::Measurement<Gate>::Create(12, {0, 1})}}});
-  add_noise2(13, p, ncircuit);
+  if (add_measurement) {
+    ncircuit.channels.push_back(
+        {{KrausOperator<Gate>::kMeasurement, 1, 1.0,
+          {gate::Measurement<Gate>::Create(12, {0, 1})}}});
+    add_noise2(13, p, ncircuit);
+  }
 
   return ncircuit;
 }
@@ -293,10 +354,10 @@ void RunBatch(const Factory& factory, const NoisyCircuit<Gate>& ncircuit,
   unsigned num_reps = 25000;
 
   auto measure = [](uint64_t r, const State& state,
-                    const std::vector<uint64_t>& stat,
+                    const typename QTSimulator::Stat& stat,
                     std::vector<unsigned>& histogram) {
-    ASSERT_EQ(stat.size(), 1);
-    ++histogram[stat[0]];
+    ASSERT_EQ(stat.samples.size(), 1);
+    ++histogram[stat.samples[0]];
   };
 
   std::vector<unsigned> histogram(1 << num_qubits, 0);
@@ -334,9 +395,7 @@ void RunOnceRepeatedly(const Factory& factory,
   State state = state_space.Create(num_qubits);
   EXPECT_FALSE(state_space.IsNull(state));
 
-  auto state_pointer = state.get();
-
-  std::vector<uint64_t> stat;
+  typename QTSimulator::Stat stat;
 
   std::vector<unsigned> histogram(1 << num_qubits, 0);
 
@@ -349,15 +408,188 @@ void RunOnceRepeatedly(const Factory& factory,
     EXPECT_TRUE(QTSimulator::RunOnce(
         param, ncircuit, i, state_space, simulator, state, stat));
 
-    EXPECT_EQ(state_pointer, state.get());
-
-    ASSERT_EQ(stat.size(), 1);
-    ++histogram[stat[0]];
+    ASSERT_EQ(stat.samples.size(), 1);
+    ++histogram[stat.samples[0]];
   }
 
   for (std::size_t i = 0; i < histogram.size(); ++i) {
     EXPECT_NEAR(double(histogram[i]) / num_reps, expected_results[i], 0.005);
   }
+}
+
+template <typename Factory, typename Gate>
+std::vector<std::complex<double>> ExpValsRunBatch(
+    const Factory& factory, const NoisyCircuit<Gate>& ncircuit,
+    bool reuse_results) {
+  using Simulator = typename Factory::Simulator;
+  using StateSpace = typename Factory::StateSpace;
+  using State = typename StateSpace::State;
+  using Fuser = MultiQubitGateFuser<IO, Gate>;
+  using QTSimulator = QuantumTrajectorySimulator<IO, Gate, MultiQubitGateFuser,
+                                                 Simulator>;
+
+  unsigned num_qubits = 2;
+  unsigned num_reps = 25000;
+
+  Simulator simulator = factory.CreateSimulator();
+  StateSpace state_space = factory.CreateStateSpace();
+
+  State state = state_space.Create(num_qubits);
+  EXPECT_FALSE(state_space.IsNull(state));
+
+  typename QTSimulator::Stat stat;
+
+  typename QTSimulator::Parameter param;
+  param.apply_last_deferred_ops = !reuse_results;
+
+  using Observables = std::vector<std::vector<qsim::OpString<Gate>>>;
+  Observables observables;
+  observables.reserve(num_qubits);
+
+  using rx = qsim::Cirq::rx<typename Gate::fp_type>;
+
+  for (unsigned q = 0; q < num_qubits; ++q) {
+    observables.push_back({{{1.0, 0.0}, {rx::Create(0, q, 1.7 + 0.6 * q)}}});
+  }
+
+  using TrajResults = std::vector<std::vector<std::complex<double>>>;
+  TrajResults traj_results(observables.size());
+
+  for (std::size_t k = 0; k < observables.size(); ++k) {
+    traj_results[k].reserve(num_reps);
+  }
+
+  std::vector<std::complex<double>> primary_results;
+  primary_results.reserve(observables.size());
+
+  auto measure = [](uint64_t r, const State& state,
+                    const typename QTSimulator::Stat& stat,
+                    const Simulator& simulator, bool reuse_results,
+                    const Observables& observables,
+                    std::vector<std::complex<double>>& primary_results,
+                    TrajResults& traj_results) {
+    if (reuse_results && stat.primary && !primary_results.empty()) {
+      for (std::size_t k = 0; k < observables.size(); ++k) {
+        traj_results[k].push_back(primary_results[k]);
+      }
+    } else {
+      for (std::size_t k = 0; k < observables.size(); ++k) {
+        const auto& obs = observables[k];
+        auto result = ExpectationValue<IO, Fuser>(obs, simulator, state);
+        traj_results[k].push_back(result);
+
+        if (reuse_results && stat.primary) {
+          primary_results.push_back(result);
+        }
+      }
+    }
+  };
+
+  EXPECT_TRUE(QTSimulator::RunBatch(param, ncircuit, 0, num_reps, state_space,
+                                    simulator, measure, simulator,
+                                    reuse_results, observables, primary_results,
+                                    traj_results));
+
+  std::vector<std::complex<double>> results;
+  results.reserve(observables.size());
+
+  double inverse_num_reps = 1.0 / num_reps;
+
+  for (std::size_t k = 0; k < observables.size(); ++k) {
+    std::complex<double> sum = 0;
+    for (unsigned i = 0; i < num_reps; ++i) {
+      sum += traj_results[k][i];
+    }
+
+    results.push_back(inverse_num_reps * sum);
+  }
+
+  return results;
+}
+
+template <typename Factory, typename Gate>
+std::vector<std::complex<double>> ExpValsRunOnceRepeatedly(
+    const Factory& factory, const NoisyCircuit<Gate>& ncircuit,
+    bool reuse_results) {
+  using Simulator = typename Factory::Simulator;
+  using StateSpace = typename Factory::StateSpace;
+  using State = typename StateSpace::State;
+  using Fuser = MultiQubitGateFuser<IO, Gate>;
+  using QTSimulator = QuantumTrajectorySimulator<IO, Gate, MultiQubitGateFuser,
+                                                 Simulator>;
+
+  unsigned num_qubits = 2;
+  unsigned num_reps = 25000;
+
+  Simulator simulator = factory.CreateSimulator();
+  StateSpace state_space = factory.CreateStateSpace();
+
+  State state = state_space.Create(num_qubits);
+  EXPECT_FALSE(state_space.IsNull(state));
+
+  typename QTSimulator::Stat stat;
+
+  typename QTSimulator::Parameter param;
+  param.apply_last_deferred_ops = true;
+
+  std::vector<std::vector<qsim::OpString<Gate>>> observables;
+  observables.reserve(num_qubits);
+
+  using rx = qsim::Cirq::rx<typename Gate::fp_type>;
+
+  for (unsigned q = 0; q < num_qubits; ++q) {
+    observables.push_back({{{1.0, 0.0}, {rx::Create(0, q, 1.7 + 0.6 * q)}}});
+  }
+
+  using TrajResults = std::vector<std::vector<std::complex<double>>>;
+  TrajResults traj_results(observables.size());
+
+  for (std::size_t k = 0; k < observables.size(); ++k) {
+    traj_results[k].reserve(num_reps);
+  }
+
+  std::vector<std::complex<double>> primary_results;
+  primary_results.reserve(observables.size());
+
+  for (unsigned i = 0; i < num_reps; ++i) {
+    state_space.SetStateZero(state);
+
+    EXPECT_TRUE(QTSimulator::RunOnce(
+        param, ncircuit, i, state_space, simulator, state, stat));
+
+    if (reuse_results && stat.primary && !primary_results.empty()) {
+      for (std::size_t k = 0; k < observables.size(); ++k) {
+        traj_results[k].push_back(primary_results[k]);
+      }
+    } else {
+      for (std::size_t k = 0; k < observables.size(); ++k) {
+        const auto& obs = observables[k];
+        auto result = ExpectationValue<IO, Fuser>(obs, simulator, state);
+        traj_results[k].push_back(result);
+
+        if (reuse_results && stat.primary) {
+          primary_results.push_back(result);
+          param.apply_last_deferred_ops = false;
+        }
+      }
+    }
+  }
+
+  std::vector<std::complex<double>> results;
+  results.reserve(observables.size());
+
+  double inverse_num_reps = 1.0 / num_reps;
+
+  for (std::size_t k = 0; k < observables.size(); ++k) {
+    std::complex<double> sum = 0;
+    for (unsigned i = 0; i < num_reps; ++i) {
+      sum += traj_results[k][i];
+    }
+
+    results.push_back(inverse_num_reps * sum);
+  }
+
+  return results;
 }
 
 template <typename Factory>
@@ -471,6 +703,28 @@ for key, val in sorted(res.histogram(key='m').items()):
 }
 
 template <typename Factory>
+void TestReusingResults(const Factory& factory) {
+  using Gate = Cirq::GateCirq<typename Factory::fp_type>;
+
+  auto ncircuit = GenerateNoisyCircuit<Gate>(0.02, AddAmplDumpNoise1<Gate>,
+                                             AddAmplDumpNoise2<Gate>, false);
+
+  auto results1 = ExpValsRunOnceRepeatedly(factory, ncircuit, false);
+  auto results2 = ExpValsRunOnceRepeatedly(factory, ncircuit, true);
+  auto results3 = ExpValsRunBatch(factory, ncircuit, false);
+  auto results4 = ExpValsRunBatch(factory, ncircuit, true);
+
+  for (std::size_t k = 0; k < results1.size(); ++k) {
+    EXPECT_NEAR(std::real(results1[k]), std::real(results2[k]), 1e-8);
+    EXPECT_NEAR(std::imag(results1[k]), std::imag(results2[k]), 1e-8);
+    EXPECT_NEAR(std::real(results1[k]), std::real(results3[k]), 1e-8);
+    EXPECT_NEAR(std::imag(results1[k]), std::imag(results3[k]), 1e-8);
+    EXPECT_NEAR(std::real(results1[k]), std::real(results4[k]), 1e-8);
+    EXPECT_NEAR(std::imag(results1[k]), std::imag(results4[k]), 1e-8);
+  }
+}
+
+template <typename Factory>
 void TestCollectKopStat(const Factory& factory) {
   using Simulator = typename Factory::Simulator;
   using StateSpace = typename Factory::StateSpace;
@@ -515,11 +769,11 @@ void TestCollectKopStat(const Factory& factory) {
                       {normal, 1, p2, {X::Create(1, 3)}}});
 
   auto measure = [](uint64_t r, const State& state,
-                    const std::vector<uint64_t>& stat,
+                    const typename QTSimulator::Stat& stat,
                     std::vector<std::vector<unsigned>>& histogram) {
-    ASSERT_EQ(stat.size(), histogram.size());
+    ASSERT_EQ(stat.samples.size(), histogram.size());
     for (std::size_t i = 0; i < histogram.size(); ++i) {
-      ++histogram[i][stat[i]];
+      ++histogram[i][stat.samples[i]];
     }
   };
 
@@ -616,7 +870,7 @@ void TestCleanCircuit(const Factory& factory) {
 
   EXPECT_FALSE(state_space.IsNull(nstate));
 
-  std::vector<uint64_t> stat;
+  typename QTSimulator::Stat stat;
 
   typename QTSimulator::Parameter param;
 
@@ -627,7 +881,7 @@ void TestCleanCircuit(const Factory& factory) {
                                    ncircuit.channels.end(), 0, state_space,
                                    simulator, nstate, stat));
 
-  EXPECT_EQ(stat.size(), 0);
+  EXPECT_EQ(stat.samples.size(), 0);
 
   for (uint64_t i = 0; i < size; ++i) {
     auto a1 = state_space.GetAmpl(state, i);
@@ -673,7 +927,7 @@ void TestInitialState(const Factory& factory) {
   EXPECT_FALSE(state_space.IsNull(state));
 
   typename QTSimulator::Parameter param;
-  std::vector<uint64_t> stat;
+  typename QTSimulator::Stat stat;
 
   for (unsigned i = 0; i < 8; ++i) {
     state_space.SetAmpl(state, i, 1 + i, 0);
@@ -736,19 +990,19 @@ void TestUncomputeFinalState(const Factory& factory) {
   typename QTSimulator::Parameter param;
   param.collect_kop_stat = true;
 
-  std::vector<uint64_t> stat;
+  typename QTSimulator::Stat stat;
 
   // Run one trajectory.
   EXPECT_TRUE(QTSimulator::RunOnce(
       param, ncircuit, 0, state_space, simulator, state, stat));
 
-  EXPECT_EQ(ncircuit.channels.size(), stat.size());
+  EXPECT_EQ(ncircuit.channels.size(), stat.samples.size());
 
   // Uncompute the final state back to |0000> (up to round-off errors).
   for (std::size_t i = 0; i < ncircuit.channels.size(); ++i) {
     auto k = ncircuit.channels.size() - 1 - i;
 
-    const auto& ops = ncircuit.channels[k][stat[k]].ops;
+    const auto& ops = ncircuit.channels[k][stat.samples[k]].ops;
 
     for (auto it = ops.rbegin(); it != ops.rend(); ++it) {
       ApplyGateDagger(simulator, *it, state);


### PR DESCRIPTION
Allows reusing quantum trajectory results to speed up simulations of circuits with weak noise and without measurements.