### PR TITLE
Fix #858: tell buildx which platform to build for

### DIFF
--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -65,14 +65,15 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+
       - name: Build Docker images
         run: |
-          docker version
-          docker buildx version
-          # First, build the base image that the other images depend on.
           docker compose build qsim-base-image
-          # Now build the other images.
-          docker compose build
+          docker compose build qsim-cxx-tests-image qsim-py-tests-image
 
       - name: Run C++ tests
         run: docker run --rm qsim-cxx-tests:latest
@@ -81,7 +82,7 @@ jobs:
         run: docker run --rm qsim-py-tests:latest
 
       - name: Run a sample simulation
-        run: docker run --rm qsim-base-image:latest -c /qsim/circuits/circuit_q24
+        run: docker run --rm qsim-base:latest -c /qsim/circuits/circuit_q24
 
       - name: Test installation process
         run: |

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -75,13 +75,13 @@ jobs:
           docker compose build
 
       - name: Run C++ tests
-        run: docker run --rm qsim-cxx-tests
+        run: docker run --rm qsim-cxx-tests:latest
 
       - name: Run Python tests
-        run: docker run --rm qsim-py-tests
+        run: docker run --rm qsim-py-tests:latest
 
       - name: Run a sample simulation
-        run: docker run --rm qsim:latest -c /qsim/circuits/circuit_q24
+        run: docker run --rm qsim-base-image:latest -c /qsim/circuits/circuit_q24
 
       - name: Test installation process
         run: |

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -76,7 +76,7 @@ jobs:
           # On GitHub, buildx tries to build all 3 images in parallel even if
           # you set COMPOSE_PARALLEL_LIMIT or use --parallel 1. That fails b/c
           # the qsim-base image is not available to the other two build jobs.
-          docker compose --parallel 1 build
+          docker compose build qsim-base-image
           docker compose build qsim-cxx-tests-image qsim-py-tests-image
 
       - name: Run C++ tests

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -66,7 +66,7 @@ jobs:
           submodules: recursive
 
       - name: Clear the Docker buildx cache
-        run: docker buildx --force --all --verbose prune
+        run: docker buildx prune --force --all --verbose
 
       - name: Build Docker images
         run: docker compose build

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -74,10 +74,10 @@ jobs:
         run: |
           # Running locally, a plain "docker compose build" works as expected.
           # On GitHub, buildx tries to build all 3 images in parallel even if
-          # you use env var COMPOSE_PARALLEL_LIMIT or option --parallel 1.
-          # The build then fails because the qsim-base image is not available
-          # to the other two build processes.
+          # you set COMPOSE_PARALLEL_LIMIT or use --parallel 1. That fails b/c
+          # the qsim-base image is not available to the other two build jobs.
           docker compose --parallel 1 build
+          docker compose build qsim-cxx-tests-image qsim-py-tests-image
 
       - name: Run C++ tests
         run: docker run --rm qsim-cxx-tests:latest

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -69,13 +69,16 @@ jobs:
         run: |
           docker version
           docker buildx version
-          docker buildx bake --load --progress=plain -f docker-compose.yml
+          # First, build the base image that the other images depend on.
+          docker compose build qsim-base-image
+          # Now build the other images.
+          docker compose build
 
       - name: Run C++ tests
-        run: docker run --rm qsim-cxx-tests:latest
+        run: docker run --rm qsim-cxx-tests
 
       - name: Run Python tests
-        run: docker run --rm qsim-py-tests:latest
+        run: docker run --rm qsim-py-tests
 
       - name: Run a sample simulation
         run: docker run --rm qsim:latest -c /qsim/circuits/circuit_q24
@@ -83,4 +86,4 @@ jobs:
       - name: Test installation process
         run: |
           cd install/tests
-          docker buildx bake --load --progress=plain -f docker-compose.yml
+          docker compose build

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -66,7 +66,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
         with:
           driver: docker
 

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -65,11 +65,11 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
-      - name: Clear the Docker buildx cache
-        run: docker buildx prune --force --all --verbose
-
       - name: Build Docker images
-        run: docker compose build
+        run: |
+          docker version
+          docker buildx version
+          docker compose build --no-cache
 
       - name: Run C++ tests
         run: docker run --rm qsim-cxx-tests:latest

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -65,11 +65,6 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
-        with:
-          driver: docker
-
       - name: Build Docker images
         run: |
           # Running locally, a plain "docker compose build" works as expected.

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           docker version
           docker buildx version
