### PR TITLE
Patch for internal tests

### DIFF
--- a/lib/qtrajectory.h
+++ b/lib/qtrajectory.h
@@ -16,6 +16,7 @@
 #define QTRAJECTORY_H_
 
 #include <cmath>
+#include <complex>
 #include <cstdint>
 #include <random>
 #include <vector>


### PR DESCRIPTION
The `std::real` call on line 326 (now 327) is breaking internal tests because they can't find `#include <complex>`. This isn't terribly surprising, since there are minor differences between the internal and external include behavior, but it means we need to directly include `<complex>`