### PR TITLE
Adding Qsim confusion matrix runtime exception

### DIFF
--- a/docs/choose_hw.md
+++ b/docs/choose_hw.md
@@ -258,7 +258,7 @@ are “embarrassingly parallelizable”, there is an automated workflow for
 distributing these trajectories over multiple nodes. A simulation of many
 noiseless circuits can also be distributed over multiple compute nodes.
 
-For mor information about running a mulitnode simulation, see [Multinode quantum
+For more information about running a mulitnode simulation, see [Multinode quantum
 simulation using HTCondor on Google Cloud](/qsim/tutorials/multinode).
 
 ## Runtime estimates

--- a/qsimcirq/qsim_simulator.py
+++ b/qsimcirq/qsim_simulator.py
@@ -213,7 +213,7 @@ class QSimSimulator(
         """Run a simulation, mimicking quantum hardware.
 
         Args:
-            program: The circuit to simulate.
+            circuit: The circuit to simulate.
             param_resolver: Parameters to run with the program.
             repetitions: Number of times to repeat the run.
 

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -336,6 +336,19 @@ def test_numpy_params():
     qsim_result = qsim_simulator.simulate_sweep(circuit, params=prs)
 
 
+def test_confusion_matrix_exception():
+    qubit = cirq.LineQubit(0)
+    cmap = {(0,): np.array([[0.8, 0.2], [0.2, 0.8]])}
+    circuit = cirq.Circuit()
+    circuit += cirq.X(qubit)
+    circuit += cirq.MeasurementGate(1, confusion_map=cmap)(qubit)
+    x, y = sympy.Symbol("x"), sympy.Symbol("y")
+    prs = [{x: np.int64(0), y: np.int64(1)}]
+    qsim_simulator = qsimcirq.QSimSimulator()
+    with pytest.raises(ValueError):
+        _ = qsim_simulator.simulate_sweep(circuit, params=prs)
+
+
 def test_invalid_params():
     # Parameters must have numeric values.
     q0 = cirq.LineQubit(0)
@@ -1219,7 +1232,6 @@ def test_multi_qubit_fusion():
 
 @pytest.mark.parametrize("mode", ["noiseless", "noisy"])
 def test_cirq_qsim_simulate_random_unitary(mode: str):
-
     q0, q1 = cirq.LineQubit.range(2)
     options = qsimcirq.QSimOptions(cpu_threads=16, verbosity=0)
     qsimSim = qsimcirq.QSimSimulator(qsim_options=options)


### PR DESCRIPTION
QSim currently does not support confusion matrices on measurement gates. See https://github.com/quantumlib/Cirq/issues/6305 for more info. While work is done to support confusion matrices surfacing a runtime exception.