### PR TITLE
Slightly relax tolerance in a test case of Apply1InteriorArbitrary

### DIFF
--- a/tests/mps_simulator_test.cc
+++ b/tests/mps_simulator_test.cc
@@ -259,7 +259,7 @@ TEST(MPSSimulator, Apply1InteriorArbitrary) {
   ASSERT_NEAR(state.get()[l_offset + 56], -11.8, 1e-5);
   ASSERT_NEAR(state.get()[l_offset + 57], 138, 1e-5);
   ASSERT_NEAR(state.get()[l_offset + 58], -12.2, 1e-5);
-  ASSERT_NEAR(state.get()[l_offset + 59], 143.2, 1e-5);
+  ASSERT_NEAR(state.get()[l_offset + 59], 143.2, 2e-5);
   ASSERT_NEAR(state.get()[l_offset + 60], -12.6, 1e-5);
   ASSERT_NEAR(state.get()[l_offset + 61], 148.4, 1e-5);
   ASSERT_NEAR(state.get()[l_offset + 62], -13, 1e-5);


### PR DESCRIPTION
The test case in `third_party/qsim/tests/mps_simulator_test.cc` on line 262 fails if the Eigen linear algebra library is updated to a recent version available from <https://gitlab.com/libeigen/eigen>. Specifically, commit 59498c96 in the Eigen repo (which can be seen at <https://gitlab.com/libeigen/eigen/-/merge_requests/1663>) changed the code in `Eigen/src/Core/arch/Complex.h` for `pmul()` to use a fused multiply-add-subtract (FMA) instruction (`fmaddsub`) instead of the previous separate multiply and add-subtract instructions. The new code improved accuracy for many of the tests in `mps_simulator_test.cc`, slightly worsened accuracy for some of the tests, and in the case of the one on line 262, made it cross the absolute tolerance value of `1e-5` by a very small amount. After considering various alternatives, the least-worst option seems to be to increase the tolerance for this one case.

Note: the qsim repository on GitHub has its own vendored copy of Eigen, so this change is not strictly necessary; however, if we ever update qsim's internal copy of Eigen, then this change will become relevant.

The original debugging & solution are the work of @pavoljuhas.