### PR TITLE
Update version to 0.19.0

### DIFF
--- a/qsimcirq/_version.py
+++ b/qsimcirq/_version.py
@@ -1,3 +1,3 @@
 """The version number defined here is read automatically in setup.py."""
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"


### PR DESCRIPTION
This minor version adds support for the "basic" version of qsim on Apple Silicon (#643).