### PR TITLE
Add tags for SSE test cases

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -360,6 +360,7 @@ cc_test(
 cc_test(
     name = "simulator_sse_test",
     size = "small",
+    tags = ["sse"],
     srcs = ["simulator_sse_test.cc"],
     deps = [
         ":simulator_testfixture",
@@ -451,6 +452,7 @@ cc_test(
 cc_test(
     name = "statespace_sse_test",
     size = "small",
+    tags = ["sse"],
     srcs = ["statespace_sse_test.cc"],
     deps = [
         ":statespace_testfixture",
@@ -532,6 +534,7 @@ cc_test(
 cc_test(
     name = "unitaryspace_sse_test",
     size = "small",
+    tags = ["sse"],
     srcs = ["unitaryspace_sse_test.cc"],
     copts = select({
         ":windows": windows_copts,
@@ -617,6 +620,7 @@ cc_test(
 cc_test(
     name = "unitary_calculator_sse_test",
     size = "small",
+    tags = ["sse"],
     srcs = ["unitary_calculator_sse_test.cc"],
     copts = select({
         ":windows": windows_copts,


### PR DESCRIPTION
The addition of tags makes it possible to to use `bazel`'s filtering options to selectively exclude certain cases during bazel build and test runs. (The addition of these tags by itself does not alter `bazel` builds or tests if no options are given to `bazel`.)