### PR TITLE
Fix #847: missing range checks in statespace_*.h files

### DIFF
--- a/lib/statespace_avx.h
+++ b/lib/statespace_avx.h
@@ -399,7 +399,7 @@ class StateSpaceAVX :
           double re = p[16 * k + j];
           double im = p[16 * k + 8 + j];
           csum += re * re + im * im;
-          while (rs[m] < csum && m < num_samples) {
+          while (m < num_samples && rs[m] < csum) {
             bitstrings.emplace_back(8 * k + j);
             ++m;
           }

--- a/lib/statespace_avx512.h
+++ b/lib/statespace_avx512.h
@@ -350,7 +350,7 @@ class StateSpaceAVX512 :
           double re = p[32 * k + j];
           double im = p[32 * k + 16 + j];
           csum += re * re + im * im;
-          while (rs[m] < csum && m < num_samples) {
+          while (m < num_samples && rs[m] < csum) {
             bitstrings.emplace_back(16 * k + j);
             ++m;
           }

--- a/lib/statespace_basic.h
+++ b/lib/statespace_basic.h
@@ -218,7 +218,7 @@ class StateSpaceBasic :
         double re = p[2 * k];
         double im = p[2 * k + 1];
         csum += re * re + im * im;
-        while (rs[m] < csum && m < num_samples) {
+        while (m < num_samples && rs[m] < csum) {
           bitstrings.emplace_back(k);
           ++m;
         }

--- a/lib/statespace_cuda_kernels.h
+++ b/lib/statespace_cuda_kernels.h
@@ -317,7 +317,7 @@ __global__ void SampleKernel(unsigned num_blocks,
         FP3 re = state[l];
         FP3 im = state[l + warp_size];
         csum += re * re + im * im;
-        while (rs[m] < csum && m < num_samples) {
+        while (m < num_samples && rs[m] < csum) {
           bitstrings[m++] = k0 + k;
         }
       }

--- a/lib/statespace_sse.h
+++ b/lib/statespace_sse.h
@@ -359,7 +359,7 @@ class StateSpaceSSE :
           double re = p[8 * k + j];
           double im = p[8 * k + 4 + j];
           csum += re * re + im * im;
-          while (rs[m] < csum && m < num_samples) {
+          while (m < num_samples && rs[m] < csum) {
             bitstrings.emplace_back(4 * k + j);
             ++m;
           }


### PR DESCRIPTION
CodeQL scans flagged lines like 353 in `lib/statespace_avx512.h`, reporting that the use of offset `m` should follow the range check:

```C++
     while (rs[m] < csum && m < num_samples) {
```

In more detail:

> The program contains an and-expression where the array access is defined before the range check. Consequently the array is accessed without any bounds checking. The range check does not protect the program from segmentation faults caused by attempts to read beyond the end of a buffer.

The same issue exists in the following files:

* statespace_basic.h
* statespace_sse.h
* statespace_avx512.h
* statespace_avx.h