### PR TITLE
Update version to v0.15.0

### DIFF
--- a/qsimcirq/_version.py
+++ b/qsimcirq/_version.py
@@ -1,3 +1,3 @@
 """The version number defined here is read automatically in setup.py."""
 
-__version__ = "0.14.1"
+__version__ = "0.15.0"


### PR DESCRIPTION
This minor version update is for the new global phase gate feature, added in #579.

Additionally, there have been a number of small patch fixes since 0.14.1:
- Fix array overflow for small input vectors (#572 and #582)
- Fix weighted-identity expectation values (#577 and #578)
- Fix custatevec not being enabled on request (#580)