### PR TITLE
CI - test cirq compatibility under Python 3.10

### DIFF
--- a/.github/workflows/cirq_compatibility.yml
+++ b/.github/workflows/cirq_compatibility.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: '3.10'
           architecture: 'x64'
       - name: Install Cirq nightly
-        run: pip3 install -U cirq --pre
+        run: pip3 install --upgrade cirq~=1.0.dev
       - name: Install qsim requirements
         run: pip3 install -r requirements.txt
       - name: Install test requirements

--- a/.github/workflows/cirq_compatibility.yml
+++ b/.github/workflows/cirq_compatibility.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+  # TODO - temporary for job testing only
+  push:
+    branches:
+      - master
+
 jobs:
   consistency:
     name: Nightly Compatibility

--- a/.github/workflows/cirq_compatibility.yml
+++ b/.github/workflows/cirq_compatibility.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install Cirq nightly
         run: pip3 install -U cirq --pre

--- a/.github/workflows/cirq_compatibility.yml
+++ b/.github/workflows/cirq_compatibility.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
-  # TODO - temporary for job testing only
-  push:
-    branches:
-      - master
-
 jobs:
   consistency:
     name: Nightly Compatibility

--- a/.github/workflows/python_format.yml
+++ b/.github/workflows/python_format.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install dev requirements
         run: pip install -r dev-requirements.txt


### PR DESCRIPTION
CI - test cirq compatibility using Python 3.10

cirq requires minimum Python version 3.10.  Running under
Python 3.7 installs cirq from June 2023.

Also change the pip3 command to install a pre-release of cirq
with stable dependencies.

Run the "Format check" job under Python 3.10 as well.
