### PR TITLE
Remove deprecated elements for Cirq v0.14

### DIFF
--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -252,18 +252,17 @@ class QSimCircuit(cirq.Circuit):
     def __init__(
         self,
         cirq_circuit: cirq.Circuit,
-        device: cirq.devices = cirq.devices.UNCONSTRAINED_DEVICE,
         allow_decomposition: bool = False,
     ):
 
         if allow_decomposition:
-            super().__init__([], device=device)
+            super().__init__()
             for moment in cirq_circuit:
                 for op in moment:
                     # This should call decompose on the gates
                     self.append(op)
         else:
-            super().__init__(cirq_circuit, device=device)
+            super().__init__(cirq_circuit)
 
     def __eq__(self, other):
         if not isinstance(other, QSimCircuit):
@@ -274,10 +273,7 @@ class QSimCircuit(cirq.Circuit):
     def _resolve_parameters_(
         self, param_resolver: cirq.study.ParamResolver, recursive: bool = True
     ):
-        return QSimCircuit(
-            cirq.resolve_parameters(super(), param_resolver, recursive),
-            device=self.device,
-        )
+        return QSimCircuit(cirq.resolve_parameters(super(), param_resolver, recursive))
 
     def translate_cirq_to_qsim(
         self, qubit_order: cirq.ops.QubitOrderOrList = cirq.ops.QubitOrder.DEFAULT

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -250,7 +250,7 @@ class QSimSimulator(
 
     def get_seed(self):
         # Limit seed size to 32-bit integer for C++ conversion.
-        return self._prng.randint(2 ** 31 - 1)
+        return self._prng.randint(2**31 - 1)
 
     def _run(
         self,
@@ -544,7 +544,7 @@ class QSimSimulator(
             if initial_state.dtype != np.complex64:
                 raise TypeError(f"initial_state vector must have dtype np.complex64.")
             input_vector = initial_state.view(np.float32)
-            if len(input_vector) != 2 ** num_qubits * 2:
+            if len(input_vector) != 2**num_qubits * 2:
                 raise ValueError(
                     f"initial_state vector size must match number of qubits."
                     f"Expected: {2**num_qubits * 2} Received: {len(input_vector)}"
@@ -675,7 +675,7 @@ class QSimSimulator(
             if initial_state.dtype != np.complex64:
                 raise TypeError(f"initial_state vector must have dtype np.complex64.")
             input_vector = initial_state.view(np.float32)
-            if len(input_vector) != 2 ** num_qubits * 2:
+            if len(input_vector) != 2**num_qubits * 2:
                 raise ValueError(
                     f"initial_state vector size must match number of qubits."
                     f"Expected: {2**num_qubits * 2} Received: {len(input_vector)}"
@@ -809,7 +809,7 @@ class QSimSimulator(
             if initial_state.dtype != np.complex64:
                 raise TypeError(f"initial_state vector must have dtype np.complex64.")
             input_vector = initial_state.view(np.float32)
-            if len(input_vector) != 2 ** num_qubits * 2:
+            if len(input_vector) != 2**num_qubits * 2:
                 raise ValueError(
                     f"initial_state vector size must match number of qubits."
                     f"Expected: {2**num_qubits * 2} Received: {len(input_vector)}"

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -250,7 +250,7 @@ class QSimSimulator(
 
     def get_seed(self):
         # Limit seed size to 32-bit integer for C++ conversion.
-        return self._prng.randint(2**31 - 1)
+        return self._prng.randint(2 ** 31 - 1)
 
     def _run(
         self,
@@ -397,7 +397,11 @@ class QSimSimulator(
             measurements = np.empty(
                 shape=(
                     repetitions,
-                    sum(cirq.num_qubits(op) for oplist in meas_ops.values() for op in oplist),
+                    sum(
+                        cirq.num_qubits(op)
+                        for oplist in meas_ops.values()
+                        for op in oplist
+                    ),
                 ),
                 dtype=int,
             )
@@ -540,7 +544,7 @@ class QSimSimulator(
             if initial_state.dtype != np.complex64:
                 raise TypeError(f"initial_state vector must have dtype np.complex64.")
             input_vector = initial_state.view(np.float32)
-            if len(input_vector) != 2**num_qubits * 2:
+            if len(input_vector) != 2 ** num_qubits * 2:
                 raise ValueError(
                     f"initial_state vector size must match number of qubits."
                     f"Expected: {2**num_qubits * 2} Received: {len(input_vector)}"
@@ -671,7 +675,7 @@ class QSimSimulator(
             if initial_state.dtype != np.complex64:
                 raise TypeError(f"initial_state vector must have dtype np.complex64.")
             input_vector = initial_state.view(np.float32)
-            if len(input_vector) != 2**num_qubits * 2:
+            if len(input_vector) != 2 ** num_qubits * 2:
                 raise ValueError(
                     f"initial_state vector size must match number of qubits."
                     f"Expected: {2**num_qubits * 2} Received: {len(input_vector)}"
@@ -805,7 +809,7 @@ class QSimSimulator(
             if initial_state.dtype != np.complex64:
                 raise TypeError(f"initial_state vector must have dtype np.complex64.")
             input_vector = initial_state.view(np.float32)
-            if len(input_vector) != 2**num_qubits * 2:
+            if len(input_vector) != 2 ** num_qubits * 2:
                 raise ValueError(
                     f"initial_state vector size must match number of qubits."
                     f"Expected: {2**num_qubits * 2} Received: {len(input_vector)}"

--- a/qsimcirq/qsimh_simulator.py
+++ b/qsimcirq/qsimh_simulator.py
@@ -48,7 +48,7 @@ class QSimhSimulator(cirq.SimulatesAmplitudes):
     ) -> Sequence[Sequence[complex]]:
 
         if not isinstance(program, qsimc.QSimCircuit):
-            program = qsimc.QSimCircuit(program, device=program.device)
+            program = qsimc.QSimCircuit(program)
 
         n_qubits = len(program.all_qubits())
         # qsim numbers qubits in reverse order from cirq

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -271,10 +271,11 @@ def test_invalid_params():
     x, y = sympy.Symbol("x"), sympy.Symbol("y")
     circuit = cirq.Circuit(cirq.X(q0) ** x, cirq.H(q0) ** y)
     prs = [{x: np.int64(0), y: np.int64(1)}, {x: np.int64(1), y: "z"}]
+    sweep = cirq.ListSweep(prs)
 
     qsim_simulator = qsimcirq.QSimSimulator()
     with pytest.raises(ValueError, match="Parameters must be numeric"):
-        _ = qsim_simulator.simulate_sweep(circuit, params=prs)
+        _ = qsim_simulator.simulate_sweep(circuit, params=sweep)
 
 
 def test_iterable_qubit_order():
@@ -1154,10 +1155,10 @@ def test_cirq_qsim_simulate_random_unitary(mode: str):
             qubits=[q0, q1], n_moments=8, op_density=0.99, random_state=iter
         )
 
-        cirq.ConvertToCzAndSingleGates().optimize_circuit(
-            random_circuit
-        )  # cannot work with params
-        cirq.ExpandComposite().optimize_circuit(random_circuit)
+        random_circuit = cirq.optimize_for_target_gateset(
+            random_circuit, gateset=cirq.CZTargetGateset()
+        )
+        random_circuit = cirq.expand_composite(random_circuit)
         if mode == "noisy":
             random_circuit.append(NoiseTrigger().on(q0))
 

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -287,14 +287,11 @@ def test_iterable_qubit_order():
     )
     qsim_simulator = qsimcirq.QSimSimulator()
 
-    assert (
-        qsim_simulator.compute_amplitudes(
-            circuit,
-            bitstrings=[0b00, 0b01],
-            qubit_order=reversed([q1, q0]),
-        )
-        == qsim_simulator.compute_amplitudes(circuit, bitstrings=[0b00, 0b01])
-    )
+    assert qsim_simulator.compute_amplitudes(
+        circuit,
+        bitstrings=[0b00, 0b01],
+        qubit_order=reversed([q1, q0]),
+    ) == qsim_simulator.compute_amplitudes(circuit, bitstrings=[0b00, 0b01])
 
     assert qsim_simulator.simulate(
         circuit, qubit_order=reversed([q1, q0])

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -287,11 +287,14 @@ def test_iterable_qubit_order():
     )
     qsim_simulator = qsimcirq.QSimSimulator()
 
-    assert qsim_simulator.compute_amplitudes(
-        circuit,
-        bitstrings=[0b00, 0b01],
-        qubit_order=reversed([q1, q0]),
-    ) == qsim_simulator.compute_amplitudes(circuit, bitstrings=[0b00, 0b01])
+    assert (
+        qsim_simulator.compute_amplitudes(
+            circuit,
+            bitstrings=[0b00, 0b01],
+            qubit_order=reversed([q1, q0]),
+        )
+        == qsim_simulator.compute_amplitudes(circuit, bitstrings=[0b00, 0b01])
+    )
 
     assert qsim_simulator.simulate(
         circuit, qubit_order=reversed([q1, q0])


### PR DESCRIPTION
Fixes #511. This PR brings qsim up to date with Cirq v0.14. Tests pass with `-W error::DeprecationWarning`.