### PR TITLE
Make debug option in manual workflow execution set Bazel verbose config

### DIFF
--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -135,7 +135,4 @@ jobs:
           pyexe: '${{steps.setup.outputs.python-version}}\\${{matrix.conf.pyarch}}\\python3.exe'
           SHELLOPTS: ${{env.use-verbose && 'xtrace' || '' }}
         shell: cmd
-        run: >-
-          bash -x dev_tools/test_libs.sh \
-              ${{env.use-verbose && '--config=verbose'}} \
-              --action_env PYTHON_BIN_PATH=${{env.pyroot}}\\${{env.pyexe}}
+        run: bash -x dev_tools/test_libs.sh ${{env.use-verbose && '--config=verbose'}} --action_env PYTHON_BIN_PATH=${{env.pyroot}}\\${{env.pyexe}}

--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -85,6 +85,7 @@ jobs:
           {os: windows-2025, pyarch: x64, py: 13},
         ]
     env:
+      # Must use explicit test for true so it works when inputs.debug is null.
       use-verbose: ${{github.event.inputs.debug == true}}
     steps:
       - name: Check out a copy of the git repository

--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -84,6 +84,8 @@ jobs:
           {os: windows-2025, pyarch: x64, py: 12},
           {os: windows-2025, pyarch: x64, py: 13},
         ]
+    env:
+      use-verbose: ${{github.event.inputs.debug == true}}
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -120,7 +122,7 @@ jobs:
         env:
           # SHELLOPTS is used by Bash. Add xtrace when doing manual debug runs.
           SHELLOPTS: ${{inputs.debug && 'xtrace' || '' }}
-        run: dev_tools/test_libs.sh ${{inputs.debug && '--config=verbose'}}
+        run: dev_tools/test_libs.sh ${{env.use-verbose && '--config=verbose'}}
 
       - if: matrix.conf.os == 'windows-2025'
         name: Run the build and test script (Windows case)
@@ -130,9 +132,9 @@ jobs:
         env:
           pyroot: 'C:\\hostedtoolcache\\windows\\Python'
           pyexe: '${{steps.setup.outputs.python-version}}\\${{matrix.conf.pyarch}}\\python3.exe'
-          SHELLOPTS: ${{inputs.debug && 'xtrace' || '' }}
+          SHELLOPTS: ${{env.use-verbose && 'xtrace' || '' }}
         shell: cmd
         run: >-
           bash -x dev_tools/test_libs.sh \
-              ${{inputs.debug && '--config=verbose'}} \
+              ${{env.use-verbose && '--config=verbose'}} \
               --action_env PYTHON_BIN_PATH=${{env.pyroot}}\\${{env.pyexe}}

--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -120,7 +120,7 @@ jobs:
         env:
           # SHELLOPTS is used by Bash. Add xtrace when doing manual debug runs.
           SHELLOPTS: ${{inputs.debug && 'xtrace' || '' }}
-        run: dev_tools/test_libs.sh --config=verbose
+        run: dev_tools/test_libs.sh ${{inputs.debug && '--config=verbose'}}
 
       - if: matrix.conf.os == 'windows-2025'
         name: Run the build and test script (Windows case)
@@ -133,5 +133,6 @@ jobs:
           SHELLOPTS: ${{inputs.debug && 'xtrace' || '' }}
         shell: cmd
         run: >-
-          bash -x dev_tools/test_libs.sh --config=verbose
-          --action_env PYTHON_BIN_PATH=${{env.pyroot}}\\${{env.pyexe}}
+          bash -x dev_tools/test_libs.sh \
+              ${{inputs.debug && '--config=verbose'}} \
+              --action_env PYTHON_BIN_PATH=${{env.pyroot}}\\${{env.pyexe}}

--- a/.github/workflows/ci_hardware_options.yaml
+++ b/.github/workflows/ci_hardware_options.yaml
@@ -62,6 +62,7 @@ jobs:
         # Optimizers for parallelism.
         parallel_opt: [openmp, nopenmp]
     env:
+      # Must use explicit test for true so it works when inputs.debug is null.
       use-verbose: ${{github.event.inputs.debug == true}}
     steps:
       - name: Check out a copy of the git repository

--- a/.github/workflows/ci_hardware_options.yaml
+++ b/.github/workflows/ci_hardware_options.yaml
@@ -29,6 +29,11 @@ on:
       - checks_requested
 
   workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Run with debugging options'
+        type: boolean
+        default: true
 
 permissions: read-all
 
@@ -83,11 +88,16 @@ jobs:
 
       - name: Run C++ tests
         run: |
-          bazel test --config=verbose --config=${{matrix.hardware_opt}} \
-          --config=${{matrix.parallel_opt}} tests:all
+          bazel test \
+              --config=${{matrix.hardware_opt}} \
+              --config=${{matrix.parallel_opt}} \
+              ${{inputs.debug && '--config=verbose'}} \
+              tests:all
 
       - name: Run sample simulation
         run: |
