### PR TITLE
Update some CMake files to add missing constructs & remove obsolete ones

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -38,6 +38,9 @@ max_line_length = 80
 [{BUILD,*.BUILD,*.bzl,*.bazel,.bazelrc}]
 indent_size = 4
 
+[{CMakeLists.txt,*.cmake}]
+indent_size = 4
+
 [{*.cc,*.h}]
 indent_size = 2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+project(qsim)
+
 set(CMAKE_CXX_STANDARD 11)
 cmake_minimum_required(VERSION 3.31)
 

--- a/pybind_interface/GetPybind11.cmake
+++ b/pybind_interface/GetPybind11.cmake
@@ -24,6 +24,5 @@ if (pybind11_FOUND)
 endif()
 
 if((NOT pybind11_FOUND) AND (NOT pybind11_POPULATED)) # check first on system path, then attempt git fetch
-  FetchContent_Populate(pybind11)
-  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
+  FetchContent_MakeAvailable(pybind11)
 endif()


### PR DESCRIPTION
This updates two CMake files:

- The top-level `CMakeLists.txt` file was missing a `project()` declaration. The lack of a `project(qsim)` declaration may have worked with old versions of cmake, but in newer versions, its absence causes build failures.
- Remove a couple of obsolete constructs from `pybind_interface/GetPybind11.cmake`. These cause failures with newer versions of CMake.