### PR TITLE
Fix for ASAN/MSAN failures

### DIFF
--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Upgrade libc 
       # An LLVM update broke this test, fix per is https://bugs.llvm.org/show_bug.cgi?id=27310.
         run: |
+          sudo apt update
           sudo apt-get upgrade libc-bin
       - name: Run C++ tests
         run: |


### PR DESCRIPTION
ASAN/MSAN are [failing](https://github.com/quantumlib/qsim/actions/runs/6881225904/job/18792708012) with `Failed to fetch mirror{...}`. This PR attempts to fix that issue.

Solution is based on [this SO question](https://askubuntu.com/questions/1320117/apt-cant-fetch-firefox-archives)