### PR TITLE
Replace sprintf() call with snprintf()

### DIFF
--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -40,7 +40,7 @@ template <typename T>
 T parseOptions(const py::dict &options, const char *key) {
   if (!options.contains(key)) {
     char msg[100];
-    std::sprintf(msg, "Argument %s is not provided.\n", key);
+    std::snprintf(msg, sizeof(msg), "Argument %s is not provided.\n", key);
     throw std::invalid_argument(msg);
   }
   const auto &value = options[key];

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -39,8 +39,7 @@ namespace {
 template <typename T>
 T parseOptions(const py::dict &options, const char *key) {
   if (!options.contains(key)) {
-    char msg[100];
-    std::snprintf(msg, sizeof(msg), "Argument %s is not provided.\n", key);
+    std::string msg = std::string("Argument ") + key + " is not provided.\n";
     throw std::invalid_argument(msg);
   }
   const auto &value = options[key];


### PR DESCRIPTION
clang on MacOS complains that sprintf() is insecure and should be replaced with snprintf().