### PR TITLE
Build: allow offline build using system libraries

### DIFF
--- a/pybind_interface/GetPybind11.cmake
+++ b/pybind_interface/GetPybind11.cmake
@@ -1,12 +1,13 @@
 include(FetchContent)
 
+set(MIN_PYBIND_VERSION "2.2.4")
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.2.4
+  GIT_TAG "v${MIN_PYBIND_VERSION}"
 )
 FetchContent_GetProperties(pybind11)
-find_package(pybind11 CONFIG)
+find_package(pybind11 "${MIN_PYBIND_VERSION}" CONFIG)
 if((NOT pybind11_FOUND) AND (NOT pybind11_POPULATED)) # check first on system path, then attempt git fetch
   FetchContent_Populate(pybind11)
   add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})

--- a/pybind_interface/GetPybind11.cmake
+++ b/pybind_interface/GetPybind11.cmake
@@ -1,0 +1,13 @@
+include(FetchContent)
+
+FetchContent_Declare(
+  pybind11
+  GIT_REPOSITORY https://github.com/pybind/pybind11
+  GIT_TAG v2.2.4
+)
+FetchContent_GetProperties(pybind11)
+find_package(pybind11 CONFIG)
+if((NOT pybind11_FOUND) AND (NOT pybind11_POPULATED)) # check first on system path, then attempt git fetch
+  FetchContent_Populate(pybind11)
+  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
+endif()

--- a/pybind_interface/avx2/CMakeLists.txt
+++ b/pybind_interface/avx2/CMakeLists.txt
@@ -12,17 +12,5 @@ if(APPLE)
     include_directories("/usr/local/include" "/usr/local/opt/llvm/include")
     link_directories("/usr/local/lib" "/usr/local/opt/llvm/lib")
 endif()
-
-include(FetchContent)
-
-FetchContent_Declare(
-  pybind11
-  GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.2.4
-)
-FetchContent_GetProperties(pybind11)
-if(NOT pybind11_POPULATED)
-  FetchContent_Populate(pybind11)
-  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
-endif()
+INCLUDE(../GetPybind11.cmake)
 pybind11_add_module(qsim_avx2 pybind_main_avx2.cpp)

--- a/pybind_interface/avx512/CMakeLists.txt
+++ b/pybind_interface/avx512/CMakeLists.txt
@@ -14,16 +14,5 @@ if(APPLE)
     link_directories("/usr/local/lib" "/usr/local/opt/llvm/lib")
 endif()
 
-include(FetchContent)
-
-FetchContent_Declare(
-  pybind11
-  GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.2.4
-)
-FetchContent_GetProperties(pybind11)
-if(NOT pybind11_POPULATED)
-  FetchContent_Populate(pybind11)
-  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
-endif()
+INCLUDE(../GetPybind11.cmake)
 pybind11_add_module(qsim_avx512 pybind_main_avx512.cpp)

--- a/pybind_interface/basic/CMakeLists.txt
+++ b/pybind_interface/basic/CMakeLists.txt
@@ -14,16 +14,5 @@ if(APPLE)
     link_directories("/usr/local/lib" "/usr/local/opt/llvm/lib")
 endif()
 
-include(FetchContent)
-
-FetchContent_Declare(
-  pybind11
-  GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.2.4
-)
-FetchContent_GetProperties(pybind11)
-if(NOT pybind11_POPULATED)
-  FetchContent_Populate(pybind11)
-  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
-endif()
+INCLUDE(../GetPybind11.cmake)
 pybind11_add_module(qsim_basic pybind_main_basic.cpp)

--- a/pybind_interface/cuda/CMakeLists.txt
+++ b/pybind_interface/cuda/CMakeLists.txt
@@ -14,19 +14,7 @@ if(APPLE)
     link_directories("/usr/local/lib" "/usr/local/opt/llvm/lib")
 endif()
 
-include(FetchContent)
-
-FetchContent_Declare(
-  pybind11
-  GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.2.4
-)
-FetchContent_GetProperties(pybind11)
-if(NOT pybind11_POPULATED)
-  FetchContent_Populate(pybind11)
-  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
-endif()
-
+INCLUDE(../GetPybind11.cmake)
 find_package(PythonLibs 3.6 REQUIRED)
 find_package(CUDA REQUIRED)
 

--- a/pybind_interface/custatevec/CMakeLists.txt
+++ b/pybind_interface/custatevec/CMakeLists.txt
@@ -27,23 +27,11 @@ if(APPLE)
     link_directories("/usr/local/lib" "/usr/local/opt/llvm/lib")
 endif()
 
-include(FetchContent)
-
-FetchContent_Declare(
-  pybind11
-  GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.2.4
-)
-FetchContent_GetProperties(pybind11)
-if(NOT pybind11_POPULATED)
-  FetchContent_Populate(pybind11)
-  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
-endif()
-
+INCLUDE(../GetPybind11.cmake)
 find_package(PythonLibs 3.6 REQUIRED)
 find_package(CUDA REQUIRED)
 
-include_directories(${PYTHON_INCLUDE_DIRS} ${pybind11_SOURCE_DIR}/include)
+include_directories(${pybind11_INCLUDE_DIRS})
 
 include_directories($ENV{CUQUANTUM_DIR}/include)
 link_directories($ENV{CUQUANTUM_DIR}/lib $ENV{CUQUANTUM_DIR}/lib64)

--- a/pybind_interface/decide/CMakeLists.txt
+++ b/pybind_interface/decide/CMakeLists.txt
@@ -19,18 +19,7 @@ if(APPLE)
     link_directories("/usr/local/lib" "/usr/local/opt/llvm/lib")
 endif()
 
-include(FetchContent)
-
-FetchContent_Declare(
-  pybind11
-  GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.2.4
-)
-FetchContent_GetProperties(pybind11)
-if(NOT pybind11_POPULATED)
-  FetchContent_Populate(pybind11)
-  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
-endif()
+INCLUDE(../GetPybind11.cmake)
 
 if(has_nvcc STREQUAL "")
   pybind11_add_module(qsim_decide decide.cpp)

--- a/pybind_interface/sse/CMakeLists.txt
+++ b/pybind_interface/sse/CMakeLists.txt
@@ -14,16 +14,5 @@ if(APPLE)
     link_directories("/usr/local/lib" "/usr/local/opt/llvm/lib")
 endif()
 
-include(FetchContent)
-
-FetchContent_Declare(
-  pybind11
-  GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.2.4
-)
-FetchContent_GetProperties(pybind11)
-if(NOT pybind11_POPULATED)
-  FetchContent_Populate(pybind11)
-  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
-endif()
+INCLUDE(../GetPybind11.cmake)
 pybind11_add_module(qsim_sse pybind_main_sse.cpp)


### PR DESCRIPTION
Goal of this PR is to support offline build using a system like https://nixos.org/, which does not support buildtime network access. This prevents the current system of fetching a specific version of pybind11 via git.

Essentially, this refactors the pybind11 library search process (via cmake) to a module, and then sets that module to default to the system pybind11 library. This will only change your build process if you also have pybind11 libraries installed on the path.

I'm also open to a flag to switch behavior between system library vs specified pybind11 version.