### PR TITLE
Do an "apt-get update" before installations

### DIFF
--- a/.github/workflows/ci_tcmalloc_test.yaml
+++ b/.github/workflows/ci_tcmalloc_test.yaml
@@ -81,7 +81,9 @@ jobs:
         run: python3 -m pip install -r requirements.txt
 
       - name: Install google-perftools for tcmalloc
-        run: sudo apt-get install libgoogle-perftools-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgoogle-perftools-dev
 
       - name: Run C++ tests
         env:


### PR DESCRIPTION
Per best practices, this adds `apt-get update` before doing an installation of Debian packages.