### PR TITLE
Fix weighted identity EVs.

### DIFF
--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -805,7 +805,7 @@ class SimulatorHelper {
       const auto& opsum_qubits = std::get<1>(opsum_qubit_count_pair);
       if (opsum_qubits == 0) {
         // This represents an identity, which always has EV = weight.
-        auto result = std::complex<double>(1.0, 0.0);
+        auto result = std::complex<double>(0.0, 0.0);
         for (const auto& str : opsum) {
           result += str.weight;
         }

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -804,8 +804,12 @@ class SimulatorHelper {
       const auto& opsum = std::get<0>(opsum_qubit_count_pair);
       const auto& opsum_qubits = std::get<1>(opsum_qubit_count_pair);
       if (opsum_qubits == 0) {
-        // This represents an identity, which always has EV=1.
-        results.push_back(std::complex<double>(1.0, 0.0));
+        // This represents an identity, which always has EV = weight.
+        auto result = std::complex<double>(1.0, 0.0);
+        for (const auto& str : opsum) {
+          result += str.weight;
+        }
+        results.push_back(result);
       } else if (opsum_qubits <= 6) {
         results.push_back(ExpectationValue<IO, Fuser>(opsum, simulator, state));
       } else {

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -523,7 +523,7 @@ def test_expectation_values(mode: str):
     ]
     psum1 = cirq.Z(a) + 3 * cirq.X(b)
     psum2 = cirq.X(a) - 3 * cirq.Z(b)
-    psum3 = cirq.I(a)
+    psum3 = cirq.I(a) * 3
 
     if mode == "noisy":
         circuit.append(NoiseTrigger().on(a))


### PR DESCRIPTION
Fixes #576.

It may be worthwhile to consider addressing this at the C++ level instead of as a special case in pybind.