### PR TITLE
Add a pip constraints file & constrain Pillow version

### DIFF
--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -87,6 +87,7 @@ jobs:
     env:
       # Must use explicit test for true so it works when inputs.debug is null.
       use-verbose: ${{github.event.inputs.debug == true}}
+      PIP_CONSTRAINT: .github/workflows/pip-constraints.txt
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/ci_format_checks.yml
+++ b/.github/workflows/ci_format_checks.yml
@@ -55,6 +55,8 @@ jobs:
     needs: find-changes
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    env:
+      PIP_CONSTRAINT: .github/workflows/pip-constraints.txt
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/ci_hardware_options.yaml
+++ b/.github/workflows/ci_hardware_options.yaml
@@ -64,6 +64,7 @@ jobs:
     env:
       # Must use explicit test for true so it works when inputs.debug is null.
       use-verbose: ${{github.event.inputs.debug == true}}
+      PIP_CONSTRAINT: .github/workflows/pip-constraints.txt
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/ci_sanitizer_tests.yaml
+++ b/.github/workflows/ci_sanitizer_tests.yaml
@@ -62,6 +62,7 @@ jobs:
     env:
       # Must use explicit test for true so it works when inputs.debug is null.
       use-verbose: ${{github.event.inputs.debug == true}}
+      PIP_CONSTRAINT: .github/workflows/pip-constraints.txt
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/ci_tcmalloc_test.yaml
+++ b/.github/workflows/ci_tcmalloc_test.yaml
@@ -58,6 +58,7 @@ jobs:
     env:
       # Must use explicit test for true so it works when inputs.debug is null.
       use-verbose: ${{github.event.inputs.debug == true}}
+      PIP_CONSTRAINT: .github/workflows/pip-constraints.txt
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/cirq_compatibility.yml
+++ b/.github/workflows/cirq_compatibility.yml
@@ -38,6 +38,8 @@ jobs:
     name: Test Cirq compatibility
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    env:
+      PIP_CONSTRAINT: .github/workflows/pip-constraints.txt
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/pip-constraints.txt
+++ b/.github/workflows/pip-constraints.txt
@@ -1,0 +1,18 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Pillow released an updated on 2025-07-01 and it broke installations
+# on Ubuntu GitHub runners.
+# TODO(mhucka) remove this after the problem is fixed.
+pillow<11.3.0

--- a/.github/workflows/reusable_build_wheels.yaml
+++ b/.github/workflows/reusable_build_wheels.yaml
@@ -60,6 +60,8 @@ jobs:
           {os: macos-15,     arch: arm64},
           {os: windows-2025, arch: AMD64},
         ]
+    env:
+      PIP_CONSTRAINT: .github/workflows/pip-constraints.txt
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
Pillow was updated to version 11.3.0 about 12 hours ago, and this is causing our builds on GitHub runners to fail because of some issue involving Pillow building wheels. Until that's resolved, this PR adds a constraints file that limits the version of Pillow installed by pip commands in the workflows.