### PR TITLE
Use rooted URL for the image in SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -13,7 +13,7 @@ repository page.
 
 <div align="center">
 <img width="75%" alt="Location of the report button on the repository page"
-    src="./report-vulnerability-button.png">
+    src="/.github/report-vulnerability-button.png">
 </div>
 
 Please report security issues in third-party modules to the person or team


### PR DESCRIPTION
Turns out the security policy document is accessible on GitHub from at least two paths, and the relative image URL only worked in one and not the other. Using a rooted URL fixes that problem.