### PR TITLE
Pin CI python version

### DIFF
--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -45,6 +45,8 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
 
       - name: Install cibuildwheel and twine
         run: python -m pip install cibuildwheel==2.12.3

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -50,6 +50,8 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
 
       - name: Install cibuildwheel and twine
         run: python -m pip install cibuildwheel==2.12.3


### PR DESCRIPTION
Fixes #632.

The python version for the `setup-python` action does not need to match the version used by `cibuildwheel`; it simply needs to be before `distutils` gets removed in python 3.12.