### PR TITLE
Workaround Centos 8 EOL

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -3,6 +3,11 @@ FROM centos:8
 USER root
 # Install baseline
 
+RUN pushd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN popd
+
 RUN yum -y update && \
 	yum install -y epel-release && \
 	yum group install -y "Development Tools" && \

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -1,13 +1,15 @@
 # Base OS
 FROM centos:8
 USER root
-# Install baseline
 
+# Centos 8 has reach end of life: https://www.centos.org/centos-linux-eol/
+# Configuration must be loaded from the vault.
 RUN pushd /etc/yum.repos.d/
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN popd
 
+# Install baseline
 RUN yum -y update && \
 	yum install -y epel-release && \
 	yum group install -y "Development Tools" && \


### PR DESCRIPTION
Fixes #515.

Centos 8 has [reached end of life](https://www.centos.org/centos-linux-eol/), and our Docker builds are now breaking as a result. This PR uses the answer in [this StackOverflow question](https://stackoverflow.com/questions/70963985/error-failed-to-download-metadata-for-repo-appstream-cannot-prepare-internal) as a workaround to keep the builds functioning.