### PR TITLE
Move most cibuildwheel options to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[tool.cibuildwheel]
+skip = "*musllinux*"
+dependency-versions = "latest"
+test-extras = "dev"
+# Due to package & module name conflict, temporarily move it away to run tests:
+before-test = "mv {package}/qsimcirq /tmp"
+test-command = "pytest -v {package}/qsimcirq_tests/qsimcirq_test.py && mv /tmp/qsimcirq {package}"
+
+[tool.cibuildwheel.macos]
+before-build = "brew install libomp llvm > /dev/null 2>&1 && brew link --force libomp > /dev/null 2>&1"
+repair-wheel-command = "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
+
+[tool.pytest.ini_options]
+addopts = "-n auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,10 @@ dependency-versions = "latest"
 test-extras = "dev"
 # Due to package & module name conflict, temporarily move it away to run tests:
 before-test = "mv {package}/qsimcirq /tmp"
-test-command = "pytest -v {package}/qsimcirq_tests/qsimcirq_test.py && mv /tmp/qsimcirq {package}"
+test-command = "pytest -s -v {package}/qsimcirq_tests/qsimcirq_test.py && mv /tmp/qsimcirq {package}"
 
 [tool.cibuildwheel.macos]
-before-build = "brew install libomp llvm > /dev/null 2>&1 && brew link --force libomp > /dev/null 2>&1"
+before-build = "brew install -q libomp llvm@19 && brew unlink libomp && brew unlink llvm@19 && brew link --force libomp && brew link --force llvm@19"
 repair-wheel-command = "delocate-listdeps {wheel} && delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 [tool.cibuildwheel]
-skip = "*musllinux*"
-dependency-versions = "latest"
 test-extras = "dev"
+dependency-versions = "latest"
 # Due to package & module name conflict, temporarily move it away to run tests:
 before-test = "mv {package}/qsimcirq /tmp"
 test-command = "pytest -s -v {package}/qsimcirq_tests/qsimcirq_test.py && mv /tmp/qsimcirq {package}"
@@ -27,6 +26,4 @@ repair-wheel-command = "delocate-listdeps {wheel} && delocate-wheel --verbose --
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
-
-[tool.pytest.ini_options]
-addopts = "-n auto"
+skip = "*musllinux*"


### PR DESCRIPTION
This adds a `pyproject.toml` file to the top level of the repository. The initial contents are settings for `cibuildwheel` and `pytest`. The `cibuildwheel` settings came from the GitHub Actions workflow for building wheels. Putting the settings here means the settings are available in more situations, such as when running `cibuildwheel` manually for testing, or if we create more scripts or workflows that run `cibuildwheel`. Since command-line options and environment variables override `cibuildwheel` values in `pyproject.toml`, these additions should not affect existing scripts and workflows.

The purpose of doing this now is to prepare for revised GitHub Actions workflows coming in another PR. These changes here need to be in place before the workflow changes.

Note: CI checks are failing, but not due to this file; it's because the CI workflows and other changes need to be made.