### PR TITLE
Use setuptools>=75.2.0, matching Colab

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ numpy>=1.26.0
 # CMake will find them. It makes a crucial difference in some environments.
 pybind11[global]
 typing_extensions
-setuptools>=78
+setuptools>=75.2.0

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ setup(
     # "pip install" from sources needs to build Pybind, which needs CMake too.
     setup_requires=[
         "packaging",
-        "setuptools>=78",
+        "setuptools>=75.2.0",
         "pybind11[global]",
         "cmake~=3.31.0",
     ],


### PR DESCRIPTION
This is to try to avoid confusing Colab users with a warning about reinstalling distutils. It makes it look like the installation failed.