### PR TITLE
Fix CI actions on GitHub

### DIFF
--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -72,7 +72,7 @@ jobs:
   
   test-mem:
     name: Test with tcmalloc
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -6,8 +6,7 @@ on:
     branches:
       - master
 
-  # TODO(pavoljuhas) - uncomment below
-  # pull_request:
+  pull_request:
 
 jobs:
   # Run tests with Bazel v5.3.0.

--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -21,7 +21,7 @@ jobs:
         parallel_opt: [openmp,nopenmp]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Install Bazel on CI
@@ -50,7 +50,7 @@ jobs:
         sanitizer_opt: [msan,asan]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Install Bazel on CI
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Install Bazel on CI

--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -6,7 +6,8 @@ on:
     branches:
       - master
 
-  pull_request:
+  # TODO(pavoljuhas) - uncomment below
+  # pull_request:
 
 jobs:
   # Run tests with Bazel v5.3.0.

--- a/.github/workflows/bazeltest.yml
+++ b/.github/workflows/bazeltest.yml
@@ -12,7 +12,7 @@ jobs:
   # Run tests with Bazel v5.3.0.
   test:
     name: Test with Bazel
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         # Hardware optimizers.
@@ -43,7 +43,7 @@ jobs:
 
   test-san:
     name: Sanitizer tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         # Test sanitizers
@@ -72,7 +72,7 @@ jobs:
   
   test-mem:
     name: Test with tcmalloc
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cirq_compatibility.yml
+++ b/.github/workflows/cirq_compatibility.yml
@@ -9,7 +9,7 @@ jobs:
     name: Nightly Compatibility
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v1
         with:
           python-version: '3.7'

--- a/.github/workflows/cirq_compatibility.yml
+++ b/.github/workflows/cirq_compatibility.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.7'
           architecture: 'x64'

--- a/.github/workflows/cirq_compatibility.yml
+++ b/.github/workflows/cirq_compatibility.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   consistency:
     name: Nightly Compatibility
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -7,8 +7,7 @@ on:
       - master
 
   # Run tests for any PRs.
-  # TODO(pavoljuhas) - uncomment below
-  # pull_request:
+  pull_request:
 
 jobs:
   # Run tests.

--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -7,7 +7,8 @@ on:
       - master
 
   # Run tests for any PRs.
-  pull_request:
+  # TODO(pavoljuhas) - uncomment below
+  # pull_request:
 
 jobs:
   # Run tests.

--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Build Docker images
-        run: docker-compose build
+        run: docker compose build
       - name: Run C++ tests
         run: docker run --rm qsim-cxx-tests:latest
       - name: Run Python tests
@@ -34,4 +34,4 @@ jobs:
       - name: Test install process
         run: |
           cd install/tests
-          docker-compose up --build
+          docker compose up --build

--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Build Docker images

--- a/.github/workflows/python_format.yml
+++ b/.github/workflows/python_format.yml
@@ -17,7 +17,7 @@ jobs:
     name: Format check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v1

--- a/.github/workflows/python_format.yml
+++ b/.github/workflows/python_format.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.7'
           architecture: 'x64'

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -20,12 +20,13 @@ jobs:
             name: mac_arm64
             cibw:
               build: "cp39* cp310* cp311* cp312*"
