### PR TITLE
Test for sse4 specifically, not just sse, in dev_tools/test_libs.sh

### DIFF
--- a/dev_tools/test_libs.sh
+++ b/dev_tools/test_libs.sh
@@ -37,7 +37,7 @@ if [[ "$features" == *avx2* ]]; then
      filters+=",avx"
      configs+=( "--config=avx" )
 fi
-if [[ "$features" == *sse* ]]; then
+if [[ "$features" == *sse4* ]]; then
      filters+=",sse"
      configs+=( "--config=sse" )
 fi


### PR DESCRIPTION
Our code actually uses SSE4.1, and there's a risk that checking only for "sse" in the flags will get an older or incompatible variant of SSE.