### PR TITLE
Fix #765: make CUDA builds work again

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -86,14 +86,14 @@ build:nosan --
 build:avx --copt=-O3
 build:avx --copt=-mavx2
 build:avx --copt=-mfma
-build:avx --build_tag_filters=avx
-test:avx --test_tag_filters=avx
+build:avx --build_tag_filters=avx --ui_event_filters=-WARNING
+test:avx --test_tag_filters=avx --ui_event_filters=-WARNING
 
 # Build with SSE
 build:sse --copt=-O3
 build:sse --copt=-msse4
-build:sse --build_tag_filters=sse
-test:sse --test_tag_filters=sse
+build:sse --build_tag_filters=sse --ui_event_filters=-WARNING
+test:sse --test_tag_filters=sse --ui_event_filters=-WARNING
 
 # Build without AVX or SSE
 build:basic --copt=-O3

--- a/.bazelrc
+++ b/.bazelrc
@@ -39,6 +39,9 @@ build --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1
 # Config options later in this file can be layered to enable them.
 build --build_tag_filters=-avx,-sse
 test --test_tag_filters=-avx,-sse
+# "bazel run" inherits options from "build". Our run targets don't have tags,
+# so we must clear the filter explicitly or we get "No targets found to run".
+run:sse --build_tag_filters=
 
 # CUDA options
 build:cuda --@local_config_cuda//:enable_cuda
@@ -59,18 +62,18 @@ test:verbose --test_summary=detailed
 
 # Shared config for sanitizers
 build:sanitizer --strip=never
-build:sanitizer --copt -O1
-build:sanitizer --copt -fno-omit-frame-pointer
+build:sanitizer --copt=-O1
+build:sanitizer --copt=-fno-omit-frame-pointer
 
 # Address sanitizer
 build:asan --config=sanitizer
-build:asan --copt -fsanitize=address
-build:asan --linkopt -fsanitize=address
+build:asan --copt=-fsanitize=address
+build:asan --linkopt=-fsanitize=address
 
 # Memory sanitizer
 build:msan --config=sanitizer
-build:msan --copt -fsanitize=leak
-build:msan --linkopt -fsanitize=leak
+build:msan --copt=-fsanitize=leak
+build:msan --linkopt=-fsanitize=leak
 
 # No sanitizers
 build:nosan --
@@ -79,27 +82,27 @@ build:nosan --
 # ~~~~ Instruction set options (choose one) ~~~~
 
 # Build with AVX2 + FMA
-build:avx --copt -O3
-build:avx --copt -mavx2
-build:avx --copt -mfma
+build:avx --copt=-O3
+build:avx --copt=-mavx2
+build:avx --copt=-mfma
 build:avx --build_tag_filters=avx
 test:avx --test_tag_filters=avx
 
 # Build with SSE
-build:sse --copt -O3
-build:sse --copt -msse4
+build:sse --copt=-O3
+build:sse --copt=-msse4
 build:sse --build_tag_filters=sse
 test:sse --test_tag_filters=sse
 
 # Build without AVX or SSE
-build:basic --copt -O3
+build:basic --copt=-O3
 
 
 # ~~~~ Parallelization (choose one, or nopenmp for none) ~~~~
 
 # Build with OpenMP
-build:openmp --copt -fopenmp
-build:openmp --linkopt -lgomp
+build:openmp --copt=-fopenmp
+build:openmp --linkopt=-lgomp
 
 # No OpenMP
 build:nopenmp --

--- a/.bazelrc
+++ b/.bazelrc
@@ -42,6 +42,7 @@ test --test_tag_filters=-avx,-sse
 # "bazel run" inherits options from "build". Our run targets don't have tags,
 # so we must clear the filter explicitly or we get "No targets found to run".
 run:sse --build_tag_filters=
+run:avx --build_tag_filters=
 
 # CUDA options
 build:cuda --@local_config_cuda//:enable_cuda

--- a/.bazelrc
+++ b/.bazelrc
@@ -35,13 +35,18 @@ build:windows --cxxopt=/std:c++17
 build --copt=-D_GLIBCXX_USE_CXX11_ABI=1
 build --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1
 
