### PR TITLE
Increment version number in master

### DIFF
--- a/qsimcirq/_version.py
+++ b/qsimcirq/_version.py
@@ -1,3 +1,3 @@
 """The version number defined here is read automatically in setup.py."""
 
-__version__ = "0.21.0"
+__version__ = "0.22.0.dev0"


### PR DESCRIPTION
The version number should have been incremented to 0.22.0.dev0 after the 0.21.0 release, but never was.