### PR TITLE
Add back missing global option to pybind11 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 absl-py
 cirq-core~=1.0
 numpy~=1.16
-pybind11
+pybind11[global]
 typing_extensions
 setuptools


### PR DESCRIPTION
Somewhere among all these merges and new PRs, I lost the [global]
option to the pybind11 requirement.