-          - os: ubuntu-20.04
-            name: manylinux2014
-            cibw:
-              arch: x86_64
-              build: "cp39* cp310* cp311* cp312*"
-              manylinux_image: manylinux2014
+          # TODO(pavoljuhas) - uncomment below
+          # - os: ubuntu-20.04
+          #   name: manylinux2014
+          #   cibw:
+          #     arch: x86_64
+          #     build: "cp39* cp310* cp311* cp312*"
+          #     manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64
             architecture: x64

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: python-wheels
           path: ./wheelhouse/*.whl
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: python-wheels
         path: dist/

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -15,22 +15,22 @@ jobs:
           - os: macos-12 # x86_64
             name: mac
             cibw:
-              build: "cp38* cp39* cp310* cp311* cp312*"
+              build: "cp39* cp310* cp311* cp312*"
           - os: macos-13-large # Apple Silicon
             name: mac_arm64
             cibw:
-              build: "cp38* cp39* cp310* cp311* cp312*"
+              build: "cp39* cp310* cp311* cp312*"
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: "cp38* cp39* cp310* cp311* cp312*"
+              build: "cp39* cp310* cp311* cp312*"
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64
             architecture: x64
             cibw:
-              build: "cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
+              build: "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -82,10 +82,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: python-wheels
         path: dist/
+        pattern: python-wheels-*
+        merge-multiple: true
     - name: Publish wheels
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -20,13 +20,12 @@ jobs:
             name: mac_arm64
             cibw:
               build: "cp39* cp310* cp311* cp312*"
-          # TODO(pavoljuhas) - uncomment below
-          # - os: ubuntu-20.04
-          #   name: manylinux2014
-          #   cibw:
-          #     arch: x86_64
-          #     build: "cp39* cp310* cp311* cp312*"
-          #     manylinux_image: manylinux2014
+          - os: ubuntu-20.04
+            name: manylinux2014
+            cibw:
+              arch: x86_64
+              build: "cp39* cp310* cp311* cp312*"
+              manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64
             architecture: x64

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -41,7 +41,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: ": no action"
+      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@12 && brew link --overwrite python@3.11 && brew link --force libomp"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -14,10 +14,14 @@ jobs:
         include:
           - os: macos-12 # x86_64
             name: mac
+            env:
+              macosx_deployment_target: "12.0"
             cibw:
               build: "cp39* cp310* cp311* cp312*"
           - os: macos-13-large # Apple Silicon
             name: mac_arm64
+            env:
+              macosx_deployment_target: "13.0"
             cibw:
               build: "cp39* cp310* cp311* cp312*"
           - os: ubuntu-20.04
@@ -32,7 +36,7 @@ jobs:
             cibw:
               build: "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
-      MACOSX_DEPLOYMENT_TARGET: "13.0"
+      MACOSX_DEPLOYMENT_TARGET: "${{ matrix.env.macosx_deployment_target }}"
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
@@ -42,7 +46,7 @@ jobs:
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"
       # due to package and module name conflict have to temporarily move it away to run tests
-      CIBW_BEFORE_TEST: mv {package}/qsimcirq /tmp
+      CIBW_BEFORE_TEST: "mv {package}/qsimcirq /tmp"
       CIBW_TEST_EXTRAS: "dev"
       CIBW_TEST_COMMAND: "pytest {package}/qsimcirq_tests/qsimcirq_test.py && mv /tmp/qsimcirq {package}"
     steps:
@@ -70,7 +74,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-${{ matrix.name }}
           path: ./wheelhouse/*.whl
   release-wheels:
     name: Publish all wheels

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -66,9 +66,6 @@ jobs:
       - name: Run C++ tests
         run: bash build_tools/test_libs.sh
 
-      - name: Show environment variables
-        run: env
-
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -33,7 +33,7 @@ jobs:
             cibw:
               build: "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
-      MACOSX_DEPLOYMENT_TARGET: "12.0"
+      MACOSX_DEPLOYMENT_TARGET: "13.0"
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -38,7 +38,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@11 && brew link --overwrite python@3.11 && brew link --force libomp"
+      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@12 && brew link --overwrite python@3.11 && brew link --force libomp"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -41,7 +41,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@12 && brew link --overwrite python@3.11 && brew link --force libomp"
+      CIBW_BEFORE_BUILD_MACOS: ": no action"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -24,7 +24,7 @@ jobs:
               macosx_deployment_target: "13.0"
             cibw:
               build: "cp39* cp310* cp311* cp312*"
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             name: manylinux2014
             cibw:
               arch: x86_64

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Run C++ tests
         run: bash build_tools/test_libs.sh
 
+      - name: Show environment variables
+        run: env
+
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -38,7 +38,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm && brew link --overwrite python@3.11 && brew link --force libomp"
+      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@12 && brew link --overwrite python@3.11 && brew link --force libomp"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -45,7 +45,7 @@ jobs:
       CIBW_TEST_EXTRAS: "dev"
       CIBW_TEST_COMMAND: "pytest {package}/qsimcirq_tests/qsimcirq_test.py && mv /tmp/qsimcirq {package}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v2

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -53,7 +53,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install cibuildwheel and twine
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.20.0
 
       - name: Install requirements
         run: python -m pip install -r requirements.txt

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -33,6 +33,7 @@ jobs:
             cibw:
               build: "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: python-wheels
         path: dist/

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -15,22 +15,22 @@ jobs:
           - os: macos-12 # x86_64
             name: mac
             cibw:
-              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
+              build: "cp38* cp39* cp310* cp311* cp312*"
           - os: macos-13-large # Apple Silicon
             name: mac_arm64
             cibw:
-              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
+              build: "cp38* cp39* cp310* cp311* cp312*"
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
+              build: "cp38* cp39* cp310* cp311* cp312*"
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64
             architecture: x64
             cibw:
-              build: "cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
+              build: "cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -38,7 +38,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@12 && brew link --overwrite python@3.11 && brew link --force libomp"
+      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@11 && brew link --overwrite python@3.11 && brew link --force libomp"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -71,9 +71,6 @@ jobs:
       - name: Run C++ tests
         run: bash build_tools/test_libs.sh
 
-      - name: Show environment variables
-        run: env
-
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -50,7 +50,7 @@ jobs:
       CIBW_TEST_EXTRAS: "dev"
       CIBW_TEST_COMMAND: "pytest {package}/qsimcirq_tests/qsimcirq_test.py && mv /tmp/qsimcirq {package}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v2

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -20,22 +20,22 @@ jobs:
           - os: macos-12 # x86_64
             name: mac
             cibw:
-              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
+              build: "cp38* cp39* cp310* cp311* cp312*"
           - os: macos-13-large # Apple Silicon
             name: mac_arm64
             cibw:
-              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
+              build: "cp38* cp39* cp310* cp311* cp312*"
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: "cp37* cp38* cp39* cp310* cp311* cp312*"
+              build: "cp38* cp39* cp310* cp311* cp312*"
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64
             architecture: x64
             cibw:
-              build: "cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
+              build: "cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
@@ -73,4 +73,3 @@ jobs:
         with:
           name: python-wheels
           path: ./wheelhouse/*.whl
-

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -20,13 +20,13 @@ jobs:
           - os: macos-12 # x86_64
             name: mac
             env:
-              MACOSX_DEPLOYMENT_TARGET: "12.0"
+              macosx_deployment_target: "12.0"
             cibw:
               build: "cp39* cp310* cp311* cp312*"
           - os: macos-13-large # Apple Silicon
             name: mac_arm64
             env:
-              MACOSX_DEPLOYMENT_TARGET: "13.0"
+              macosx_deployment_target: "13.0"
             cibw:
               build: "cp39* cp310* cp311* cp312*"
           - os: ubuntu-20.04
@@ -41,6 +41,7 @@ jobs:
             cibw:
               build: "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
+      MACOSX_DEPLOYMENT_TARGET: "${{ matrix.env.macosx_deployment_target }}"
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -46,7 +46,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: ": no action"
+      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@12 && brew link --overwrite python@3.11 && brew link --force libomp"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -79,5 +79,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-${{ matrix.name }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -29,7 +29,7 @@ jobs:
               macosx_deployment_target: "13.0"
             cibw:
               build: "cp39* cp310* cp311* cp312*"
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             name: manylinux2014
             cibw:
               arch: x86_64

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Run C++ tests
         run: bash build_tools/test_libs.sh
 
+      - name: Show environment variables
+        run: env
+
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -46,7 +46,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@12 && brew link --overwrite python@3.11 && brew link --force libomp"
+      CIBW_BEFORE_BUILD_MACOS: ": no action"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -42,7 +42,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm && brew link --overwrite python@3.11 && brew link --force libomp"
+      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@12 && brew link --overwrite python@3.11 && brew link --force libomp"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -20,22 +20,22 @@ jobs:
           - os: macos-12 # x86_64
             name: mac
             cibw:
-              build: "cp38* cp39* cp310* cp311* cp312*"
+              build: "cp39* cp310* cp311* cp312*"
           - os: macos-13-large # Apple Silicon
             name: mac_arm64
             cibw:
-              build: "cp38* cp39* cp310* cp311* cp312*"
+              build: "cp39* cp310* cp311* cp312*"
           - os: ubuntu-20.04
             name: manylinux2014
             cibw:
               arch: x86_64
-              build: "cp38* cp39* cp310* cp311* cp312*"
+              build: "cp39* cp310* cp311* cp312*"
               manylinux_image: manylinux2014
           - os: windows-2019
             name: win_amd64
             architecture: x64
             cibw:
-              build: "cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
+              build: "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -58,7 +58,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install cibuildwheel and twine
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.20.0
 
       - name: Install requirements
         run: python -m pip install -r requirements.txt

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -37,6 +37,7 @@ jobs:
             cibw:
               build: "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -37,11 +37,12 @@ jobs:
             cibw:
               build: "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: "brew install libomp libunwind && brew link --overwrite python@3.11 && brew link --force libomp && brew link --force libunwind"
+      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm && brew link --overwrite python@3.11 && brew link --force libomp"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -42,7 +42,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@12 && brew link --overwrite python@3.11 && brew link --force libomp"
+      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@11 && brew link --overwrite python@3.11 && brew link --force libomp"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -19,10 +19,14 @@ jobs:
         include:
           - os: macos-12 # x86_64
             name: mac
+            env:
+              MACOSX_DEPLOYMENT_TARGET: "12.0"
             cibw:
               build: "cp39* cp310* cp311* cp312*"
           - os: macos-13-large # Apple Silicon
             name: mac_arm64
+            env:
+              MACOSX_DEPLOYMENT_TARGET: "13.0"
             cibw:
               build: "cp39* cp310* cp311* cp312*"
           - os: ubuntu-20.04
@@ -37,7 +41,6 @@ jobs:
             cibw:
               build: "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
-      MACOSX_DEPLOYMENT_TARGET: "13.0"
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -42,7 +42,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@11 && brew link --overwrite python@3.11 && brew link --force libomp"
+      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm@12 && brew link --overwrite python@3.11 && brew link --force libomp"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -37,12 +37,11 @@ jobs:
             cibw:
               build: "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
-      MACOSX_DEPLOYMENT_TARGET: "12.0"
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"
       CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.cibw.manylinux_image }}"
-      CIBW_BEFORE_BUILD_MACOS: "brew install libomp llvm && brew link --overwrite python@3.11 && brew link --force libomp"
+      CIBW_BEFORE_BUILD_MACOS: "brew install libomp libunwind && brew link --overwrite python@3.11 && brew link --force libomp && brew link --force libunwind"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
       # to install latest delocate package
       CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: python-wheels
           path: ./wheelhouse/*.whl

--- a/.github/workflows/testing_wheels.yml
+++ b/.github/workflows/testing_wheels.yml
@@ -37,7 +37,7 @@ jobs:
             cibw:
               build: "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64"
     env:
-      MACOSX_DEPLOYMENT_TARGET: "12.0"
+      MACOSX_DEPLOYMENT_TARGET: "13.0"
       CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "${{ matrix.cibw.arch || 'auto' }}"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -19,10 +19,10 @@ git submodule update --init --recursive
 To build qsim and run all the tests:
 
 ```
-# docker-compose up --build
+# docker compose up --build
 ```
 
-`docker-compose` will create the `qsim`, `qsim-cxx-tests`, and `qsim-py-tests`
+`docker compose` will create the `qsim`, `qsim-cxx-tests`, and `qsim-py-tests`
 images and automatically run all tests. A successful run should have the
 following messages somewhere in the logs:
 
@@ -34,7 +34,7 @@ qsim-py-tests exited with code 0
 To build without running tests, simply run:
 
 ```
-# docker-compose build
+# docker compose build
 ```
 
 ## Run Simulations


### PR DESCRIPTION
* update linux runners to ubuntu-22 or ubuntu-latest, but run test-mem
  job on ubuntu-20 for it for some reason fails on ubuntu-22
* bump up CI actions to be compatible with node 20, namely bump up to
  actions/checkout@v4, actions/setup-python@v5, download-artifact@v4, upload-artifact@v4
* update steps involving download-artifact and upload-artifact actions per
  https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md
* migrate to docker compose v2
* to build binary wheels for mac os, set MACOSX_DEPLOYMENT_TARGET according
  to the macos version
* stop building and testing wheels for old Python versions 3.7, 3.8