### PR TITLE
Fix: Consistent Usage of `target_link_libraries` for CUDA Targets

### DIFF
--- a/pybind_interface/cuda/CMakeLists.txt
+++ b/pybind_interface/cuda/CMakeLists.txt
@@ -27,4 +27,4 @@ set_target_properties(qsim_cuda PROPERTIES
 )
 set_source_files_properties(pybind_main_cuda.cpp PROPERTIES LANGUAGE CUDA)
 
-target_link_libraries(qsim_cuda PUBLIC OpenMP::OpenMP_CXX)
+target_link_libraries(qsim_cuda OpenMP::OpenMP_CXX)

--- a/pybind_interface/custatevec/CMakeLists.txt
+++ b/pybind_interface/custatevec/CMakeLists.txt
@@ -45,4 +45,4 @@ set_target_properties(qsim_custatevec PROPERTIES
 )
 set_source_files_properties(pybind_main_custatevec.cpp PROPERTIES LANGUAGE CUDA)
 
-target_link_libraries(qsim_custatevec PUBLIC OpenMP::OpenMP_CXX)
+target_link_libraries(qsim_custatevec OpenMP::OpenMP_CXX)

--- a/pybind_interface/decide/CMakeLists.txt
+++ b/pybind_interface/decide/CMakeLists.txt
@@ -30,6 +30,7 @@ if(has_nvcc)
             SUFFIX "${PYTHON_MODULE_EXTENSION}"
     )
     set_source_files_properties(decide.cpp PROPERTIES LANGUAGE CUDA)
+    target_link_libraries(qsim_decide OpenMP::OpenMP_CXX)
 elseif(has_hipcc)
     list(APPEND CMAKE_MODULE_PATH "/opt/rocm/lib/cmake/hip")
     find_package(HIP REQUIRED)
@@ -41,8 +42,9 @@ elseif(has_hipcc)
             PREFIX "${PYTHON_MODULE_PREFIX}"
             SUFFIX "${PYTHON_MODULE_EXTENSION}"
     )
+    target_link_libraries(qsim_decide PUBLIC OpenMP::OpenMP_CXX)
 else()
     pybind11_add_module(qsim_decide decide.cpp)
+    target_link_libraries(qsim_decide PUBLIC OpenMP::OpenMP_CXX)
 endif()
 
-target_link_libraries(qsim_decide PUBLIC OpenMP::OpenMP_CXX)


### PR DESCRIPTION
This pull request addresses a build configuration issue that arises (introduced in #643) when mixing plain and keyword signatures of `target_link_libraries` in CMake for the `qsim_cuda`, `qsim_custatevec`, `qsim_decide` targets. The existing setup led to a CMake error, as documented:

```
CMake Error at pybind_interface/cuda/CMakeLists.txt:48 (target_link_libraries):
  The plain signature for target_link_libraries has already been used with
  the target "qsim_cuda".  All uses of target_link_libraries with a target
  must be either all-keyword or all-plain.
```

### Changes Made:

- Modified the `target_link_libraries` command for the `qsim_cuda`, `qsim_custatevec`, `qsim_decide` targets to use the plain form. This change aligns with the internal usage of `target_link_libraries` within the `cuda_add_library` macro, ensuring consistency across the build configuration.

### Rationale:

CMake requires that all invocations of `target_link_libraries` for a specific target maintain a consistent usage pattern - either all using the plain form or all using the keyword form (such as `PUBLIC` or `PRIVATE`). The [`cuda_add_library` macro used in this project](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/FindCUDA.cmake#L2023-2031) employs the plain form of `target_link_libraries`, which necessitates a similar approach for additional invocations of `target_link_libraries` for the `qsim_cuda`, `qsim_custatevec`, `qsim_decide` targets.

By aligning the usage pattern, this pull request resolves the build configuration error and maintains consistency in the CMake setup, ensuring a smoother build process.