### PR TITLE
Fix #838: replace use of exec with runpy in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@
 
 import os
 import re
+import runpy
 import sys
 import shutil
 import platform
@@ -131,8 +132,9 @@ description = "Schrödinger and Schrödinger-Feynman simulators for quantum circ
 # README file as long_description.
 long_description = open("README.md", encoding="utf-8").read()
 
-__version__ = ""
-exec(open("qsimcirq/_version.py").read())
+__version__ = runpy.run_path("qsimcirq/_version.py")["__version__"]
+if not __version__:
+    raise ValueError("Version string cannot be empty")
 
 setup(
     name="qsimcirq",


### PR DESCRIPTION
`setup.py` uses `exec` to read the version number from the version file. It's generally considered best practice to avoid `exec` because of risks it carries. In this particular case, we can borrow the technique used in Cirq's `setup.py`, and use the Python `runpy` package.