### PR TITLE
Set copt in platform-specific way & increase bazel test timeouts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,6 +37,7 @@ build --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1
 
 # Test flags
 test --test_output=errors
+test --test_timeout=600
 
 # CUDA options
 build:cuda --@local_config_cuda//:enable_cuda

--- a/.bazelrc
+++ b/.bazelrc
@@ -19,9 +19,24 @@ common --announce_rc
 common --experimental_repo_remote_exec
 common --verbose_failures
 
-# Default build options
-build --copt -std=c++17
-build --copt -D_GLIBCXX_USE_CXX11_ABI=1
+# C++ language selection. The variants are needed because MS Visual Studio on
+# Windows uses slightly different syntax.
+common --enable_platform_specific_config
+
+build:linux --copt=-std=c++17
+build:linux --copt=-D_GLIBCXX_USE_CXX11_ABI=1
+build:linux --cxxopt=-std=c++17
+build:linux --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1
+
+build:macos --copt=-std=c++17
+build:macos --copt=-D_GLIBCXX_USE_CXX11_ABI=1
+build:macos --cxxopt=-std=c++17
+build:macos --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1
+
+build:windows --copt=/std:c++17
+build:windows --copt=-D_GLIBCXX_USE_CXX11_ABI=1
+build:windows --cxxopt=/std:c++17
+build:windows --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1
 
 # Test flags
 test --test_output=errors

--- a/.bazelrc
+++ b/.bazelrc
@@ -24,19 +24,16 @@ common --verbose_failures
 common --enable_platform_specific_config
 
 build:linux --copt=-std=c++17
-build:linux --copt=-D_GLIBCXX_USE_CXX11_ABI=1
 build:linux --cxxopt=-std=c++17
-build:linux --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1
 
 build:macos --copt=-std=c++17
-build:macos --copt=-D_GLIBCXX_USE_CXX11_ABI=1
 build:macos --cxxopt=-std=c++17
-build:macos --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1
 
 build:windows --copt=/std:c++17
-build:windows --copt=-D_GLIBCXX_USE_CXX11_ABI=1
 build:windows --cxxopt=/std:c++17
-build:windows --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1
+
+build --copt=-D_GLIBCXX_USE_CXX11_ABI=1
+build --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1
 
 # Test flags
 test --test_output=errors


### PR DESCRIPTION
Attempting to use option `--copt=-std=c++17` fails on Windows because the syntax need to be slightly different: `--copt=/std:c++17`. To handle these differences between platforms, we can take advantage of Bazel's `--enable_platform_specific_config` option and define different build configs for Linux, Windows, and Mac.

Separately, on MacOS 13 runners on GitHub, a couple of tests failed because they exceeded the default test timeout. This PR increases the timeout.