### PR TITLE
Use ubuntu-20.04

### DIFF
--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -12,7 +12,7 @@ jobs:
   # Run tests with Bazel v0.26.
   test:
     name: Test with Bazel
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # Hardware optimizers.
@@ -40,7 +40,7 @@ jobs:
 
   test-san:
     name: Sanitizer tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # Test sanitizers
@@ -61,7 +61,7 @@ jobs:
   
   test-mem:
     name: Test with tcmalloc
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cirq_compatibility.yml
+++ b/.github/workflows/cirq_compatibility.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   consistency:
     name: Nightly Compatibility
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1


### PR DESCRIPTION
The `ubuntu-18.04` runner is deprecated and will be turned down soon: https://github.com/actions/runner-images/issues/6002

We need to use a newer runner to keep these CI checks alive. This PR upgrades us to `ubuntu-20.04`, which is consistent with what Cirq uses for its CI checks.