### PR TITLE
Require that version of setuptools be recent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ numpy>=1.26.0
 # CMake will find them. It makes a crucial difference in some environments.
 pybind11[global]
 typing_extensions
-setuptools
+setuptools>=78


### PR DESCRIPTION
For some reason, if we don't require a recent version of setuptools explicitly, then on Windows runners on GitHub, when creating virtual environmwents, we end up with a very old version that behaves differently. Setuptools is up to version 80 today, so version 78 should be reasonable without being excessively stringent.