### PR TITLE
Restrict python version to 3.7 <= x < 3.11

### DIFF
--- a/docs/install_qsimcirq.md
+++ b/docs/install_qsimcirq.md
@@ -25,19 +25,19 @@ file. You can install them with `pip3 install -r dev-requirements.txt` or
 
 ## Linux installation
 
-We provide `qsimcirq` Python wheels on 64-bit `x86` architectures with `Python 3.{6,7,8,9}`.
+We provide `qsimcirq` Python wheels on 64-bit `x86` architectures with `Python 3.{7,8,9,10}`.
 
 Simply run `pip3 install qsimcirq`.
 
 ## MacOS installation
 
-We provide `qsimcirq` Python wheels on `x86` architectures with `Python 3.{6,7,8,9}`.
+We provide `qsimcirq` Python wheels on `x86` architectures with `Python 3.{7,8,9,10}`.
 
 Simply run `pip3 install qsimcirq`.
 
 ## Windows installation
 
-We provide `qsimcirq` Python wheels on 64-bit `x86` and `amd64` architectures with `Python 3.{6,7,8,9}`.
+We provide `qsimcirq` Python wheels on 64-bit `x86` and `amd64` architectures with `Python 3.{7,8,9,10}`.
 
 Simply run `pip3 install qsimcirq`.
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     url="https://github.com/quantumlib/qsim",
     author="Vamsi Krishna Devabathini",
     author_email="devabathini92@gmail.com",
-    python_requires=">=3.7.0",
+    python_requires=">=3.7.0,<3.11.0",
     install_requires=requirements,
     extras_require={
         "dev": dev_requirements,


### PR DESCRIPTION
Fixes #591.

This makes explicit the python versions for which qsim is released: 3.7, 3.8, 3.9, and 3.10. Reference:
https://github.com/quantumlib/qsim/blob/f3d8d373a0bac7900aa1d58bf2c133d6ceb0fe0a/.github/workflows/release_wheels.yml#L21-L23