### PR TITLE
build wheel for 3.12

### DIFF
--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -30,7 +30,7 @@ jobs:
             name: win_amd64
             architecture: x64
             cibw:
-              build: "cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64"
+              build: "cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
@@ -50,10 +50,10 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.12'
+          python-version: '3.11'
 
       - name: Install cibuildwheel and twine
-        run: python -m pip install cibuildwheel==2.12.3
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Install requirements
         run: python -m pip install -r requirements.txt

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -50,7 +50,7 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install cibuildwheel and twine
         run: python -m pip install cibuildwheel==2.12.3

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -29,19 +29,19 @@ jobs:
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: "cp312*" #"cp37* cp38* cp39* cp310* cp311*"
+              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64
             architecture: x64
             cibw:
-              build: "cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64"
+              build: "cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm && brew link --overwrite python@3.12 && brew link --force libomp"
+      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm && brew link --overwrite python@3.11 && brew link --force libomp"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"
@@ -55,16 +55,16 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.12'
+          python-version: 'cibuildwheel==2.16.2'
 
       - name: Install cibuildwheel and twine
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.12.3
 
       - name: Install requirements
         run: python -m pip install -r requirements.txt
 
-      # - name: Run C++ tests
-      #   run: bash build_tools/test_libs.sh
+      - name: Run C++ tests
+        run: bash build_tools/test_libs.sh
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -35,7 +35,7 @@ jobs:
             name: win_amd64
             architecture: x64
             cibw:
-              build: "cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64"
+              build: "cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -55,7 +55,7 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install cibuildwheel and twine
         run: python -m pip install cibuildwheel==2.12.3

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -35,7 +35,7 @@ jobs:
             name: win_amd64
             architecture: x64
             cibw:
-              build: "cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
+              build: "cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
@@ -55,10 +55,10 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v2
         with:
-          python-version: 'cibuildwheel==2.16.2'
+          python-version: '3.11'
 
       - name: Install cibuildwheel and twine
-        run: python -m pip install cibuildwheel==2.12.3
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Install requirements
         run: python -m pip install -r requirements.txt

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -29,7 +29,7 @@ jobs:
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
+              build: ["cp37*", "cp38*", "cp39*", "cp310*, "cp311*", "cp312*"]
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64
@@ -41,7 +41,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm && brew link --overwrite python@3.11 && brew link --force libomp"
+      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm && brew link --overwrite python@3.12 && brew link --force libomp"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Install requirements
         run: python -m pip install -r requirements.txt
 
-      - name: Run C++ tests
-        run: bash build_tools/test_libs.sh
+      # - name: Run C++ tests
+      #   run: bash build_tools/test_libs.sh
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -29,7 +29,7 @@ jobs:
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: "cp312* cp37* cp38* cp39* cp310* cp311*"
+              build: "cp312*" #"cp37* cp38* cp39* cp310* cp311*"
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64
@@ -58,7 +58,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install cibuildwheel and twine
-        run: python -m pip install cibuildwheel==2.12.3
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Install requirements
         run: python -m pip install -r requirements.txt

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -29,7 +29,7 @@ jobs:
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: ["cp37*", "cp38*", "cp39*", "cp310*, "cp311*", "cp312*"]
+              build: ["cp312*", "cp37*", "cp38*", "cp39*", "cp310*, "cp311*"]
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -29,7 +29,7 @@ jobs:
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: ["cp312*", "cp37*", "cp38*", "cp39*", "cp310*, "cp311*"]
+              build: "cp312* cp37* cp38* cp39* cp310* cp311*"
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64


### PR DESCRIPTION
The version we are using of `cibuildwheel==2.12.3` is old and silently ignores py3.12 without raising an  error or warning this resulted in no wheel being released for 3.12 https://github.com/quantumlib/qsim/issues/655

fix: upgrade to `cibuildwheel==2.16.2`

---
before
![before](https://github.com/quantumlib/qsim/assets/5949112/d30b52d6-6378-47aa-b956-972a48f46bbe)

after

![after](https://github.com/quantumlib/qsim/assets/5949112/293fab09-761f-4378-aeae-2d0753fce1ee)

---

Also I added 3.12 to windows as well since that was initially overlooked

---
fixes https://github.com/quantumlib/qsim/issues/655