### PR TITLE
Advance versions for compatibility

### DIFF
--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -15,18 +15,18 @@ jobs:
           - os: macos-10.15
             name: mac
             cibw:
-              build: "cp36* cp37* cp38* cp39* cp310*"
+              build: "cp37* cp38* cp39* cp310*"
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: "cp36* cp37* cp38* cp39* cp310*"
+              build: "cp37* cp38* cp39* cp310*"
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64
             architecture: x64
             cibw:
-              build: "cp36-win_amd64 cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64"
+              build: "cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -29,6 +29,7 @@ jobs:
               build: "cp36-win_amd64 cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
+      CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
       CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm"
@@ -46,7 +47,7 @@ jobs:
       - uses: actions/setup-python@v2
 
       - name: Install cibuildwheel and twine
-        run: python -m pip install cibuildwheel==2.0.1
+        run: python -m pip install cibuildwheel==2.2.2
 
       - name: Run C++ tests
         run: bash build_tools/test_libs.sh

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -34,6 +34,7 @@ jobs:
               build: "cp36-win_amd64 cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
+      CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
       CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm"
@@ -51,7 +52,7 @@ jobs:
       - uses: actions/setup-python@v2
 
       - name: Install cibuildwheel and twine
-        run: python -m pip install cibuildwheel==2.0.1
+        run: python -m pip install cibuildwheel==2.2.2
 
       - name: Run C++ tests
         run: bash build_tools/test_libs.sh

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -20,18 +20,18 @@ jobs:
           - os: macos-10.15
             name: mac
             cibw:
-              build: "cp36* cp37* cp38* cp39* cp310*"
+              build: "cp37* cp38* cp39* cp310*"
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: "cp36* cp37* cp38* cp39* cp310*"
+              build: "cp37* cp38* cp39* cp310*"
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64
             architecture: x64
             cibw:
-              build: "cp36-win_amd64 cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64"
+              build: "cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"

--- a/pybind_interface/GetPybind11.cmake
+++ b/pybind_interface/GetPybind11.cmake
@@ -1,6 +1,6 @@
 include(FetchContent)
 
-set(MIN_PYBIND_VERSION "2.2.4")
+set(MIN_PYBIND_VERSION "2.8.1")
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY https://github.com/pybind/pybind11

--- a/pybind_interface/cuda/CMakeLists.txt
+++ b/pybind_interface/cuda/CMakeLists.txt
@@ -15,7 +15,7 @@ if(APPLE)
 endif()
 
 INCLUDE(../GetPybind11.cmake)
-find_package(PythonLibs 3.6 REQUIRED)
+find_package(PythonLibs 3.7 REQUIRED)
 find_package(CUDA REQUIRED)
 
 include_directories(${PYTHON_INCLUDE_DIRS} ${pybind11_SOURCE_DIR}/include)

--- a/pybind_interface/custatevec/CMakeLists.txt
+++ b/pybind_interface/custatevec/CMakeLists.txt
@@ -28,7 +28,7 @@ if(APPLE)
 endif()
 
 INCLUDE(../GetPybind11.cmake)
-find_package(PythonLibs 3.6 REQUIRED)
+find_package(PythonLibs 3.7 REQUIRED)
 find_package(CUDA REQUIRED)
 
 include_directories(${pybind11_INCLUDE_DIRS})

--- a/pybind_interface/decide/CMakeLists.txt
+++ b/pybind_interface/decide/CMakeLists.txt
@@ -24,7 +24,7 @@ INCLUDE(../GetPybind11.cmake)
 if(has_nvcc STREQUAL "")
   pybind11_add_module(qsim_decide decide.cpp)
 else()
-  find_package(PythonLibs 3.6 REQUIRED)
+  find_package(PythonLibs 3.7 REQUIRED)
   find_package(CUDA REQUIRED)
 
   include_directories(${PYTHON_INCLUDE_DIRS} ${pybind11_SOURCE_DIR}/include)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 absl-py
 cirq-core
-numpy~=1.16
+numpy~=1.21
 pybind11
 typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     url="https://github.com/quantumlib/qsim",
     author="Vamsi Krishna Devabathini",
     author_email="devabathini92@gmail.com",
-    python_requires=">=3.3.0",
+    python_requires=">=3.7.0",
     install_requires=requirements,
     extras_require={
         "dev": dev_requirements,


### PR DESCRIPTION
Fixes #537.

Bumps forward several pinned versions to get qsim building with Python 3.10.