-# Test flags
-test --test_output=errors
-test --test_timeout=600
+# The default for vector instruction sets is to exclude them.
+# Config options later in this file can be layered to enable them.
+build --build_tag_filters=-avx,-sse
+test --test_tag_filters=-avx,-sse
 
 # CUDA options
 build:cuda --@local_config_cuda//:enable_cuda
 build:cuda --define=using_cuda=true --define=using_cuda_nvcc=true
+
+# Test flags
+test --test_output=errors
+test --test_timeout=600
 
 # Configs for verbose builds & tests
 common:verbose --announce_rc
@@ -77,10 +82,14 @@ build:nosan --
 build:avx --copt -O3
 build:avx --copt -mavx2
 build:avx --copt -mfma
+build:avx --build_tag_filters=avx
+test:avx --test_tag_filters=avx
 
 # Build with SSE
 build:sse --copt -O3
 build:sse --copt -msse4
+build:sse --build_tag_filters=sse
+test:sse --test_tag_filters=sse
 
 # Build without AVX or SSE
 build:basic --copt -O3

--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -106,13 +106,15 @@ jobs:
             requirements.txt
             dev-requirements.txt
 
-      - name: Set up Bazel ${{inputs.bazel-cache != 'false' && 'with' || 'without'}} caching
+      # Do not change the != false to be a direct !inputs.bazel-cache. (The
+      # value can be empty, in which case the latter won't work as expected.)
+      - name: Set up Bazel ${{inputs.bazel-cache != false && 'with' || 'without'}} caching
         uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
         with:
           disk-cache: ${{github.workflow}}
-          bazelisk-cache: ${{inputs.bazel-cache != 'false'}}
-          external-cache: ${{inputs.bazel-cache != 'false'}}
-          repository-cache: ${{inputs.bazel-cache != 'false'}}
+          bazelisk-cache: ${{inputs.bazel-cache != false}}
+          external-cache: ${{inputs.bazel-cache != false}}
+          repository-cache: ${{inputs.bazel-cache != false}}
 
       - name: Install qsim development dependencies
         run: |

--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -34,6 +34,10 @@ on:
         description: 'Run with debugging options'
         type: boolean
         default: true
+      bazel-cache:
+        description: 'Use Bazel caches'
+        type: boolean
+        default: true
 
 permissions: read-all
 
@@ -102,13 +106,13 @@ jobs:
             requirements.txt
             dev-requirements.txt
 
-      - name: Set up Bazel with caching
+      - name: Set up Bazel ${{inputs.bazel-cache != 'false' && 'with' || 'without'}} caching
         uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
         with:
           disk-cache: ${{github.workflow}}
-          bazelisk-cache: true
-          external-cache: true
-          repository-cache: true
+          bazelisk-cache: ${{inputs.bazel-cache != 'false'}}
+          external-cache: ${{inputs.bazel-cache != 'false'}}
+          repository-cache: ${{inputs.bazel-cache != 'false'}}
 
       - name: Install qsim development dependencies
         run: |

--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Set up Bazel ${{inputs.bazel-cache != false && 'with' || 'without'}} caching
         uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
         with:
