### PR TITLE
Suppress CMake version warning coming from Pybind11

### DIFF
--- a/pybind_interface/GetPybind11.cmake
+++ b/pybind_interface/GetPybind11.cmake
@@ -1,6 +1,12 @@
 include(FetchContent)
 
 set(MIN_PYBIND_VERSION "2.13.6")
+
+# Suppress warning "Compatibility with CMake < 3.10 will be removed ..." coming
+# from Pybind11. Not ideal, but avoids wasting time trying to find the cause.
+# TODO(mhucka): remove the settings when pybind11 updates its CMake files
+set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "Disable CMake deprecation warnings" FORCE)
+
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY https://github.com/pybind/pybind11
@@ -8,3 +14,5 @@ FetchContent_Declare(
   OVERRIDE_FIND_PACKAGE
 )
 FetchContent_MakeAvailable(pybind11)
+
+set(CMAKE_WARN_DEPRECATED ON CACHE BOOL "Reenable CMake deprecation warnings" FORCE)


### PR DESCRIPTION
When building using cibuildwheel, the following warning is printed:

```
 CMake Deprecation Warning at .../pybind11-src/CMakeLists.txt:13
 (cmake_minimum_required):
    Compatibility with CMake < 3.10 will be removed from a future
    version of
    CMake.

    Update the VERSION argument <min> value.  Or, use the
    <min>...<max> syntax to tell CMake that the project requires
    at least <min> but has been updated to work with policies
    introduced by <max> or earlier.
```

The warning is coming from Pybind11's CMake files, not ours. We can't do anything about it, and we end up wasting time looking for the cause in qsim's files.

The change in this PR suppresses deprecation warnings around the part where Pybind11 is included.

This change should be reverted when Pybind11 updates the minimum required CMake version to a number that doesn't trigger the warning.