### PR TITLE
Don't use Python 3.12 with Black (in ci_format_checks.yml)

### DIFF
--- a/.github/workflows/ci_format_checks.yml
+++ b/.github/workflows/ci_format_checks.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Python with caching of pip dependencies
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: pip
           cache-dependency-path: dev-requirements.txt
 


### PR DESCRIPTION
Running with Python 3.12 can give the following error, if you're unlucky enough to get 3.12.5:

```
Python 3.12.5 has a memory safety issue that can cause Black's AST
safety checks to fail. Please upgrade to Python 3.12.6 or downgrade to
Python 3.12.4
```

This particular workflow doesn't care much. Let's try 3.13.