### PR TITLE
Use bazel-contrib/setup-bazel instead of manually installing a deb during CI

### DIFF
--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: bazel-contrib/setup-bazel@0.8.5
+        bazelisk-cache: true
+        disk-cache: ${{ github.workflow }}
+        repository-cache: true
       - name: Checkout submodules
         run: git submodule update --init --recursive
-      - name: Install Bazel on CI
-        run: |
-          wget https://github.com/bazelbuild/bazel/releases/download/5.3.0/bazel_5.3.0-linux-x86_64.deb
-          sudo dpkg -i bazel_5.3.0-linux-x86_64.deb
       - name: Install requirements
         run: |
           python3 -m pip install -r requirements.txt
@@ -51,16 +51,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: bazel-contrib/setup-bazel@0.8.5
+        bazelisk-cache: true
+        disk-cache: ${{ github.workflow }}
+        repository-cache: true
       - name: Checkout submodules
         run: git submodule update --init --recursive
-      - name: Install Bazel on CI
-        run: |
-          wget https://github.com/bazelbuild/bazel/releases/download/5.3.0/bazel_5.3.0-linux-x86_64.deb
-          sudo dpkg -i bazel_5.3.0-linux-x86_64.deb
       - name: Install requirements
         run: |
           python3 -m pip install -r requirements.txt
-      - name: Upgrade libc 
+      - name: Upgrade libc
       # An LLVM update broke this test, fix per is https://bugs.llvm.org/show_bug.cgi?id=27310.
         run: |
           sudo apt update
@@ -69,19 +69,19 @@ jobs:
         run: |
           bazel test --config=avx --config=openmp \
           --config=${{ matrix.sanitizer_opt }} tests:all
-  
+
   test-mem:
     name: Test with tcmalloc
     runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
+      - uses: bazel-contrib/setup-bazel@0.8.5
+        bazelisk-cache: true
+        disk-cache: ${{ github.workflow }}
+        repository-cache: true
       - name: Checkout submodules
         run: git submodule update --init --recursive
-      - name: Install Bazel on CI
-        run: |
-          wget https://github.com/bazelbuild/bazel/releases/download/5.3.0/bazel_5.3.0-linux-x86_64.deb
-          sudo dpkg -i bazel_5.3.0-linux-x86_64.deb
       - name: Install requirements
         run: |
           python3 -m pip install -r requirements.txt

--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -23,10 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: bazel-contrib/setup-bazel@0.8.5
-        bazelisk-cache: true
-        disk-cache: ${{ github.workflow }}
-        repository-cache: true
-        bazelisk-version: 1.x
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+          bazelisk-version: 1.x
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Install requirements
@@ -53,10 +54,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: bazel-contrib/setup-bazel@0.8.5
-        bazelisk-cache: true
-        disk-cache: ${{ github.workflow }}
-        repository-cache: true
-        bazelisk-version: 1.x
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+          bazelisk-version: 1.x
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Install requirements
@@ -79,10 +81,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: bazel-contrib/setup-bazel@0.8.5
-        bazelisk-cache: true
-        disk-cache: ${{ github.workflow }}
-        repository-cache: true
-        bazelisk-version: 1.x
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+          bazelisk-version: 1.x
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Install requirements

--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -26,6 +26,7 @@ jobs:
         bazelisk-cache: true
         disk-cache: ${{ github.workflow }}
         repository-cache: true
+        bazelisk-version: 1.x
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Install requirements
@@ -55,6 +56,7 @@ jobs:
         bazelisk-cache: true
         disk-cache: ${{ github.workflow }}
         repository-cache: true
+        bazelisk-version: 1.x
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Install requirements
@@ -80,6 +82,7 @@ jobs:
         bazelisk-cache: true
         disk-cache: ${{ github.workflow }}
         repository-cache: true
+        bazelisk-version: 1.x
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Install requirements


### PR DESCRIPTION
Use [`bazel-contrib/setup-bazel`](https://github.com/bazel-contrib/setup-bazel) instead of manually installing a deb during CI

Also fix some EOL whitespace because that's how my vim is configured.

@95-martin-orion 