### PR TITLE
Catch identities in expectation value calcs

### DIFF
--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -797,6 +797,9 @@ class SimulatorHelper {
       const auto& opsum_qubits = std::get<1>(opsum_qubit_count_pair);
       if (opsum_qubits <= 6) {
         results.push_back(ExpectationValue<IO, Fuser>(opsum, simulator, state));
+      } else if (opsum_qubits == 0) {
+        // This represents an identity, whose EV is always 1.
+        results.push_back(1);
       } else {
         Fuser::Parameter params;
         params.max_fused_size = max_fused_size;

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -795,11 +795,11 @@ class SimulatorHelper {
     for (const auto& opsum_qubit_count_pair : opsums_and_qubit_counts) {
       const auto& opsum = std::get<0>(opsum_qubit_count_pair);
       const auto& opsum_qubits = std::get<1>(opsum_qubit_count_pair);
-      if (opsum_qubits <= 6) {
+      if (opsum_qubits == 0) {
+        // This represents an identity, which always has EV=1.
+        results.push_back(std::complex<double>(1.0, 0.0));
+      } else if (opsum_qubits <= 6) {
         results.push_back(ExpectationValue<IO, Fuser>(opsum, simulator, state));
-      } else if (opsum_qubits == 0) {
-        // This represents an identity, whose EV is always 1.
-        results.push_back(1);
       } else {
         Fuser::Parameter params;
         params.max_fused_size = max_fused_size;

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -523,18 +523,19 @@ def test_expectation_values(mode: str):
     ]
     psum1 = cirq.Z(a) + 3 * cirq.X(b)
     psum2 = cirq.X(a) - 3 * cirq.Z(b)
+    psum3 = cirq.I(a)
 
     if mode == "noisy":
         circuit.append(NoiseTrigger().on(a))
 
     qsim_simulator = qsimcirq.QSimSimulator()
     qsim_result = qsim_simulator.simulate_expectation_values_sweep(
-        circuit, [psum1, psum2], params
+        circuit, [psum1, psum2, psum3], params
     )
 
     cirq_simulator = cirq.Simulator()
     cirq_result = cirq_simulator.simulate_expectation_values_sweep(
-        circuit, [psum1, psum2], params
+        circuit, [psum1, psum2, psum3], params
     )
 
     assert cirq.approx_eq(qsim_result, cirq_result, atol=1e-6)


### PR DESCRIPTION
Fixes #565.

`cirq.PauliString` does not include identities in its `.items()` representation. Changing this is difficult due to how Cirq handles Paulis; instead, it is simpler to treat empty `PauliString`s as identities in qsim.