-          disk-cache: ${{github.workflow}}
+          disk-cache: ${{inputs.bazel-cache != false && github.workflow}}
           bazelisk-cache: ${{inputs.bazel-cache != false}}
           external-cache: ${{inputs.bazel-cache != false}}
           repository-cache: ${{inputs.bazel-cache != false}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,9 @@ ADD_SUBDIRECTORY(pybind_interface/basic)
 ADD_SUBDIRECTORY(pybind_interface/decide)
 
 # Add subdirectories based on the architecture or available compilers.
-if(NOT CMAKE_APPLE_SILICON_PROCESSOR)
+if(CMAKE_APPLE_SILICON_PROCESSOR)
+    message(STATUS "qsim: detected Apple Silicon -- skipping AVX/SSE components")
+else()
     if(CMAKE_CUDA_COMPILER)
         ADD_SUBDIRECTORY(pybind_interface/cuda)
         if(DEFINED ENV{CUQUANTUM_ROOT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,40 +1,46 @@
-set(CMAKE_CXX_STANDARD 11)
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(CMAKE_CXX_STANDARD 17)
 cmake_minimum_required(VERSION 3.31)
+project(qsim LANGUAGES CXX)
 
-# Set prelimary value so that other variables we need are defined
-project(qsim)
+include(CheckLanguage)
+check_language(CUDA)
 
-# Darwin + Arm64 => Apple Silicon, where we can't build Cuda, AVX or SSE features.
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-    set(APPLE_ARM TRUE)
+if(CMAKE_CUDA_COMPILER)
+    message(STATUS "qsim: found CUDA compiler ${CMAKE_CUDA_COMPILER} ${CMAKE_CUDA_COMPILER_VERSION}")
 else()
-    set(APPLE_ARM FALSE)
-endif()
-
-# Set the project name and language more precisely
-if(APPLE)
-    project(qsim LANGUAGES CXX)
-else()
-    execute_process(COMMAND which nvcc OUTPUT_VARIABLE has_nvcc OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(has_nvcc)
-        project(qsim LANGUAGES CXX CUDA)
+    message(STATUS "qsim: did not find CUDA compiler")
+    execute_process(COMMAND which hipcc OUTPUT_VARIABLE has_hipcc OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(has_hipcc)
+        message(STATUS "qsim: found hipcc")
+        project(qsim LANGUAGES CXX HIP)
     else()
-        execute_process(COMMAND which hipcc OUTPUT_VARIABLE has_hipcc OUTPUT_STRIP_TRAILING_WHITESPACE)
-        if(has_hipcc)
-            project(qsim LANGUAGES CXX HIP)
-        else()
-            project(qsim LANGUAGES CXX)
-        endif()
+        message(STATUS "qsim: did not find nvcc or hipcc")
     endif()
 endif()
 
 find_package(OpenMP REQUIRED)
 
-# Add subdirectories based on the architecture or available compilers
+# Always build the basic part.
 ADD_SUBDIRECTORY(pybind_interface/basic)
 ADD_SUBDIRECTORY(pybind_interface/decide)
-if(NOT APPLE_ARM)
-    if(has_nvcc)
+
+# Add subdirectories based on the architecture or available compilers.
+if(NOT CMAKE_APPLE_SILICON_PROCESSOR)
+    if(CMAKE_CUDA_COMPILER)
         ADD_SUBDIRECTORY(pybind_interface/cuda)
         if(DEFINED ENV{CUQUANTUM_ROOT})
             ADD_SUBDIRECTORY(pybind_interface/custatevec)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,9 @@ ADD_SUBDIRECTORY(pybind_interface/decide)
 
 # Add subdirectories based on the architecture or available compilers.
 if(CMAKE_APPLE_SILICON_PROCESSOR)
-    message(STATUS "qsim: detected Apple Silicon -- skipping AVX/SSE components")
+    message(STATUS "qsim: detected Apple Silicon; will exclude AVX/SSE/CUDA")
 else()
+    message(STATUS "qsim: didn't detect Apple Silicon; will include AVX/SSE/CUDA")
     if(CMAKE_CUDA_COMPILER)
         ADD_SUBDIRECTORY(pybind_interface/cuda)
         if(DEFINED ENV{CUQUANTUM_ROOT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,18 @@ project(qsim LANGUAGES CXX)
 include(CheckLanguage)
 check_language(CUDA)
 
+if(NOT CMAKE_APPLE_SILICON_PROCESSOR)
+    # When running builds using cibuildwheel, the value is not set even when
+    # running on Apple Silicon. Check and set it ourselves if we have to.
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+        set(CMAKE_APPLE_SILICON_PROCESSOR TRUE)
+        message(STATUS "qsim: detected Apple Silicon")
+    else()
+        set(CMAKE_APPLE_SILICON_PROCESSOR FALSE)
+        message(STATUS "qsim: didn't detect Apple Silicon")
+    endif()
+endif()
+
 if(CMAKE_CUDA_COMPILER)
     message(STATUS "qsim: found CUDA compiler ${CMAKE_CUDA_COMPILER} ${CMAKE_CUDA_COMPILER_VERSION}")
 else()
@@ -39,10 +51,7 @@ ADD_SUBDIRECTORY(pybind_interface/basic)
 ADD_SUBDIRECTORY(pybind_interface/decide)
 
 # Add subdirectories based on the architecture or available compilers.
-if(CMAKE_APPLE_SILICON_PROCESSOR)
-    message(STATUS "qsim: detected Apple Silicon; will exclude AVX/SSE/CUDA")
-else()
-    message(STATUS "qsim: didn't detect Apple Silicon; will include AVX/SSE/CUDA")
+if(NOT CMAKE_APPLE_SILICON_PROCESSOR)
     if(CMAKE_CUDA_COMPILER)
         ADD_SUBDIRECTORY(pybind_interface/cuda)
         if(DEFINED ENV{CUQUANTUM_ROOT})

--- a/dev_tools/test_libs.sh
+++ b/dev_tools/test_libs.sh
@@ -28,12 +28,12 @@ if [[ "$1" == "-h" || "$1" == "--help" || "$1" == "help" ]]; then
     exit 0
 fi
 
-# Unless we can tell this system supports AVX, we skip those tests.
+# Look for AVX and SSE in the processor's feature flags.
 declare features=""
 declare filters=""
 features="$(python -c 'import cpuinfo; print(" ".join(cpuinfo.get_cpu_info().get("flags", [])))')"
-[[ "$features" == *avx2* ]] || filters+=",-avx"
-[[ "$features" == *sse* ]] || filters+=",-sse"
+[[ "$features" == *avx2* ]] && filters+=",avx"
+[[ "$features" == *sse* ]] && filters+=",sse"
 filters="${filters#,}"
 
 declare -a build_filters=()
@@ -43,10 +43,10 @@ if [[ -n "$filters" ]]; then
     test_filters=( "--test_tag_filters=$filters" )
 fi
 
-# Apps are sample programs and are only meant to run on Linux.
+# The apps are sample programs and are only meant to run on Linux.
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    bazel build "${build_filters[@]}" --config=sse "$@" apps:all
     bazel build "${build_filters[@]}" "$@" apps:all
+    bazel build "$@" apps:all
 fi
 
 # Run all basic tests. This should work on all platforms.

--- a/pybind_interface/avx2/CMakeLists.txt
+++ b/pybind_interface/avx2/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.31)
 project(qsim)
 
@@ -8,7 +22,6 @@ ELSE()
 ENDIF()
 
 if(APPLE)
-    set(CMAKE_CXX_STANDARD 14)
     include_directories(
       "/usr/local/include"
       "/usr/local/opt/llvm/include"

--- a/pybind_interface/avx512/CMakeLists.txt
+++ b/pybind_interface/avx512/CMakeLists.txt
@@ -1,6 +1,19 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.31)
 project(qsim)
-
 
 IF (WIN32)
     set(CMAKE_CXX_FLAGS "/arch:AVX512 /O2 /openmp")
@@ -9,7 +22,6 @@ ELSE()
 ENDIF()
 
 if(APPLE)
-    set(CMAKE_CXX_STANDARD 14)
     include_directories(
       "/usr/local/include"
       "/usr/local/opt/llvm/include"

--- a/pybind_interface/basic/CMakeLists.txt
+++ b/pybind_interface/basic/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.31)
 project(qsim)
 
@@ -7,9 +21,7 @@ else()
     set(CMAKE_CXX_FLAGS "-O3")
 endif()
 
-
 if(APPLE)
-    set(CMAKE_CXX_STANDARD 14)
     include_directories(
       "/usr/local/include"
       "/usr/local/opt/llvm/include"

--- a/pybind_interface/cuda/CMakeLists.txt
+++ b/pybind_interface/cuda/CMakeLists.txt
@@ -33,7 +33,6 @@ else()  # means pybind11 has been fetched in GetPybind11.cmake
     include_directories(${pybind11_SOURCE_DIR}/include)
 endif()
 
-#cuda_add_library(qsim_cuda MODULE pybind_main_cuda.cpp)
 add_library(qsim_cuda MODULE pybind_main_cuda.cpp)
 set_target_properties(qsim_cuda PROPERTIES
     CUDA_ARCHITECTURES "$ENV{CUDAARCHS}"

--- a/pybind_interface/cuda/CMakeLists.txt
+++ b/pybind_interface/cuda/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.31)
 project(qsim LANGUAGES CXX CUDA)
 
@@ -8,7 +22,6 @@ else()
 endif()
 
 if(APPLE)
-    set(CMAKE_CXX_STANDARD 14)
     include_directories(
       "/usr/local/include"
       "/usr/local/opt/llvm/include"

--- a/pybind_interface/cuda/CMakeLists.txt
+++ b/pybind_interface/cuda/CMakeLists.txt
@@ -24,8 +24,7 @@ if(APPLE)
 endif()
 
 INCLUDE(../GetPybind11.cmake)
-find_package(PythonLibs 3.7 REQUIRED)
-find_package(CUDA REQUIRED)
+find_package(Python 3.10 REQUIRED)
 
 include_directories(${PYTHON_INCLUDE_DIRS})
 if(pybind11_FOUND)
@@ -34,7 +33,8 @@ else()  # means pybind11 has been fetched in GetPybind11.cmake
     include_directories(${pybind11_SOURCE_DIR}/include)
 endif()
 
-cuda_add_library(qsim_cuda MODULE pybind_main_cuda.cpp)
+#cuda_add_library(qsim_cuda MODULE pybind_main_cuda.cpp)
+add_library(qsim_cuda MODULE pybind_main_cuda.cpp)
 set_target_properties(qsim_cuda PROPERTIES
     CUDA_ARCHITECTURES "$ENV{CUDAARCHS}"
     PREFIX "${PYTHON_MODULE_PREFIX}"

--- a/pybind_interface/custatevec/CMakeLists.txt
+++ b/pybind_interface/custatevec/CMakeLists.txt
@@ -22,7 +22,6 @@ else()
 endif()
 
 if(APPLE)
-    set(CMAKE_CXX_STANDARD 14)
     include_directories(
       "/usr/local/include"
       "/usr/local/opt/llvm/include"

--- a/pybind_interface/custatevec/CMakeLists.txt
+++ b/pybind_interface/custatevec/CMakeLists.txt
@@ -38,15 +38,14 @@ if(APPLE)
 endif()
 
 INCLUDE(../GetPybind11.cmake)
-find_package(PythonLibs 3.7 REQUIRED)
-find_package(CUDA REQUIRED)
+find_package(Python3 3.10 REQUIRED)
 
 include_directories(${pybind11_INCLUDE_DIRS})
 
 include_directories($ENV{CUQUANTUM_ROOT}/include)
 link_directories($ENV{CUQUANTUM_ROOT}/lib $ENV{CUQUANTUM_ROOT}/lib64)
 
-cuda_add_library(qsim_custatevec MODULE pybind_main_custatevec.cpp)
+add_library(qsim_custatevec MODULE pybind_main_custatevec.cpp)
 target_link_libraries(qsim_custatevec -lcustatevec -lcublas)
 
 set_target_properties(qsim_custatevec PROPERTIES

--- a/pybind_interface/decide/CMakeLists.txt
+++ b/pybind_interface/decide/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
     set(CMAKE_CXX_FLAGS "-O3")
 endif()
 
-if(CMAKE_APPLE_SILICON_PROCESSOR)
+if(APPLE)
     include_directories(
       "/usr/local/include"
       "/usr/local/opt/llvm/include"

--- a/pybind_interface/decide/CMakeLists.txt
+++ b/pybind_interface/decide/CMakeLists.txt
@@ -1,5 +1,22 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.31)
-project(qsim LANGUAGES CXX CUDA)
+project(qsim LANGUAGES CXX)
+
+include(CheckLanguage)
+check_language(CUDA)
 
 if(WIN32)
     set(CMAKE_CXX_FLAGS "/O2 /openmp")
@@ -7,8 +24,7 @@ else()
     set(CMAKE_CXX_FLAGS "-O3")
 endif()
 
-if(APPLE)
-    set(CMAKE_CXX_STANDARD 14)
+if(CMAKE_APPLE_SILICON_PROCESSOR)
     include_directories(
       "/usr/local/include"
       "/usr/local/opt/llvm/include"
@@ -26,7 +42,7 @@ endif()
 include(../GetPybind11.cmake)
 
 # Configure based on the detected platform
-if(has_nvcc)
+if(CMAKE_CUDA_COMPILER)
     add_library(qsim_decide MODULE decide.cpp)
     if(DEFINED ENV{CUQUANTUM_ROOT})
         target_compile_options(qsim_decide PRIVATE

--- a/pybind_interface/decide/CMakeLists.txt
+++ b/pybind_interface/decide/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.31)
+project(qsim LANGUAGES CXX CUDA)
 
 if(WIN32)
     set(CMAKE_CXX_FLAGS "/O2 /openmp")
@@ -26,14 +27,13 @@ include(../GetPybind11.cmake)
 
 # Configure based on the detected platform
 if(has_nvcc)
-    find_package(CUDA REQUIRED)
-    cuda_add_library(qsim_decide MODULE decide.cpp)
+    add_library(qsim_decide MODULE decide.cpp)
     if(DEFINED ENV{CUQUANTUM_ROOT})
         target_compile_options(qsim_decide PRIVATE
             $<$<COMPILE_LANGUAGE:CUDA>:-D__CUSTATEVEC__>
         )
     endif()
-    find_package(Python3 3.7 REQUIRED COMPONENTS Interpreter Development)
+    find_package(Python3 3.10 REQUIRED COMPONENTS Interpreter Development)
     include_directories(${PYTHON_INCLUDE_DIRS} ${pybind11_SOURCE_DIR}/include)
     set_target_properties(qsim_decide PROPERTIES
         CUDA_ARCHITECTURES "$ENV{CUDAARCHS}"
@@ -47,7 +47,7 @@ elseif(has_hipcc)
     find_package(HIP REQUIRED)
     hip_add_library(qsim_decide MODULE decide.cpp)
     set_source_files_properties(decide.cpp PROPERTIES LANGUAGE HIP)
-    find_package(Python3 3.7 REQUIRED COMPONENTS Interpreter Development)
+    find_package(Python3 3.10 REQUIRED COMPONENTS Interpreter Development)
     include_directories(${PYTHON_INCLUDE_DIRS} ${pybind11_SOURCE_DIR}/include)
     set_target_properties(qsim_decide PROPERTIES
         PREFIX "${PYTHON_MODULE_PREFIX}"

--- a/pybind_interface/hip/CMakeLists.txt
+++ b/pybind_interface/hip/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 endif()
 
 INCLUDE(../GetPybind11.cmake)
-find_package(PythonLibs 3.7 REQUIRED)
+find_package(PythonLibs 3.10 REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH "/opt/rocm/lib/cmake/hip")
 find_package(HIP REQUIRED)

--- a/pybind_interface/hip/CMakeLists.txt
+++ b/pybind_interface/hip/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.31)
 project(qsim LANGUAGES CXX HIP)
 

--- a/pybind_interface/sse/CMakeLists.txt
+++ b/pybind_interface/sse/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.31)
 project(qsim)
 
@@ -8,7 +22,6 @@ ELSE()
 ENDIF()
 
 if(APPLE)
-    set(CMAKE_CXX_STANDARD 14)
     include_directories(
       "/usr/local/include"
       "/usr/local/opt/llvm/include"

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ class CMakeBuild(build_ext):
 
         if shutil.which("nvcc") is not None:
             cmake_args += [
-            "-DCMAKE_CUDA_COMPILER=nvcc",
+                "-DCMAKE_CUDA_COMPILER=nvcc",
             ]
 
         additional_cmake_args = os.environ.get("CMAKE_ARGS", "")

--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,15 @@ class CMakeBuild(build_ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         python_include_dir = sysconfig.get_path("include")
         cmake_args = [
-            "-DCMAKE_CUDA_COMPILER=nvcc",
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
             "-DPYTHON_EXECUTABLE=" + sys.executable,
             "-DPYTHON_INCLUDE_DIR=" + python_include_dir,
         ]
+
+        if shutil.which("nvcc") is not None:
+            cmake_args += [
+            "-DCMAKE_CUDA_COMPILER=nvcc",
+            ]
 
         additional_cmake_args = os.environ.get("CMAKE_ARGS", "")
         if additional_cmake_args:


### PR DESCRIPTION
The bulk of these fixes were originally done by @fdmalone. This updates the CMake rules to avoid deprecated constructs for finding the CUDA rules and configurations. In addition, while we're at it, this also updates the minimum Python version to 3.10 so that this is consistent with the requirements defined elsewhere in the latest version of qsim.