### PR TITLE
Add cmake to dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 black~=25.1.0
+cmake~=3.31.0
 flynt~=1.0
 pytest
 pytest-xdist


### PR DESCRIPTION
The CMake Python package is needed during building and testing. Logically, it really does belong in dev-requirements.txt.