### PR TITLE
Add pytest-xdist to dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 black~=25.1.0
 flynt~=1.0
 pytest
+pytest-xdist[psutil]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 black~=25.1.0
 flynt~=1.0
 pytest
-pytest-xdist[psutil]
+pytest-xdist


### PR DESCRIPTION
This allows for parallel `pytest` execution. 

(By itself, this addition to `dev-requirements.txt` does nothing; the purpose is to make it a separate commit so that the xdist features can be used in updated workflows and test scripts.)