### PR TITLE
Upgrade to latest setup-python action

### DIFF
--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
 
       - name: Install cibuildwheel and twine
         run: python -m pip install cibuildwheel==2.0.1

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
 
       - name: Install cibuildwheel and twine
         run: python -m pip install cibuildwheel==2.0.1


### PR DESCRIPTION
Yet another attempt at #537. The older version of `setup-python` may not have installed python 3.10 by default.