### PR TITLE
DisARM qsim

### DIFF
--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -15,12 +15,7 @@ jobs:
           - os: macos-10.15
             name: mac
             cibw:
-              build: "cp36* cp37* cp38*"
-          - os: macos-10.15
-            name: mac-arm
-            cibw:
-              arch: universal2
-              build: "cp39*"
+              build: "cp36* cp37* cp38* cp39*"
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -20,12 +20,7 @@ jobs:
           - os: macos-10.15
             name: mac
             cibw:
-              build: "cp36* cp37* cp38*"
-          - os: macos-10.15
-            name: mac-arm
-            cibw:
-              arch: universal2
-              build: "cp39*"
+              build: "cp36* cp37* cp38* cp39*"
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:


### PR DESCRIPTION
As noted in #495, qsim wheels are not compatible with MacOS M1. This PR removes the `universal2` wheels from the test and release workflows so that M1s do not install a known-invalid wheel.

Some complications will persist: M1s could still install wheel published for older qsim versions, and building qsim from source is also broken on M1 devices. However, this at least stops us from continuing to advertise a functioning ARM-compatible qsim wheel in subsequent releases.