### PR TITLE
Convert to Debian

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -1,33 +1,24 @@
 # Base OS
-FROM centos:8
+FROM debian:bullseye
 USER root
 
-# Centos 8 has reach end of life: https://www.centos.org/centos-linux-eol/
-# Configuration must be loaded from the vault.
-RUN pushd /etc/yum.repos.d/ && \
-	sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
-	sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
-	popd
-
 # Install baseline
-RUN yum -y update && \
-	yum install -y epel-release && \
-	yum group install -y "Development Tools" && \
-	yum install -y python3-devel cmake python3-pip git && \
-	python3 -m pip install --upgrade pip && \
-	python3 -m pip install cirq && \
-	python3 -m pip install cirq[contrib] && \
-	python3 -m pip install qsimcirq && \
-	python3 -m pip install jupyterlab && \
+RUN apt-get -y update && \
+        apt-get install -y python3-dev python3-pip git && \
+        python3 -m pip install --upgrade pip && \
+        python3 -m pip install cirq && \
+        python3 -m pip install cirq[contrib] && \
+        python3 -m pip install qsimcirq && \
+        python3 -m pip install jupyterlab && \
     python3 -m pip install jupyter_http_over_ws && \
     jupyter serverextension enable --py jupyter_http_over_ws && \
-	cd / && \
-	git clone https://github.com/quantumlib/qsim.git
+        cd / && \
+        git clone https://github.com/quantumlib/qsim.git
 
 RUN  jupyter serverextension enable --py jupyter_http_over_ws
 
 CMD ["jupyter-notebook", "--port=8888", "--no-browser",\
       "--ip=0.0.0.0", "--allow-root", \
-	  "--NotebookApp.allow_origin='*'", \
+          "--NotebookApp.allow_origin='*'", \
       "--NotebookApp.port_retries=0", \
-	  "--NotebookApp.token=''"]
+          "--NotebookApp.token=''"]


### PR DESCRIPTION
Switches the base Docker image from CentOS 8 (which is past end-of-life) to Debian.

This is necessary as CentOS 8 does not support Python > 3.6, but both qsim and Cirq now require Python 3.7+. Tested in Google Cloud Shell and verified that the new image gets the latest qsim+cirq versions (0.13.3 and 0.15.0, respectively).