### PR TITLE
Add cache control options for manual debugging runs

### DIFF
--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -34,6 +34,10 @@ on:
         description: 'Run with debugging options'
         type: boolean
         default: true
+      bazel-cache:
+        description: 'Use Bazel caches'
+        type: boolean
+        default: true
 
 permissions: read-all
 
@@ -91,6 +95,16 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
+      # Do not change the != false to be a direct !inputs.bazel-cache. (The
+      # value can be empty, in which case the latter won't work as expected.)
+      - name: Set up Bazel ${{inputs.bazel-cache != false && 'with' || 'without'}} caching
+        uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
+        with:
+          disk-cache: ${{inputs.bazel-cache != false && github.workflow}}
+          bazelisk-cache: ${{inputs.bazel-cache != false}}
+          external-cache: ${{inputs.bazel-cache != false}}
+          repository-cache: ${{inputs.bazel-cache != false}}
+
       - name: Set up Python with caching of pip dependencies
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup
@@ -101,14 +115,6 @@ jobs:
           cache-dependency-path: |
             requirements.txt
             dev-requirements.txt
-
-      - name: Set up Bazel with caching
-        uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
-        with:
-          disk-cache: ${{github.workflow}}
-          bazelisk-cache: true
-          external-cache: true
-          repository-cache: true
 
       - name: Install qsim development dependencies
         run: |

--- a/.github/workflows/ci_hardware_options.yaml
+++ b/.github/workflows/ci_hardware_options.yaml
@@ -29,6 +29,15 @@ on:
       - checks_requested
 
   workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Run with debugging options'
+        type: boolean
+        default: true
+      bazel-cache:
+        description: 'Use Bazel caches'
+        type: boolean
+        default: true
 
 permissions: read-all
 
@@ -63,13 +72,15 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
-      - name: Set up Bazel with caching
+      # Do not change the != false to be a direct !inputs.bazel-cache. (The
+      # value can be empty, in which case the latter won't work as expected.)
+      - name: Set up Bazel ${{inputs.bazel-cache != false && 'with' || 'without'}} caching
         uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
         with:
-          disk-cache: ${{github.workflow}}
-          bazelisk-cache: true
-          external-cache: true
-          repository-cache: true
+          disk-cache: ${{inputs.bazel-cache != false && github.workflow}}
+          bazelisk-cache: ${{inputs.bazel-cache != false}}
+          external-cache: ${{inputs.bazel-cache != false}}
+          repository-cache: ${{inputs.bazel-cache != false}}
 
       - name: Set up Python with caching of pip dependencies
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -83,11 +94,16 @@ jobs:
 
       - name: Run C++ tests
         run: |
-          bazel test --config=verbose --config=${{matrix.hardware_opt}} \
-          --config=${{matrix.parallel_opt}} tests:all
+          bazel test \
+              --config=${{matrix.hardware_opt}} \
+              --config=${{matrix.parallel_opt}} \
+              ${{inputs.debug && '--config=verbose'}} \
+              tests:all
 
       - name: Run sample simulation
         run: |
-          bazel run --config=verbose --config=${{matrix.hardware_opt}} \
-          --config=${{matrix.parallel_opt}} apps:qsim_base \
-          -- -c circuits/circuit_q24
+          bazel run \
+              --config=${{matrix.hardware_opt}} \
+              --config=${{matrix.parallel_opt}} \
+              ${{inputs.debug && '--config=verbose'}} \
+              apps:qsim_base -- -c circuits/circuit_q24

--- a/.github/workflows/ci_sanitizer_tests.yaml
+++ b/.github/workflows/ci_sanitizer_tests.yaml
@@ -29,6 +29,15 @@ on:
       - checks_requested
 
   workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Run with debugging options'
+        type: boolean
+        default: true
+      bazel-cache:
+        description: 'Use Bazel caches'
+        type: boolean
+        default: true
 
 permissions: read-all
 
@@ -61,12 +70,15 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
-      - uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
+      # Do not change the != false to be a direct !inputs.bazel-cache. (The
+      # value can be empty, in which case the latter won't work as expected.)
+      - name: Set up Bazel ${{inputs.bazel-cache != false && 'with' || 'without'}} caching
+        uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
         with:
-          disk-cache: ${{github.workflow}}
-          bazelisk-cache: true
-          external-cache: true
-          repository-cache: true
+          disk-cache: ${{inputs.bazel-cache != false && github.workflow}}
+          bazelisk-cache: ${{inputs.bazel-cache != false}}
+          external-cache: ${{inputs.bazel-cache != false}}
+          repository-cache: ${{inputs.bazel-cache != false}}
 
       - name: Set up Python with caching of pip dependencies
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -81,5 +93,9 @@ jobs:
 
       - name: Run C++ tests
         run: |
-          bazel test --config=verbose --config=avx --config=openmp \
-          --config=${{matrix.sanitizer_opt}} tests:all
+          bazel test \
+              --config=avx \
+              --config=openmp \
+              --config=${{matrix.sanitizer_opt}} \
+              ${{inputs.debug && '--config=verbose'}} \
+              tests:all

--- a/.github/workflows/ci_tcmalloc_test.yaml
+++ b/.github/workflows/ci_tcmalloc_test.yaml
@@ -34,6 +34,10 @@ on:
         description: 'Run with debugging options'
         type: boolean
         default: true
+      bazel-cache:
+        description: 'Use Bazel caches'
+        type: boolean
+        default: true
 
 permissions: read-all
 
@@ -62,13 +66,15 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
-      - name: Set up Bazel with caching
+      # Do not change the != false to be a direct !inputs.bazel-cache. (The
+      # value can be empty, in which case the latter won't work as expected.)
+      - name: Set up Bazel ${{inputs.bazel-cache != false && 'with' || 'without'}} caching
         uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
         with:
-          disk-cache: ${{github.workflow}}
-          bazelisk-cache: true
-          external-cache: true
-          repository-cache: true
+          disk-cache: ${{inputs.bazel-cache != false && github.workflow}}
+          bazelisk-cache: ${{inputs.bazel-cache != false}}
+          external-cache: ${{inputs.bazel-cache != false}}
+          repository-cache: ${{inputs.bazel-cache != false}}
 
       - name: Set up Python with caching of pip dependencies
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -87,5 +93,9 @@ jobs:
         env:
           PERFTOOLS_VERBOSE: ${{inputs.debug && 1 || ''}}
         run: |
-          bazel test --config=verbose --config=avx --config=openmp \
-          --config=tcmalloc tests:all
+          bazel test \
+              --config=avx \
+              --config=openmp \
+              --config=tcmalloc \
+              ${{inputs.debug && '--config=verbose'}} \
+              tests:all


### PR DESCRIPTION
I ran into a problem that turned out to be due to Bazel caches. To help future debugging situations, this adds an additional flag to `workflow_dispatch` manual workflow runs. The flag lets the user disable the Bazel caches.