### PR TITLE
Fix #846: multip. result converted to larger type

### DIFF
--- a/lib/matrix.h
+++ b/lib/matrix.h
@@ -50,7 +50,7 @@ inline void MatrixClear(Matrix<fp_type>& m) {
  */
 template <typename fp_type>
 inline void MatrixIdentity(unsigned n, Matrix<fp_type>& m) {
-  m.resize(2 * n * n);
+  m.resize(2 * static_cast<typename Matrix<fp_type>::size_type>(n) * n);
 
   MatrixClear(m);
 


### PR DESCRIPTION
CodeQL scans flagged the construct ➀ below on line 53 in `lib/matrix.h` because the multiplication result may overflow 'unsigned int' before it is converted to 'size_type'.

```C++
template <typename fp_type>
inline void MatrixIdentity(unsigned n, Matrix<fp_type>& m) {
  m.resize(2 * n * n);      ➀
```

The warning is:

> This rule finds code that converts the result of an integer multiplication to a larger type. Since the conversion applies after the multiplication, arithmetic overflow may still occur.