-          docker compose build
+          docker buildx bake --load --progress=plain -f docker-compose.yml
 
       - name: Run C++ tests
         run: docker run --rm qsim-cxx-tests:latest
@@ -83,4 +83,4 @@ jobs:
       - name: Test installation process
         run: |
           cd install/tests
-          docker compose build
+          docker buildx bake --load --progress=plain -f docker-compose.yml

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -72,8 +72,12 @@ jobs:
 
       - name: Build Docker images
         run: |
-          docker compose build qsim-base-image
-          docker compose build qsim-cxx-tests-image qsim-py-tests-image
+          # Running locally, a plain "docker compose build" works as expected.
+          # On GitHub, buildx tries to build all 3 images in parallel even if
+          # you use env var COMPOSE_PARALLEL_LIMIT or option --parallel 1.
+          # The build then fails because the qsim-base image is not available
+          # to the other two build processes.
+          docker compose --parallel 1 build
 
       - name: Run C++ tests
         run: docker run --rm qsim-cxx-tests:latest

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           docker version
           docker buildx version
-          docker compose build --no-cache
+          docker compose build
 
       - name: Run C++ tests
         run: docker run --rm qsim-cxx-tests:latest

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -65,6 +65,9 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
+      - name: Clear the Docker buildx cache
+        run: docker buildx --force --all --verbose prune
+
       - name: Build Docker images
         run: docker compose build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base OS
-FROM ubuntu:24.04
+FROM ubuntu:24.04 as qsim-base
 
 # Allow passing this variable in from the outside.
 ARG CUDA_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base OS
-FROM ubuntu:24.04 as qsim-base
+FROM ubuntu:24.04 AS qsim-base
 
 # Allow passing this variable in from the outside.
 ARG CUDA_PATH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
         build:
             context: ./
             dockerfile: Dockerfile
+        outputs:
+        - type=docker
     qsim-cxx-tests:
         platform: linux/amd64
         image: qsim-cxx-tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
         build:
             context: ./
             dockerfile: Dockerfile
-        outputs:
-        - type=docker
     qsim-cxx-tests:
         platform: linux/amd64
         image: qsim-cxx-tests
@@ -16,7 +14,7 @@ services:
             context: ./
             dockerfile: tests/Dockerfile
         depends_on:
-        - qsim
+          - qsim
     qsim-py-tests:
         platform: linux/amd64
         image: qsim-py-tests
@@ -25,4 +23,4 @@ services:
             context: ./
             dockerfile: pybind_interface/Dockerfile
         depends_on:
-        - qsim
+          - qsim

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,24 @@
 services:
-    qsim-base:
+    qsim-base-image:
         platform: linux/amd64
-        image: qsim
-        container_name: qsim
+        image: qsim-base
         build:
             context: ./
             dockerfile: Dockerfile
+            target: qsim-base
 
     qsim-cxx-tests:
-        platform: linux/amd64
-        image: qsim-cxx-tests
-        container_name: qsim-cxx-tests
         build:
             context: ./
             dockerfile: tests/Dockerfile
+            target: qsim-cxx-tests
         depends_on:
-          - qsim-base
+          - qsim-base-image
 
     qsim-py-tests:
-        platform: linux/amd64
-        image: qsim-py-tests
-        container_name: qsim-py-tests
         build:
             context: ./
             dockerfile: pybind_interface/Dockerfile
+            target: qsim-py-tests
         depends_on:
-          - qsim-base
+          - qsim-base-image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 services:
     qsim:
+        platform: linux/amd64
         image: qsim
         container_name: qsim
         build:
             context: ./
             dockerfile: Dockerfile
     qsim-cxx-tests:
+        platform: linux/amd64
         image: qsim-cxx-tests
         container_name: qsim-cxx-tests
         build:
@@ -14,6 +16,7 @@ services:
         depends_on:
         - qsim
     qsim-py-tests:
+        platform: linux/amd64
         image: qsim-py-tests
         container_name: qsim-py-tests
         build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
 services:
-    qsim:
+    qsim-base:
         platform: linux/amd64
         image: qsim
         container_name: qsim
         build:
             context: ./
             dockerfile: Dockerfile
+
     qsim-cxx-tests:
         platform: linux/amd64
         image: qsim-cxx-tests
@@ -14,7 +15,8 @@ services:
             context: ./
             dockerfile: tests/Dockerfile
         depends_on:
