### PR TITLE
Set `PYTHON_INCLUDE_DIR` in `setup.py` and pass it to CMake

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import sys
 import shutil
 import platform
 import subprocess
+import sysconfig
 
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
@@ -38,10 +39,12 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+        python_include_dir = sysconfig.get_path("include")
         cmake_args = [
             "-DCMAKE_CUDA_COMPILER=nvcc",
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
             "-DPYTHON_EXECUTABLE=" + sys.executable,
+            "-DPYTHON_INCLUDE_DIR=" + python_include_dir,
         ]
 
         cfg = "Debug" if self.debug else "Release"


### PR DESCRIPTION
Prevents
```
CMake Error at /home/bas.nijholt/micromamba/envs/qsim/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find PythonLibs (missing: PYTHON_INCLUDE_DIRS) (Required is at
  least version "3.7")
Call Stack (most recent call first):
  /home/bas.nijholt/micromamba/envs/qsim/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /home/bas.nijholt/micromamba/envs/qsim/share/cmake-3.27/Modules/FindPythonLibs.cmake:323 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  pybind_interface/cuda/CMakeLists.txt:18 (find_package)
```