### PR TITLE
Fix #855: don't call cirq.unitary() on non-unitary matrices

### DIFF
--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -1057,7 +1057,7 @@ class NoiseMixture(NoiseChannel):
         super().__init__(*args, **kwargs)
 
     def _mixture_(self):
-        return [(prob, cirq.unitary(op)) for prob, op, in self._prob_op_pairs]
+        return [(prob, op) for prob, op, in self._prob_op_pairs]
 
 
 @pytest.mark.parametrize(

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -2025,11 +2025,11 @@ def test_qsimcirq_identity_expectation_value():
     for w, pauli in objs:
         pauli = pauli[::-1]
         hamiltonian += float(w) * cirq.PauliString(
-            cirq.I(cirq.LineQubit(i))
-            if p == "I"
-            else cirq.Z(cirq.LineQubit(i))
-            if p == "Z"
-            else None
+            (
+                cirq.I(cirq.LineQubit(i))
+                if p == "I"
+                else cirq.Z(cirq.LineQubit(i)) if p == "Z" else None
+            )
             for i, p in enumerate(pauli)
         )
 

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -1057,6 +1057,16 @@ class NoiseMixture(NoiseChannel):
         super().__init__(*args, **kwargs)
 
     def _mixture_(self):
+        # Cirq's mixture() function in mixture_protocol.py returns tuples of
+        # the form (probability, unitary peration). It does this by applying
+        # Cirq's unitary() function to the second elements of the tuples
+        # returned from here. Now, the values in self._prob_op_pairs will be
+        # tuples of the form (probability, NoiseStep). NoiseStep defines a
+        # _unitary_() method that simply returns the array as-is. Thus, when
+        # Cirq's mixture() function gets the value returned here and calls
+        # unitary() on those NoiseStep objects, the values unitary() returns
+        # will not actually be unitary. This is done knowingly. The nonunitary
+        # values are eventually normalized in test_multi_qubit_noise().
         return [(prob, op) for prob, op, in self._prob_op_pairs]
 
 

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -1058,7 +1058,7 @@ class NoiseMixture(NoiseChannel):
 
     def _mixture_(self):
         # Cirq's mixture() function in mixture_protocol.py returns tuples of
-        # the form (probability, unitary peration). It does this by applying
+        # the form (probability, unitary operation). It does this by applying
         # Cirq's unitary() function to the second elements of the tuples
         # returned from here. Now, the values in self._prob_op_pairs will be
         # tuples of the form (probability, NoiseStep). NoiseStep defines a


### PR DESCRIPTION
In Cirq 1.6.0, the function [`unitary(...)`](https://github.com/quantumlib/Cirq/blob/fe0dc2187ca3269c178526e8ba41083fa1a467c9/cirq-core/cirq/protocols/unitary_protocol.py#L81) in `cirq-core/cirq/protocols/unitary_protocol.py` changed. Whereas previously, if the value passed in was a NumPy array, the array was returned without doing anything else, `unitary(...)` was changed in [Cirq PR #7536](https://github.com/quantumlib/Cirq/issues/7536) to test that the NumPy array really _is_ unitary and raise an exception if it isn't. This arguably corrected a fault in `unitary(...)` because with the previous definition, it would return non-unitary results if given a NumPy array that wasn't already unitary. However, one of the tests in qsim depended on this flaw: the test case knowingly invoked `unitary(...)` with a non-unitary matrix. This recently led to exceptions being raised in the qsim tests with Cirq 1.6.0 but not with prior Cirq versions.

The solution in this case turned out to be very simple: the call to `cirq.unitary(...)` on line 1060 was unnecessary because the previous version of `unitary(...)` simply returned the value untouched anyway. Removing the call kept the previous behavior (which was to use a non-unitary matrix in that situation) and works in both Cirq 1.5.0 and 1.6.0.

(An additional change to reformatting a few lines elsewhere was needed to satisfy the CI checks for formatting.)