### PR TITLE
Update qsim version to 0.15.1 for cuquantum bazel support

### DIFF
--- a/qsimcirq/_version.py
+++ b/qsimcirq/_version.py
@@ -1,3 +1,3 @@
 """The version number defined here is read automatically in setup.py."""
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"


### PR DESCRIPTION
This PR will be merged after #600 is merged, and then release 0.15.1 version.