### PR TITLE
Update docs: Add option to use image with CUDA preinstalled

### DIFF
--- a/docs/choose_hw.md
+++ b/docs/choose_hw.md
@@ -140,8 +140,8 @@ At the time of writing, the following compatible GPUs are available on GCP:
 *    [NVIDIA V100](https://www.techpowerup.com/gpu-specs/tesla-v100-pcie-16-gb.c2957).
      Like the NVIDIA T4, this GPU has 16GB of RAM and
      therefore supports up to 30 qubits. It is faster than the T4.
-     Further, it is compatible with multi-GPU simulations. With 8 NVIDIA V100s (128GB),
-     you can simulate up to 33 qubits.
+     Further, it is compatible with multi-GPU simulations. With 4 NVIDIA V100s (64GB),
+     you can simulate up to 32 qubits.
 *    [NVIDIA L4](https://www.techpowerup.com/gpu-specs/l4.c4091). This GPU has 24GB
      of RAM and can therefore simulate up to 31 qubits. With eight of them (192GB), you can simulate
      up to 34 qubits.

--- a/docs/choose_hw.md
+++ b/docs/choose_hw.md
@@ -129,7 +129,7 @@ choose a specific machine:
 For GPU simulations, you may follow the instructions in [this](tutorials/gcp_gpu)
 guide to set up a virtual machine (VM) on Google Cloud Platform (GCP).
 Alternatively, you can use your own hardware.
-Note the [hardware requirements](https://docs.nvidia.com/cuda/cuquantum/getting_started.html#custatevec)
+Note the [hardware requirements](https://docs.nvidia.com/cuda/cuquantum/latest/getting_started.html#custatevec)
 for NVIDIA's cuQuantum when picking a GPU; in particular, it must have
 CUDA Compute Capability 7.0 or higher.
 At the time of writing, the following compatible GPUs are available on GCP:

--- a/docs/tutorials/gcp_gpu.md
+++ b/docs/tutorials/gcp_gpu.md
@@ -37,7 +37,7 @@ instance section, ensure that your VM has the following properties:
     3.   In the **Size** field, enter **40** (minimum).
 
     **Alternatively, you can click the "Switch Image" button and use the image with
-    CUDA pre-installed, which lets you skip step 3. I have verified that this works
+    CUDA pre-installed, which lets you skip step 3. It has been verified that this works
     with cuQuantum Appliance (option 3).**
 
 *   The instructions above override steps 3 through 5 in the [Create a Linux VM
@@ -181,8 +181,7 @@ to set up NVIDIA Container Toolkit.
 
 ## 9. Install NVIDIA cuQuantum Appliance (Option 3 only)
 Follow the instructions [here](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuquantum-appliance)
-to set up cuQuantum Appliance. If this link is broken, you can try the [cached page](https://webcache.googleusercontent.com/search?q=cache%3Ahttps%3A%2F%2Fcatalog.ngc.nvidia.com%2Forgs%2Fnvidia%2Fcontainers%2Fcuquantum-appliance&rlz=1CAFOSO_enUS1067&oq=cache%3Ahttps%3A%2F%2Fcatalog.ngc.nvidia.com%2Forgs%2Fnvidia%2Fcontainers%2Fcuquantum-appliance&gs_lcrp=EgZjaHJvbWUqBggAEEUYOzIGCAAQRRg7MgYIARBFGDoyBggCEEUYPDIGCAMQRRg80gEIMzMyMGowajSoAgCwAgA).
-You may need to use `sudo` for the Docker commands.
+to set up cuQuantum Appliance. You may need to use `sudo` for the Docker commands.
 
 ## 10. Verify your installation (Options 1, 2, and 3)
 

--- a/docs/tutorials/gcp_gpu.md
+++ b/docs/tutorials/gcp_gpu.md
@@ -35,6 +35,11 @@ instance section, ensure that your VM has the following properties:
     1.   In the **Operating System** option, choose **Ubuntu**.
     2.   In the **Version** option, choose **20.04 LTS**.
     3.   In the **Size** field, enter **40** (minimum).
+
+    **Alternatively, you can click the "Switch Image" button and use the image with
+    CUDA pre-installed, which lets you skip step 3. I have verified that this works
+    with cuQuantum Appliance (option 3).**
+
 *   The instructions above override steps 3 through 5 in the [Create a Linux VM
     instance](https://cloud.google.com/compute/docs/quickstart-linux)
     Quickstart.
@@ -176,8 +181,8 @@ to set up NVIDIA Container Toolkit.
 
 ## 9. Install NVIDIA cuQuantum Appliance (Option 3 only)
 Follow the instructions [here](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuquantum-appliance)
-to set up cuQuantum Appliance. You may need to use `sudo` for the Docker commands.
-
+to set up cuQuantum Appliance. If this link is broken, you can try the [cached page](https://webcache.googleusercontent.com/search?q=cache%3Ahttps%3A%2F%2Fcatalog.ngc.nvidia.com%2Forgs%2Fnvidia%2Fcontainers%2Fcuquantum-appliance&rlz=1CAFOSO_enUS1067&oq=cache%3Ahttps%3A%2F%2Fcatalog.ngc.nvidia.com%2Forgs%2Fnvidia%2Fcontainers%2Fcuquantum-appliance&gs_lcrp=EgZjaHJvbWUqBggAEEUYOzIGCAAQRRg7MgYIARBFGDoyBggCEEUYPDIGCAMQRRg80gEIMzMyMGowajSoAgCwAgA).
+You may need to use `sudo` for the Docker commands.
 
 ## 10. Verify your installation (Options 1, 2, and 3)
 


### PR DESCRIPTION
Describe the option to use a VM image that has CUDA preinstalled. Also redirect to a cached version of the cuQuantum Appliance website because the page is down.