### PR TITLE
Prevent duplicate noise addition

### DIFF
--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -473,6 +473,9 @@ class QSimCircuit(cirq.Circuit):
                     time = time_offset + gi
                     add_op_to_circuit(qsim_op, time, qubit_to_index_dict, qsim_ncircuit)
                     gate_count += 1
+                # Only gates decompose to multiple time steps.
+                if gi > 0:
+                    continue
                 # Handle mixture output.
                 for mixture in ops_by_mix:
                     mixdata = []


### PR DESCRIPTION
Fixes #553.

Prior to this change, if a moment contained both (1) a noiseless gate that decomposes into multiple gates, and (2) a noisy gate, the circuit translator would (incorrectly) add a copy of the noisy gate for every gate produced by the noiseless gate.

Fortunately, because this generates a pair of gates in the translated circuit which overlap in time and targeted qubits, there is no risk of this having polluted previous experiments - anyone hitting this issue would see an error rather than incorrect results.