-          bazel run --config=verbose --config=${{matrix.hardware_opt}} \
-          --config=${{matrix.parallel_opt}} apps:qsim_base \
-          -- -c circuits/circuit_q24
+          bazel run \
+              --config=${{matrix.hardware_opt}} \
+              --config=${{matrix.parallel_opt}} \
+              ${{inputs.debug && '--config=verbose'}} \
+              apps:qsim_base -- -c circuits/circuit_q24

--- a/.github/workflows/ci_hardware_options.yaml
+++ b/.github/workflows/ci_hardware_options.yaml
@@ -61,6 +61,8 @@ jobs:
         hardware_opt: [avx, sse, basic]
         # Optimizers for parallelism.
         parallel_opt: [openmp, nopenmp]
+    env:
+      use-verbose: ${{github.event.inputs.debug == true}}
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -95,7 +97,7 @@ jobs:
           bazel test \
               --config=${{matrix.hardware_opt}} \
               --config=${{matrix.parallel_opt}} \
-              ${{inputs.debug && '--config=verbose'}} \
+              ${{env.use-verbose && '--config=verbose'}} \
               tests:all
 
       - name: Run sample simulation
@@ -103,5 +105,5 @@ jobs:
           bazel run \
               --config=${{matrix.hardware_opt}} \
               --config=${{matrix.parallel_opt}} \
-              ${{inputs.debug && '--config=verbose'}} \
+              ${{env.use-verbose && '--config=verbose'}} \
               apps:qsim_base -- -c circuits/circuit_q24

--- a/.github/workflows/ci_sanitizer_tests.yaml
+++ b/.github/workflows/ci_sanitizer_tests.yaml
@@ -59,6 +59,8 @@ jobs:
       matrix:
         # Memory and address sanitizers.
         sanitizer_opt: [msan, asan]
+    env:
+      use-verbose: ${{github.event.inputs.debug == true}}
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -94,5 +96,5 @@ jobs:
               --config=avx \
               --config=openmp \
               --config=${{matrix.sanitizer_opt}} \
-              ${{inputs.debug && '--config=verbose'}} \
+              ${{env.use-verbose && '--config=verbose'}} \
               tests:all

--- a/.github/workflows/ci_sanitizer_tests.yaml
+++ b/.github/workflows/ci_sanitizer_tests.yaml
@@ -29,6 +29,11 @@ on:
       - checks_requested
 
   workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Run with debugging options'
+        type: boolean
+        default: true
 
 permissions: read-all
 
@@ -81,5 +86,9 @@ jobs:
 
       - name: Run C++ tests
         run: |
-          bazel test --config=verbose --config=avx --config=openmp \
-          --config=${{matrix.sanitizer_opt}} tests:all
+          bazel test \
+              --config=avx \
+              --config=openmp \
+              --config=${{matrix.sanitizer_opt}} \
+              ${{inputs.debug && '--config=verbose'}} \
+              tests:all

--- a/.github/workflows/ci_sanitizer_tests.yaml
+++ b/.github/workflows/ci_sanitizer_tests.yaml
@@ -60,6 +60,7 @@ jobs:
         # Memory and address sanitizers.
         sanitizer_opt: [msan, asan]
     env:
+      # Must use explicit test for true so it works when inputs.debug is null.
       use-verbose: ${{github.event.inputs.debug == true}}
     steps:
       - name: Check out a copy of the git repository

--- a/.github/workflows/ci_tcmalloc_test.yaml
+++ b/.github/workflows/ci_tcmalloc_test.yaml
@@ -87,5 +87,9 @@ jobs:
         env:
           PERFTOOLS_VERBOSE: ${{inputs.debug && 1 || ''}}
         run: |
-          bazel test --config=verbose --config=avx --config=openmp \
-          --config=tcmalloc tests:all
+          bazel test \
+              --config=avx \
+              --config=openmp \
+              --config=tcmalloc \
+              ${{inputs.debug && '--config=verbose'}} \
+              tests:all

--- a/.github/workflows/ci_tcmalloc_test.yaml
+++ b/.github/workflows/ci_tcmalloc_test.yaml
@@ -55,6 +55,8 @@ jobs:
     needs: find-changes
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    env:
+      use-verbose: ${{github.event.inputs.debug == true}}
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -89,11 +91,11 @@ jobs:
 
       - name: Run C++ tests
         env:
-          PERFTOOLS_VERBOSE: ${{inputs.debug && 1 || ''}}
+          PERFTOOLS_VERBOSE: ${{env.use-verbose && 1 || ''}}
         run: |
           bazel test \
               --config=avx \
               --config=openmp \
               --config=tcmalloc \
-              ${{inputs.debug && '--config=verbose'}} \
+              ${{env.use-verbose && '--config=verbose'}} \
               tests:all

--- a/.github/workflows/ci_tcmalloc_test.yaml
+++ b/.github/workflows/ci_tcmalloc_test.yaml
@@ -56,6 +56,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
+      # Must use explicit test for true so it works when inputs.debug is null.
       use-verbose: ${{github.event.inputs.debug == true}}
     steps:
       - name: Check out a copy of the git repository


### PR DESCRIPTION
It makes sense for the debug option during manual runs to pass the `--config=verbose` option to our Bazel invocations.