### PR TITLE
Avoid numpy size limits.

### DIFF
--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -99,7 +99,7 @@ def _needs_trajectories(circuit: cirq.Circuit) -> bool:
                 op, {param: 1 for param in cirq.parameter_names(op)}
             )
         )
-        if not (cirq.has_unitary(test_op) or cirq.is_measurement(test_op)):
+        if not (cirq.is_measurement(test_op) or cirq.has_unitary(test_op)):
             return True
     return False
 
@@ -356,7 +356,12 @@ class QSimSimulator(
             translator_fn_name = "translate_cirq_to_qsim"
             sampler_fn = self._sim_module.qsim_sample
 
-        if not noisy and program.are_all_measurements_terminal() and repetitions > 1:
+        if (
+            not noisy and
+            program.are_all_measurements_terminal() and
+            repetitions > 1 and
+            num_qubits <= 32  # max length of ndarray.shape
+        ):
             # Measurements must be replaced with identity gates to sample properly.
             # Simply removing them may omit qubits from the circuit.
             for i in range(len(program.moments)):

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -357,10 +357,10 @@ class QSimSimulator(
             sampler_fn = self._sim_module.qsim_sample
 
         if (
-            not noisy and
-            program.are_all_measurements_terminal() and
-            repetitions > 1 and
-            num_qubits <= 32  # max length of ndarray.shape
+            not noisy
+            and program.are_all_measurements_terminal()
+            and repetitions > 1
+            and num_qubits <= 32  # max length of ndarray.shape
         ):
             # Measurements must be replaced with identity gates to sample properly.
             # Simply removing them may omit qubits from the circuit.


### PR DESCRIPTION
Copying offline discussion:

**Issue 1**: when checking for non-unitary operations in a circuit, a 33+ qubit operation creates an invalid numpy array in Cirq.
**Solution**: reverse the order of `(protocols.has_unitary(test_op) or protocols.is_measurement(test_op))` so that the measurement check triggers first.

**Issue 2**: when sampling from a 33+ qubit state vector, an invalid numpy array is created in Cirq.
**Solution**: The call to Cirq is actually an [optimization for repeated samples](https://github.com/quantumlib/qsim/blob/d063d427d1f55d580416259233ce9c64037c00a0/qsimcirq/qsim_simulator.py#L377); for circuits where this optimization is not possible, we already have a qsim alternative which does not make this call (but is more expensive to simulate). We can add `num_qubits <= 32` to the conditions for calling the Cirq method.

-----

A couple important things to note about this change:
* If non-measurement gates acting on 33+ qubits exist, they will be decomposed into smaller gates prior to the `has_unitary` check, and thus avoid issue 1.
* Using the qsim method in issue 2 involves running the circuit `repetitions` times. This is unnecessary; for the 33+ qubit case we should run once and sample on the qsim side, but this will take some additional work. 