### PR TITLE
Update `black` version, unpin `click`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-black~=22.0
-click<=8.0.4
+black~=22.3.0
 flynt~=0.60
 pytest


### PR DESCRIPTION
Bumps past the hiccup with `click`.