### PR TITLE
Update version to 0.13.1

### DIFF
--- a/qsimcirq/_version.py
+++ b/qsimcirq/_version.py
@@ -1,3 +1,3 @@
 """The version number defined here is read automatically in setup.py."""
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"


### PR DESCRIPTION
Patch release to add python3.10 wheels for qsim.

The stable version of python recently rolled over to 3.10, breaking the normal qsim install path. This resolves that.