### PR TITLE
Fix niggling Docker issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ignore this in case the user previously did a "pip install -e ."
+qsimcirq.egg-info

--- a/install/tests/Dockerfile
+++ b/install/tests/Dockerfile
@@ -36,4 +36,4 @@ COPY ./qsimcirq_tests/ /test-install/
 
 # Run the tests from that location.
 WORKDIR /test-install/
-ENTRYPOINT python3 -m pytest ./
+ENTRYPOINT ["python3", "-m", "pytest", "./"]

--- a/pybind_interface/Dockerfile
+++ b/pybind_interface/Dockerfile
@@ -12,4 +12,4 @@ WORKDIR /qsim/
 RUN make -C /qsim/ pybind
 
 # Compile and run qsim tests
-ENTRYPOINT make -C /qsim/ run-py-tests
+ENTRYPOINT ["make", "-C", "/qsim/", "run-py-tests"]

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -7,4 +7,4 @@ COPY ./tests/ /qsim/tests/
 WORKDIR /qsim/
 
 # Compile and run qsim tests
-ENTRYPOINT make -C /qsim/ run-cxx-tests
+ENTRYPOINT ["make", "-C", "/qsim/", "run-cxx-tests"]


### PR DESCRIPTION
This fixes a couple of problems that came to light:

* The configuration in `install/tests/Dockerfile` copies the entire qsim source directory into the Docker container. If the user previously did a `pip install .` in the qsim source directory, this will copy the egg directory too. This confuses pip installation commands inside the Docker environment. Adding a `.dockerignore` file to ignore the egg directory solves this, and is more maintainable than trying to copy only select parts of the qsim source directory.
* Docker now seems to have deprecated the previous `build` command in favor the `buildx` module. This module complains if `ENTRYPOINT` values don't use the JSON variant of the syntax. Changing the `Dockerfile`s to use this syntax solves this, and the syntax is backwards-compatible with the previous `build`.