### PR TITLE
fix Docker and Bazel CIs

### DIFF
--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -60,6 +60,10 @@ jobs:
       - name: Install requirements
         run: |
           python3 -m pip install -r requirements.txt
+      - name: Upgrade libc 
+      # An LLVM update broke this test, fix per is https://bugs.llvm.org/show_bug.cgi?id=27310.
+        run: |
+          sudo apt-get upgrade libc-bin=2.31-0ubuntu9.9
       - name: Run C++ tests
         run: |
           bazel test --config=avx --config=openmp \

--- a/install/tests/Dockerfile
+++ b/install/tests/Dockerfile
@@ -3,8 +3,14 @@ FROM debian
 
 # Install requirements
 RUN apt-get update
-RUN apt-get install -y python3-dev python3-pip
+RUN apt-get install -y python3-dev python3-pip python3-venv
 RUN apt-get install -y cmake git
+
+# Create venv to avoid collision between system packages (e.g. numpy) and Cirq's deps.
+RUN python3 -m venv test_env
+
+# Activate venv.
+ENV PATH="test_env/bin:$PATH"
 
 COPY ./ /qsim/
 RUN pip3 install /qsim/

--- a/pybind_interface/Dockerfile
+++ b/pybind_interface/Dockerfile
@@ -2,11 +2,16 @@
 FROM qsim
 
 # Install additional requirements
-RUN apt-get install -y python3-dev python3-pybind11 python3-pytest python3-pip
+RUN apt-get install -y python3-dev python3-pybind11 python3-pip python3-venv
 
-# The --force flag is used mainly so that the old numpy installation from pybind
-# gets replaced with the one cirq requires
-RUN pip3 install --prefer-binary cirq-core --force
+# Create venv to avoid collision between system packages (e.g. numpy) and Cirq's deps.
+RUN python3 -m venv test_env
+
+# Activate venv.
+ENV PATH="test_env/bin:$PATH"
+
+# break-system-packages flag to override system packages (e.g. numpy) with Cirq's deps.
+RUN pip3 install --prefer-binary cirq-core
 
 # Copy relevant files
 COPY ./pybind_interface/ /qsim/pybind_interface/
@@ -17,6 +22,9 @@ WORKDIR /qsim/
 
 # Build pybind code early to cache the results
 RUN make -C /qsim/ pybind
+
+# Install pytest
+RUN pip3 install pytest
 
 # Compile and run qsim tests
 ENTRYPOINT make -C /qsim/ run-py-tests


### PR DESCRIPTION
fixes https://github.com/quantumlib/qsim/issues/624
the docker CI failes due to a mismatch between system packages scientific libraries (e.g. numpy) installed by `python3-pybind11` and those required by Cirq. Fix by allowing Cirq to override those packages' versions. This is the same as we had before with the `--force` flag which doesn't seem to work anymore, instead I'm using `a virtualenv

---

fixes https://github.com/quantumlib/qsim/issues/625
these were broken due to an update to the LLVM library which broke the compilation step https://bugs.llvm.org/show_bug.cgi?id=27310. Fix is to upgrade libc-bin.