### PR TITLE
    refactor(dev-requirements): use stable black

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
-black==20.8b1
+black~=22.1.0
 flynt~=0.60
 pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
-black~=22.1.0
+black~=22.0
 flynt~=0.60
 pytest

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -250,7 +250,7 @@ class QSimSimulator(
 
     def get_seed(self):
         # Limit seed size to 32-bit integer for C++ conversion.
-        return self._prng.randint(2 ** 31 - 1)
+        return self._prng.randint(2**31 - 1)
 
     def _run(
         self,
@@ -540,7 +540,7 @@ class QSimSimulator(
             if initial_state.dtype != np.complex64:
                 raise TypeError(f"initial_state vector must have dtype np.complex64.")
             input_vector = initial_state.view(np.float32)
-            if len(input_vector) != 2 ** num_qubits * 2:
+            if len(input_vector) != 2**num_qubits * 2:
                 raise ValueError(
                     f"initial_state vector size must match number of qubits."
                     f"Expected: {2**num_qubits * 2} Received: {len(input_vector)}"
@@ -672,7 +672,7 @@ class QSimSimulator(
             if initial_state.dtype != np.complex64:
                 raise TypeError(f"initial_state vector must have dtype np.complex64.")
             input_vector = initial_state.view(np.float32)
-            if len(input_vector) != 2 ** num_qubits * 2:
+            if len(input_vector) != 2**num_qubits * 2:
                 raise ValueError(
                     f"initial_state vector size must match number of qubits."
                     f"Expected: {2**num_qubits * 2} Received: {len(input_vector)}"
@@ -807,7 +807,7 @@ class QSimSimulator(
             if initial_state.dtype != np.complex64:
                 raise TypeError(f"initial_state vector must have dtype np.complex64.")
             input_vector = initial_state.view(np.float32)
-            if len(input_vector) != 2 ** num_qubits * 2:
+            if len(input_vector) != 2**num_qubits * 2:
                 raise ValueError(
                     f"initial_state vector size must match number of qubits."
                     f"Expected: {2**num_qubits * 2} Received: {len(input_vector)}"

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -286,14 +286,11 @@ def test_iterable_qubit_order():
     )
     qsim_simulator = qsimcirq.QSimSimulator()
 
-    assert (
-        qsim_simulator.compute_amplitudes(
-            circuit,
-            bitstrings=[0b00, 0b01],
-            qubit_order=reversed([q1, q0]),
-        )
-        == qsim_simulator.compute_amplitudes(circuit, bitstrings=[0b00, 0b01])
-    )
+    assert qsim_simulator.compute_amplitudes(
+        circuit,
+        bitstrings=[0b00, 0b01],
+        qubit_order=reversed([q1, q0]),
+    ) == qsim_simulator.compute_amplitudes(circuit, bitstrings=[0b00, 0b01])
 
     assert qsim_simulator.simulate(
         circuit, qubit_order=reversed([q1, q0])

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ class CMakeBuild(build_ext):
             cmake_args += [
                 "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), extdir)
             ]
-            if sys.maxsize > 2 ** 32:
+            if sys.maxsize > 2**32:
                 cmake_args += ["-A", "x64"]
             build_args += ["--", "/m"]
         else:


### PR DESCRIPTION
- refactor(dev-requirements): use stable black
- style: format with black 22.1.0

I also relaxed the version requirement on black, since it's now out of beta and considered stable.