### PR TITLE
Fix googletest CMake build

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -55,7 +55,8 @@ run-hip-tests: hip-tests
 $(GTEST_DIR)/make:
 	-git submodule update --init --recursive googletest
 	mkdir -p $(GTEST_DIR)/make
-	cd $(GTEST_DIR)/make &&	$(CMAKE) .. && $(MAKE)
+	cd $(GTEST_DIR) && $(CMAKE) -B make -S ..
+	cd $(GTEST_DIR)/make && make
 
 %.x: %.cc $(GTEST_DIR)/make
 	$(CXX) -o ./$@ $< $(TESTFLAGS) $(CXXFLAGS) $(ARCHFLAGS)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,7 +22,7 @@ GMOCK_DIR = $(CURDIR)/googletest/googlemock
 
 CMAKE=cmake
 
-TESTFLAGS = -I$(GTEST_DIR)/include -L$(GTEST_DIR)/make/lib -lgtest
+TESTFLAGS = -I$(GTEST_DIR)/include -L$(GTEST_DIR)/build/lib -lgtest
 
 .PHONY: cxx-tests
 cxx-tests: $(CXX_TARGETS)
@@ -52,25 +52,25 @@ run-custatevec-tests: custatevec-tests
 run-hip-tests: hip-tests
 	for exe in $(HIP_TARGETS); do if ! ./$$exe; then exit 1; fi; done
 
-$(GTEST_DIR)/make:
+$(GTEST_DIR)/build:
 	-git submodule update --init --recursive googletest
-	mkdir -p $(GTEST_DIR)/make
-	cd $(GTEST_DIR) && $(CMAKE) -B make -S ..
-	cd $(GTEST_DIR)/make && make
+	mkdir -p $(GTEST_DIR)/build
+	cd $(GTEST_DIR) && $(CMAKE) -B build -S ..
+	cd $(GTEST_DIR)/build && make
 
-%.x: %.cc $(GTEST_DIR)/make
+%.x: %.cc $(GTEST_DIR)/build
 	$(CXX) -o ./$@ $< $(TESTFLAGS) $(CXXFLAGS) $(ARCHFLAGS)
 
-%cuda_test.x: %cuda_test.cu $(GTEST_DIR)/make
+%cuda_test.x: %cuda_test.cu $(GTEST_DIR)/build
 	$(NVCC) -o ./$@ $< $(TESTFLAGS) $(NVCCFLAGS)
 
-%custatevec_test.x: %custatevec_test.cu $(GTEST_DIR)/make
+%custatevec_test.x: %custatevec_test.cu $(GTEST_DIR)/build
 	$(NVCC) -o ./$@ $< $(TESTFLAGS) $(NVCCFLAGS) $(CUSTATEVECFLAGS)
 
-%hip_test.x: %cuda_test.cu $(GTEST_DIR)/make
+%hip_test.x: %cuda_test.cu $(GTEST_DIR)/build
 	$(HIPCC) -o ./$@ $< $(TESTFLAGS) $(HIPCCFLAGS)
 
 .PHONY: clean
 clean:
 	-rm -f ./*.x ./*.a ./*.so ./*.mod
-	rm -rf $(GTEST_DIR)/make
+	rm -rf $(GTEST_DIR)/build


### PR DESCRIPTION
Possibly due to changes in more recent versions of Googletest, or possibly due to changes in more recent versions of CMake, the previous way that CMake was invoked to build the googletest library failed with errors about `GOOGLETEST_VERSION` being undefined. This was happening because `cmake` was being run from `tests/googletest/googletest/make` instead of `tests/googletest/googletest`. Changing the directory where CMake is invoked and adding the `-B` flag fixes that problem.

In addition, the original makefile had a subdirectory named "make". Have a subdirectory named "make" when the program `make` is being used is confusing at the very least, and may lead to errors depending on how the user's `$PATH` is set up. This PR also renames the directory to `build`.