### PR TITLE
Allow installing for Python 3.12

### DIFF
--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -15,16 +15,16 @@ jobs:
           - os: macos-12 # x86_64
             name: mac
             cibw:
-              build: "cp37* cp38* cp39* cp310* cp311*"
+              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
           - os: macos-13-large # Apple Silicon
             name: mac_arm64
             cibw:
-              build: "cp37* cp38* cp39* cp310* cp311*"
+              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: "cp37* cp38* cp39* cp310* cp311*"
+              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -20,16 +20,16 @@ jobs:
           - os: macos-12 # x86_64
             name: mac
             cibw:
-              build: "cp37* cp38* cp39* cp310* cp311*"
+              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
           - os: macos-13-large # Apple Silicon
             name: mac_arm64
             cibw:
-              build: "cp37* cp38* cp39* cp310* cp311*"
+              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: "cp37* cp38* cp39* cp310* cp311*"
+              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
     url="https://github.com/quantumlib/qsim",
     author="Vamsi Krishna Devabathini",
     author_email="devabathini92@gmail.com",
-    python_requires=">=3.7.0,<3.12.0",
+    python_requires=">=3.7.0",
     install_requires=requirements,
     extras_require={
         "dev": dev_requirements,


### PR DESCRIPTION
I have tested qsim on Python 3.12 and everything works just fine.