-          - qsim
+          - qsim-base
+
     qsim-py-tests:
         platform: linux/amd64
         image: qsim-py-tests
@@ -23,4 +25,4 @@ services:
             context: ./
             dockerfile: pybind_interface/Dockerfile
         depends_on:
-          - qsim
+          - qsim-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,14 @@
 services:
     qsim-base-image:
-        platform: linux/amd64
         image: qsim-base
+        platform: linux/amd64
         build:
             context: ./
             dockerfile: Dockerfile
             target: qsim-base
 
-    qsim-cxx-tests:
+    qsim-cxx-tests-image:
+        image: qsim-cxx-tests
         build:
             context: ./
             dockerfile: tests/Dockerfile
@@ -15,7 +16,8 @@ services:
         depends_on:
           - qsim-base-image
 
-    qsim-py-tests:
+    qsim-py-tests-image:
+        image: qsim-py-tests
         build:
             context: ./
             dockerfile: pybind_interface/Dockerfile

--- a/pybind_interface/Dockerfile
+++ b/pybind_interface/Dockerfile
@@ -1,5 +1,5 @@
 # Base OS
-FROM qsim
+FROM qsim-base as qsim-py-tests
 
 # Copy relevant files
 COPY ./pybind_interface/ /qsim/pybind_interface/

--- a/pybind_interface/Dockerfile
+++ b/pybind_interface/Dockerfile
@@ -1,5 +1,5 @@
 # Base OS
-FROM qsim-base as qsim-py-tests
+FROM qsim-base AS qsim-py-tests
 
 # Copy relevant files
 COPY ./pybind_interface/ /qsim/pybind_interface/

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,5 +1,5 @@
 # Base OS
-FROM qsim-base as qsim-cxx-tests
+FROM qsim-base AS qsim-cxx-tests
 
 # Copy relevant files
 COPY ./tests/ /qsim/tests/

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,5 +1,5 @@
 # Base OS
-FROM qsim
+FROM qsim-base as qsim-cxx-tests
 
 # Copy relevant files
 COPY ./tests/ /qsim/tests/


### PR DESCRIPTION
Docker builds on GitHub are failing with the problem that Docker build is trying to get qsim images from docker.io:

```
#1 [internal] load local bake definitions
#1 reading from stdin 935B done
#1 DONE 0.0s

#2 [qsim internal] load build definition from Dockerfile
#2 transferring dockerfile: 1.34kB done
#2 DONE 0.0s

#3 [qsim-py-tests internal] load build definition from Dockerfile
#3 transferring dockerfile: 381B done
#3 DONE 0.0s

#4 [qsim-cxx-tests internal] load build definition from Dockerfile
#4 transferring dockerfile: 208B done
#4 DONE 0.0s

#5 [qsim-cxx-tests internal] load metadata for #docker.io/library/qsim:latest
```

Apparently, this happens because the `buildx` plugin, which is the default builder in many modern Docker setups, can build images in parallel and uses an isolated builder environment. An image built for one service (like `qsim`): might not be immediately loaded into the local Docker daemon's image store. When the build for a dependent service (like `qsim-cxx-tests`) starts, it can't find the `qsim` base image locally and falls back to searching Docker Hub.

This is despite the fact that a plain `docker compose build` locally (at least in my Debian Linux environment) works as expected.

After a lot of trial and error, the only solution I could find is to split up the `docker compose build …` into 2 steps, the first being to build the qsim base image separately:

```yaml
- name: Build Docker images
  run: |
    docker compose build qsim-base-image
    docker compose build qsim-cxx-tests-image qsim-py-tests-image
```

In addition to this change, in the process of debugging this I found it useful to make some housekeeping changes to the `Dockerfile` and `docker-compose.yml` files, in particular to change the names of jobs and images to distinguish the different things being run or built. (Having several things all named `qsim` was not helpful.)

Noting here what else I tried and that didn't work:

* What I thought would be the obvious solution (i.e., using the command-line argument `--parallel 1` or setting the env var `COMPOSE_PARALLEL_LIMIT` to tell `buildx` not to build in parallel) did not work on GitHub. Since I can't reproduce the problem locally, I can't be sure if that would have solved it anyway.

* Trying to use the buildx `bake` command first, like this:

  ```shell
  docker buildx bake --load --progress=plain -f docker-compose.yml
  docker compose build
  ```

* Trying to clear the Docker cache.
