### PR TITLE
Update min version specification in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_CXX_STANDARD 11)
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.31)
 
 # Check if CMAKE_SYSTEM_NAME is Darwin (macOS) and CMAKE_SYSTEM_PROCESSOR is arm64
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")

--- a/pybind_interface/avx2/CMakeLists.txt
+++ b/pybind_interface/avx2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.31)
 project(qsim)
 
 IF (WIN32)

--- a/pybind_interface/avx512/CMakeLists.txt
+++ b/pybind_interface/avx512/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.31)
 project(qsim)
 
 

--- a/pybind_interface/basic/CMakeLists.txt
+++ b/pybind_interface/basic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.31)
 project(qsim)
 
 if(WIN32)

--- a/pybind_interface/cuda/CMakeLists.txt
+++ b/pybind_interface/cuda/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.31)
 project(qsim LANGUAGES CXX CUDA)
 
 if(WIN32)

--- a/pybind_interface/custatevec/CMakeLists.txt
+++ b/pybind_interface/custatevec/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.31)
 project(qsim LANGUAGES CXX CUDA)
 
 if(WIN32)

--- a/pybind_interface/decide/CMakeLists.txt
+++ b/pybind_interface/decide/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.31)
 
 if(WIN32)
     set(CMAKE_CXX_FLAGS "/O2 /openmp")

--- a/pybind_interface/hip/CMakeLists.txt
+++ b/pybind_interface/hip/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.31)
 project(qsim LANGUAGES CXX HIP)
 
 if(WIN32)

--- a/pybind_interface/sse/CMakeLists.txt
+++ b/pybind_interface/sse/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.31)
 project(qsim)
 
 IF (WIN32)


### PR DESCRIPTION
This increases the values supplied in `cmake_minimum_required` directives from the previous 3.11 to 3.31, so that CMake does not complain about the minimum version being too old.