### PR TITLE
Fix #854: change NoiseChannel.__str__ to use correct method

### DIFF
--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -1045,7 +1045,7 @@ class NoiseChannel(cirq.Gate):
         return [m for _, m in self._prob_op_pairs]
 
     def __str__(self):
-        return f"NoiseChannel({self._ops})"
+        return f"NoiseChannel({self._prob_op_pairs})"
 
     def __repr__(self):
         return str(self)


### PR DESCRIPTION
An inspection of the code of class `NoiseChannel` in `qsimcirq_tests/qsimcirq_tests.py` suggests that the call to the `_ops` method should be instead to `_prob_op_pairs`, like this:

```python
def __str__(self):
    return f"NoiseChannel({self._prob_op_pairs})"
```

This works, and printing instances of the class do print something reasonable.