### PR TITLE
Tighten boot disk lower bound

### DIFF
--- a/docs/tutorials/gcp_gpu.md
+++ b/docs/tutorials/gcp_gpu.md
@@ -34,7 +34,7 @@ instance section, ensure that your VM has the following properties:
 *   In the **Boot disk** section, click the **Change** button:
     1.   In the **Operating System** option, choose **Ubuntu**.
     2.   In the **Version** option, choose **20.04 LTS**.
-    3.   In the **Size** field, enter **100** (minimum known to be sufficient).
+    3.   In the **Size** field, enter **40** (minimum).
 *   The instructions above override steps 3 through 5 in the [Create a Linux VM
     instance](https://cloud.google.com/compute/docs/quickstart-linux)
     Quickstart.


### PR DESCRIPTION
The user who called out #639 narrowed the bound. They suspect as low as 32GB might be sufficient, but to allow files to grow somewhat before this needs another update I've opted to advertise 40GB as the new minimum.