### PR TITLE
Fix expectation values.

### DIFF
--- a/lib/expect.h
+++ b/lib/expect.h
@@ -105,11 +105,11 @@ std::complex<double> ExpectationValue(
 
   typename Fuser::Parameter param;
   param.max_fused_size = 6;
-
   for (const auto& str : strings) {
-    if (str.ops.size() == 0) continue;
-
-    if (str.ops.size() == 1) {
+    if (str.ops.size() == 0) {
+      eval += str.weight;
+    }
+    else if (str.ops.size() == 1) {
       const auto& op = str.ops[0];
       auto r = simulator.ExpectationValue(op.qubits, op.matrix.data(), state);
       eval += str.weight * r;

--- a/lib/expect.h
+++ b/lib/expect.h
@@ -108,8 +108,7 @@ std::complex<double> ExpectationValue(
   for (const auto& str : strings) {
     if (str.ops.size() == 0) {
       eval += str.weight;
-    }
-    else if (str.ops.size() == 1) {
+    } else if (str.ops.size() == 1) {
       const auto& op = str.ops[0];
       auto r = simulator.ExpectationValue(op.qubits, op.matrix.data(), state);
       eval += str.weight * r;

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -1930,21 +1930,23 @@ def test_cirq_qsim_circuit_memoization_simulate_expectation_values_sweep(mode: s
         assert cirq.approx_eq(qsim_result, cirq_result, atol=1e-6)
         
         
-def test_qsimcirq_identity_expectation_value():
-    objs = [(1.5, 'II'), (-0.3, 'IZ')]
+def test_qsimcirq_identity_expectation_value(): 
+    objs = [(1.5, "II"), (-0.3, "IZ")]
     num_qubits = 2
     qubits = cirq.LineQubit.range(num_qubits)
-    cirq_circuit = cirq.Circuit(cirq.H(qubits[0]),
-                                cirq.CNOT(qubits[0], qubits[1]))
+    cirq_circuit = cirq.Circuit(cirq.H(qubits[0]), cirq.CNOT(qubits[0], qubits[1]))
 
     hamiltonian = 0
     for w, pauli in objs:
         pauli = pauli[::-1]
         hamiltonian += float(w) * cirq.PauliString(
-            cirq.I(cirq.LineQubit(i)) if p == 'I' else
-            cirq.Z(cirq.LineQubit(i)) if p == 'Z' else
-            None  
-            for i, p in enumerate(pauli))
+            cirq.I(cirq.LineQubit(i))
+            if p == "I"
+            else cirq.Z(cirq.LineQubit(i))
+            if p == "Z"
+            else None  
+            for i, p in enumerate(pauli)
+        )
 
     qsimSim = qsimcirq.QSimSimulator()
     qsimcirq_result = qsimSim.simulate_expectation_values(cirq_circuit, hamiltonian) 

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -1927,4 +1927,26 @@ def test_cirq_qsim_circuit_memoization_simulate_expectation_values_sweep(mode: s
         qsim_result = qsim_sim.simulate_expectation_values_sweep(
             circuit, [psum1, psum2], params
         )
-        assert cirq.approx_eq(qsim_result, cirq_result, atol=1e-6)
+        
+        
+def test_qsimcirq_identity_expectation_value():
+    objs = [(1.5, 'II'), (-0.3, 'IZ')]
+    num_qubits = 2
+    qubits = cirq.LineQubit.range(num_qubits)
+    cirq_circuit = cirq.Circuit(cirq.H(qubits[0]),
+                                cirq.CNOT(qubits[0], qubits[1]))
+
+    hamiltonian = 0
+    for w, pauli in objs:
+        pauli = pauli[::-1]
+        hamiltonian += float(w) * cirq.PauliString(
+            cirq.I(cirq.LineQubit(i)) if p == 'I' else
+            cirq.Z(cirq.LineQubit(i)) if p == 'Z' else
+            None  
+            for i, p in enumerate(pauli))
+
+    qsimSim = qsimcirq.QSimSimulator()
+    qsimcirq_result = qsimSim.simulate_expectation_values(cirq_circuit, hamiltonian) 
+    cirqSim = cirq.Simulator()
+    cirq_result = cirqSim.simulate_expectation_values(cirq_circuit, hamiltonian)  
+    assert cirq.approx_eq(qsimcirq_result, cirq_result, atol=1e-6)

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -1928,9 +1928,9 @@ def test_cirq_qsim_circuit_memoization_simulate_expectation_values_sweep(mode: s
             circuit, [psum1, psum2], params
         )
         assert cirq.approx_eq(qsim_result, cirq_result, atol=1e-6)
-        
-        
-def test_qsimcirq_identity_expectation_value(): 
+
+
+def test_qsimcirq_identity_expectation_value():
     objs = [(1.5, "II"), (-0.3, "IZ")]
     num_qubits = 2
     qubits = cirq.LineQubit.range(num_qubits)
@@ -1944,12 +1944,12 @@ def test_qsimcirq_identity_expectation_value():
             if p == "I"
             else cirq.Z(cirq.LineQubit(i))
             if p == "Z"
-            else None  
+            else None
             for i, p in enumerate(pauli)
         )
 
     qsimSim = qsimcirq.QSimSimulator()
-    qsimcirq_result = qsimSim.simulate_expectation_values(cirq_circuit, hamiltonian) 
+    qsimcirq_result = qsimSim.simulate_expectation_values(cirq_circuit, hamiltonian)
     cirqSim = cirq.Simulator()
-    cirq_result = cirqSim.simulate_expectation_values(cirq_circuit, hamiltonian)  
+    cirq_result = cirqSim.simulate_expectation_values(cirq_circuit, hamiltonian)
     assert cirq.approx_eq(qsimcirq_result, cirq_result, atol=1e-6)

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -1927,6 +1927,7 @@ def test_cirq_qsim_circuit_memoization_simulate_expectation_values_sweep(mode: s
         qsim_result = qsim_sim.simulate_expectation_values_sweep(
             circuit, [psum1, psum2], params
         )
+        assert cirq.approx_eq(qsim_result, cirq_result, atol=1e-6)
         
         
 def test_qsimcirq_identity_expectation_value():


### PR DESCRIPTION
The coefficient of the identity operators is now included in the expectation value calculation. The following example uses three different methods to calculate the expectation value. qsimcirq discards the coefficient of the identity operator. This PR resolves this issue.

```python
import cirq
import qsimcirq


objs = [(1.5, 'IIIIIII'), (-0.3, 'XZXIXII')]
num_qubits = 7
moments = 9
density = 0.95
qubits = cirq.LineQubit.range(num_qubits)
cirq_circuit = cirq.testing.random_circuit(qubits=qubits,
                                      n_moments=moments,
                                      op_density=density)

hamiltonian = 0
for w, pauli in objs:
    pauli = pauli[::-1]
    hamiltonian += float(w) * cirq.PauliString(
        cirq.I(cirq.LineQubit(i)) if p == 'I' else
        cirq.X(cirq.LineQubit(i)) if p == 'X' else
        cirq.Y(cirq.LineQubit(i)) if p == 'Y' else
        cirq.Z(cirq.LineQubit(i)) if p == 'Z' else
        None  
        for i, p in enumerate(pauli))


energy_ham = hamiltonian.expectation_from_state_vector(
    state_vector= cirq.final_state_vector(cirq_circuit), 
    qubit_map={q: i for i, q in enumerate(qubits)},
    atol=0.01)

qsimSim = qsimcirq.QSimSimulator()
qsimcirq_result = qsimSim.simulate_expectation_values(cirq_circuit, hamiltonian) 

cirqSim = cirq.Simulator()
cirq_result = cirqSim.simulate_expectation_values(cirq_circuit, hamiltonian)  


print(f'energy_ham = {energy_ham}')
print(f'qsimcirq_result = {qsimcirq_result}')
print(f'cirq_result = {cirq_result}')
```