### PR TITLE
Install dev-requirements.txt into Python environments

### DIFF
--- a/.github/workflows/ci_format_checks.yml
+++ b/.github/workflows/ci_format_checks.yml
@@ -67,10 +67,14 @@ jobs:
         with:
           python-version: '3.13'
           cache: pip
-          cache-dependency-path: dev-requirements.txt
+          cache-dependency-path: |
+            requirements.txt
+            dev-requirements.txt
 
-      - name: Install dev requirements
-        run: pip install -r dev-requirements.txt
+      - name: Install qsim development dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
 
       - name: Check Python file format
         env:

--- a/.github/workflows/ci_hardware_options.yaml
+++ b/.github/workflows/ci_hardware_options.yaml
@@ -76,10 +76,14 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-          cache-dependency-path: requirements.txt
+          cache-dependency-path: |
+            requirements.txt
+            dev-requirements.txt
 
-      - name: Install qsim requirements
-        run: python3 -m pip install -r requirements.txt
+      - name: Install qsim development dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
 
       - name: Run C++ tests
         run: |

--- a/.github/workflows/ci_sanitizer_tests.yaml
+++ b/.github/workflows/ci_sanitizer_tests.yaml
@@ -74,10 +74,14 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-          cache-dependency-path: requirements.txt
+          cache-dependency-path: |
+            requirements.txt
+            dev-requirements.txt
 
-      - name: Install qsim requirements
-        run: python3 -m pip install -r requirements.txt
+      - name: Install qsim development dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
 
       - name: Run C++ tests
         run: |

--- a/.github/workflows/ci_tcmalloc_test.yaml
+++ b/.github/workflows/ci_tcmalloc_test.yaml
@@ -75,10 +75,14 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-          cache-dependency-path: requirements.txt
+          cache-dependency-path: |
+            requirements.txt
+            dev-requirements.txt
 
-      - name: Install qsim requirements
-        run: python3 -m pip install -r requirements.txt
+      - name: Install qsim development dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
 
       - name: Install google-perftools for tcmalloc
         run: sudo apt-get install libgoogle-perftools-dev


### PR DESCRIPTION
After switching to Python 3.12 for the Python environment in the workflows, one of the workflows started failing. That workflow only loaded `requirements.txt`. It wasn't clear why, and took time to debug, and ultimately I think the problem was elsewhere. However, what wasted my time is chasing a red herring thinking that the problem was due to not loading `dev-requirements.txt`.

I think it's better if all the workflows load both `requirements.txt` and `dev-requirements.txt` to reduce the number of variables in future debugging episodes. (They may not all need it, and if there's a specific reason for a workflow not to load dev-requirements then that's okay. It's just that it's better if the default is uniform across all the workflows.)