### PR TITLE
Fix warning about SPDX license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ setup(
     extras_require={
         "dev": dev_requirements,
     },
-    license="Apache 2",
+    license="Apache-2.0",
     description=description,
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -167,7 +167,6 @@ setup(
         "Environment :: GPU :: NVIDIA CUDA",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
When running cibuildwheel 2.23.3 runs under Python 3.12, the following warning would show up in the logs:

```
  /tmp/pip-build-env-ucihqcl8/overlay/lib/python3.12/site-packages/setuptools/dist.py:759:
  SetuptoolsDeprecationWarning: License classifiers are deprecated.
  !!

          ********************************************************************************
          Please consider removing the following classifiers in favor
          of a SPDX license expression:

          License :: OSI Approved :: Apache Software License

          See
          https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
          for details.
          ********************************************************************************
```

This commit removes the license classifier and updates the `license` keyword to use the SPDX license id.