### PR TITLE
refactor: split dev requirements out of main requirements.txt

### DIFF
--- a/.github/workflows/cirq_compatibility.yml
+++ b/.github/workflows/cirq_compatibility.yml
@@ -18,5 +18,7 @@ jobs:
         run: pip3 install -U cirq --pre
       - name: Install qsim requirements
         run: pip3 install -r requirements.txt
+      - name: Install test requirements
+        run: pip3 install -r dev-requirements.txt
       - name: Run python tests
         run: make run-py-tests

--- a/.github/workflows/python_format.yml
+++ b/.github/workflows/python_format.yml
@@ -24,9 +24,7 @@ jobs:
         with:
           python-version: '3.7'
           architecture: 'x64'
-      - name: Install flynt
-        run: cat requirements.txt | grep flynt | xargs pip install
-      - name: Install black
-        run: cat requirements.txt | grep black | xargs pip install
+      - name: Install dev requirements
+        run: pip install -r dev-requirements.txt
       - name: Format
         run: check/format-incremental

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -39,7 +39,8 @@ jobs:
       CIBW_BEFORE_BUILD_MACOS: "brew install libomp"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
       # due to package and module name conflict have to temporarily move it away to run tests
-      CIBW_BEFORE_TEST: "mv {package}/qsimcirq /tmp"
+      CIBW_BEFORE_TEST: mv {package}/qsimcirq /tmp
+      CIBW_TEST_EXTRAS: "dev"
       CIBW_TEST_COMMAND: "pytest {package}/qsimcirq_tests/qsimcirq_test.py && mv /tmp/qsimcirq {package}"
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -45,6 +45,7 @@ jobs:
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
       # due to package and module name conflict have to temporarily move it away to run tests
       CIBW_BEFORE_TEST: "mv {package}/qsimcirq /tmp"
+      CIBW_TEST_EXTRAS: "dev"
       CIBW_TEST_COMMAND: "pytest {package}/qsimcirq_tests/qsimcirq_test.py && mv /tmp/qsimcirq {package}"
     steps:
       - uses: actions/checkout@v2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include requirements.txt
+include dev-requirements.txt
 include CMakeLists.txt
 
 graft pybind_interface

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+black==20.8b1
+flynt~=0.60
+pytest

--- a/docs/install_qsimcirq.md
+++ b/docs/install_qsimcirq.md
@@ -17,6 +17,12 @@ Prerequisites are included in the
 [`requirements.txt`](https://github.com/quantumlib/qsim/blob/master/requirements.txt)
 file, and will be automatically installed along with qsimcirq.
 
+If you'd like to develop qsimcirq, a separate set of dependencies are includes
+in the
+[`dev-requirements.txt`](https://github.com/quantumlib/qsim/blob/master/dev-requirements.txt)
+file. You can install them with `pip3 install -r dev-requirements.txt` or
+`pip3 install qsimcirq[dev]`.
+
 ## Linux installation
 
 We provide `qsimcirq` Python wheels on 64-bit `x86` architectures with `Python 3.{6,7,8,9}`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,5 @@
-# Runtime requirements for the python 3 version of cirq.
-
+absl-py
 cirq-core
 numpy~=1.16
-typing_extensions
-absl-py
-
-# Build and test requirements
-
-black==20.8b1
-flynt~=0.60
 pybind11
-pytest
+typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ class CMakeBuild(build_ext):
 
 
 requirements = open("requirements.txt").readlines()
+dev_requirements = open("dev-requirements.txt").readlines()
 
 description = "Schrödinger and Schrödinger-Feynman simulators for quantum circuits."
 
@@ -95,6 +96,9 @@ setup(
     author_email="devabathini92@gmail.com",
     python_requires=">=3.3.0",
     install_requires=requirements,
+    extras_require={
+        "dev": dev_requirements,
+    },
     license="Apache 2",
     description=description,
     long_description=long_description,


### PR DESCRIPTION
This is a re-try of #467 since it has come up as an issue again.

Hopefully this time I managed to fix the release workflow correctly.
