### PR TITLE
Fix comparator bug which are not compliant to the strict weak ordering

### DIFF
--- a/lib/fuser_mqubit.h
+++ b/lib/fuser_mqubit.h
@@ -954,8 +954,11 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
 
                   if (ln != nullptr && rn != nullptr) {
                     return R()(ln->val->parent->time, rn->val->parent->time);
-                  } else {
+                  } else if (ln != rn) {
                     return ln != nullptr || rn == nullptr;
+                  } else {
+                    // Comparator needs to be irreflexive to get a strict weak ordering.
+                    return false;
                   }
                 });
 

--- a/lib/fuser_mqubit.h
+++ b/lib/fuser_mqubit.h
@@ -955,8 +955,9 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
                   if (ln != nullptr && rn != nullptr) {
                     return R()(ln->val->parent->time, rn->val->parent->time);
                   } else {
-                    // Comparator needs to be irreflexive to get a strict weak ordering.
-                    return ln != nullptr && rn == nullptr;
+                    // nullptrs are larger than everything else and
+                    // equivalent among each other.
+                    return ln != nullptr;
                   }
                 });
 

--- a/lib/fuser_mqubit.h
+++ b/lib/fuser_mqubit.h
@@ -954,12 +954,10 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
 
                   if (ln != nullptr && rn != nullptr) {
                     return R()(ln->val->parent->time, rn->val->parent->time);
-                  } else if (ln != rn) {
-                    return ln != nullptr || rn == nullptr;
                   } else {
                     // Comparator needs to be irreflexive to get a strict weak ordering.
-                    return false;
-                  }
+                    return ln != nullptr && rn == nullptr;
+                  } else {
                 });
 
       for (auto link : links) {

--- a/lib/fuser_mqubit.h
+++ b/lib/fuser_mqubit.h
@@ -957,7 +957,7 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
                   } else {
                     // Comparator needs to be irreflexive to get a strict weak ordering.
                     return ln != nullptr && rn == nullptr;
-                  } else {
+                  }
                 });
 
       for (auto link : links) {


### PR DESCRIPTION
std::sort requries a strict weak ordering, but the comparator was reflexive (x < x).