### PR TITLE
Silence compiler warnings about "using serial compilation"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ CXX ?= g++
 NVCC ?= nvcc
 HIPCC ?= hipcc
 
-CXXFLAGS ?= -O3 -std=c++17 -fopenmp
+CXXFLAGS ?= -O3 -std=c++17 -fopenmp -flto=auto
 NVCCFLAGS ?= -O3 --std c++17 -Wno-deprecated-gpu-targets
 HIPCCFLAGS ?= -O3
 

--- a/pybind_interface/GetCUDAARCHS.cmake
+++ b/pybind_interface/GetCUDAARCHS.cmake
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-# Check whether the user has provided info about the GPU(s) installed
-# on their system. If not, try to determine what it is automaticaly.
 if(CMAKE_CUDA_ARCHITECTURES)
     # CMake 3.18+ sets this variable from $CUDAARCHS automatically.
     message(STATUS "qsim: using CUDA architectures "

--- a/pybind_interface/avx2/CMakeLists.txt
+++ b/pybind_interface/avx2/CMakeLists.txt
@@ -18,7 +18,7 @@ project(qsim)
 IF (WIN32)
     set(CMAKE_CXX_FLAGS "/arch:AVX2 /O2 /openmp")
 ELSE()
-    set(CMAKE_CXX_FLAGS "-mavx2 -mfma -O3")
+    set(CMAKE_CXX_FLAGS "-mavx2 -mfma -O3 -flto=auto")
 ENDIF()
 
 if(APPLE)

--- a/pybind_interface/avx512/CMakeLists.txt
+++ b/pybind_interface/avx512/CMakeLists.txt
@@ -18,7 +18,7 @@ project(qsim)
 IF (WIN32)
     set(CMAKE_CXX_FLAGS "/arch:AVX512 /O2 /openmp")
 ELSE()
-    set(CMAKE_CXX_FLAGS "-mavx512f -mbmi2 -O3")
+    set(CMAKE_CXX_FLAGS "-mavx512f -mbmi2 -O3 -flto=auto")
 ENDIF()
 
 if(APPLE)

--- a/pybind_interface/basic/CMakeLists.txt
+++ b/pybind_interface/basic/CMakeLists.txt
@@ -18,7 +18,7 @@ project(qsim)
 if(WIN32)
     set(CMAKE_CXX_FLAGS "/O2 /openmp")
 else()
-    set(CMAKE_CXX_FLAGS "-O3")
+    set(CMAKE_CXX_FLAGS "-O3 -flto=auto")
 endif()
 
 if(APPLE)

--- a/pybind_interface/cuda/CMakeLists.txt
+++ b/pybind_interface/cuda/CMakeLists.txt
@@ -18,7 +18,7 @@ project(qsim LANGUAGES CXX CUDA)
 if(WIN32)
     set(CMAKE_CXX_FLAGS "/O2 /openmp")
 else()
-    set(CMAKE_CXX_FLAGS "-O3")
+    set(CMAKE_CXX_FLAGS "-O3 -flto=auto")
 endif()
 
 if(APPLE)

--- a/pybind_interface/custatevec/CMakeLists.txt
+++ b/pybind_interface/custatevec/CMakeLists.txt
@@ -18,7 +18,7 @@ project(qsim LANGUAGES CXX CUDA)
 if(WIN32)
     set(CMAKE_CXX_FLAGS "/O2 /openmp")
 else()
-    set(CMAKE_CXX_FLAGS "-O3")
+    set(CMAKE_CXX_FLAGS "-O3 -flto=auto")
 endif()
 
 if(APPLE)

--- a/pybind_interface/decide/CMakeLists.txt
+++ b/pybind_interface/decide/CMakeLists.txt
@@ -21,7 +21,7 @@ check_language(CUDA)
 if(WIN32)
     set(CMAKE_CXX_FLAGS "/O2 /openmp")
 else()
-    set(CMAKE_CXX_FLAGS "-O3")
+    set(CMAKE_CXX_FLAGS "-O3 -flto=auto")
 endif()
 
 if(APPLE)

--- a/pybind_interface/hip/CMakeLists.txt
+++ b/pybind_interface/hip/CMakeLists.txt
@@ -18,7 +18,7 @@ project(qsim LANGUAGES CXX HIP)
 if(WIN32)
     set(CMAKE_CXX_FLAGS "/O2 /openmp")
 else()
-    set(CMAKE_CXX_FLAGS "-O3")
+    set(CMAKE_CXX_FLAGS "-O3 -flto=auto")
 endif()
 
 INCLUDE(../GetPybind11.cmake)

--- a/pybind_interface/sse/CMakeLists.txt
+++ b/pybind_interface/sse/CMakeLists.txt
@@ -18,7 +18,7 @@ project(qsim)
 IF (WIN32)
     set(CMAKE_CXX_FLAGS "/O2 /openmp")
 ELSE()
-    set(CMAKE_CXX_FLAGS "-msse4.1 -O3")
+    set(CMAKE_CXX_FLAGS "-msse4.1 -O3 -flto=auto")
 ENDIF()
 
 if(APPLE)


### PR DESCRIPTION
On Ubuntu, one sees warnings like this:

```
lto-wrapper: warning: using serial compilation of 13 LTRANS jobs
lto-wrapper: note: see the ‘-flto’ option documentation for more
information
lto-wrapper: warning: using serial compilation of 15 LTRANS jobs
lto-wrapper: note: see the ‘-flto’ option documentation for more
information
lto-wrapper: warning: using serial compilation of 16 LTRANS jobs
lto-wrapper: note: see the ‘-flto’ option documentation for more
information
lto-wrapper: warning: using serial compilation of 16 LTRANS jobs
lto-wrapper: note: see the ‘-flto’ option documentation for more
information
```

This seems to be the default behavior if the option `-flto` is not given a value (c.f. https://stackoverflow.com/a/72222512/28972686). Giving it a value of "auto" makes the warning go away and lets the compilation toolchain decide how much parallism it can use.