### PR TITLE
Fix #858 by splitting up docker compose build

### DIFF
--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -66,7 +66,13 @@ jobs:
           submodules: recursive
 
       - name: Build Docker images
-        run: docker compose build
+        run: |
+          # Running locally, a plain "docker compose build" works as expected.
+          # On GitHub, buildx tries to build all 3 images in parallel even if
+          # you set COMPOSE_PARALLEL_LIMIT or use --parallel 1. That fails b/c
+          # the qsim-base image is not available to the other two build jobs.
+          docker compose build qsim-base-image
+          docker compose build qsim-cxx-tests-image qsim-py-tests-image
 
       - name: Run C++ tests
         run: docker run --rm qsim-cxx-tests:latest
@@ -75,7 +81,7 @@ jobs:
         run: docker run --rm qsim-py-tests:latest
 
       - name: Run a sample simulation
-        run: docker run --rm qsim:latest -c /qsim/circuits/circuit_q24
+        run: docker run --rm qsim-base:latest -c /qsim/circuits/circuit_q24
 
       - name: Test installation process
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base OS
-FROM ubuntu:24.04
+FROM ubuntu:24.04 AS qsim-base
 
 # Allow passing this variable in from the outside.
 ARG CUDA_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,15 @@ ARG CUDA_PATH
 ENV PATH="$CUDA_PATH/bin:$PATH"
 
 # Update package list & install some basic tools we'll need.
-RUN apt-get update
-RUN apt-get install -y python3-dev python3-pip python3-venv make g++ wget git
+# hadolint ignore=DL3009,DL3008
+RUN apt-get update && \
+    apt-get install -y make g++ wget git --no-install-recommends && \
+    apt-get install -y python3-dev python3-pip python3-venv --no-install-recommends
 
 # Ubuntu 24's version of CMake is 3.28. We need a newer version.
 RUN apt-get remove --purge --auto-remove cmake
-RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-linux-x86_64.sh
-RUN sh cmake-3.31.7-linux-x86_64.sh --prefix=/usr/local --skip-license
+RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-linux-x86_64.sh && \
+    sh cmake-3.31.7-linux-x86_64.sh --prefix=/usr/local --skip-license
 
 # Copy relevant files for simulation.
 COPY ./Makefile /qsim/Makefile
@@ -31,8 +33,9 @@ RUN python3 -m venv --upgrade-deps test_env
 ENV PATH="/test_env/bin:$PATH"
 
 # Install qsim requirements.
-RUN python3 -m pip install -r /qsim/requirements.txt
-RUN python3 -m pip install -r /qsim/dev-requirements.txt
+# hadolint ignore=DL3042
+RUN python3 -m pip install -r /qsim/requirements.txt && \
+    python3 -m pip install -r /qsim/dev-requirements.txt
 
 # Compile qsim.
 WORKDIR /qsim/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,26 @@
 services:
-    qsim:
-        image: qsim
-        container_name: qsim
+    qsim-base-image:
+        image: qsim-base
+        platform: linux/amd64
         build:
             context: ./
             dockerfile: Dockerfile
-    qsim-cxx-tests:
+            target: qsim-base
+
+    qsim-cxx-tests-image:
         image: qsim-cxx-tests
-        container_name: qsim-cxx-tests
         build:
             context: ./
             dockerfile: tests/Dockerfile
+            target: qsim-cxx-tests
         depends_on:
-        - qsim
-    qsim-py-tests:
+          - qsim-base-image
+
+    qsim-py-tests-image:
         image: qsim-py-tests
-        container_name: qsim-py-tests
         build:
             context: ./
             dockerfile: pybind_interface/Dockerfile
+            target: qsim-py-tests
         depends_on:
-        - qsim
+          - qsim-base-image

--- a/install/tests/Dockerfile
+++ b/install/tests/Dockerfile
@@ -6,13 +6,15 @@ ARG CUDA_PATH
 ENV PATH="$CUDA_PATH/bin:$PATH"
 
 # Update package list & install some basic tools we'll need.
-RUN apt-get update
-RUN apt-get install -y python3-dev python3-pip python3-venv make g++ wget git
+# hadolint ignore=DL3009,DL3008
+RUN apt-get update && \
+    apt-get install -y make g++ wget git --no-install-recommends && \
+    apt-get install -y python3-dev python3-pip python3-venv --no-install-recommends
 
 # Ubuntu 24's version of CMake is 3.28. We need a newer version.
 RUN apt-get remove --purge --auto-remove cmake
-RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-linux-x86_64.sh
-RUN sh cmake-3.31.7-linux-x86_64.sh --prefix=/usr/local --skip-license
+RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-linux-x86_64.sh && \
+    sh cmake-3.31.7-linux-x86_64.sh --prefix=/usr/local --skip-license
 
 # Copy qsim files from the outside-Docker location to an inside-Docker location.
 COPY ./ /qsim/
@@ -29,6 +31,7 @@ ENV PATH="/qsim/test_env/bin:$PATH"
 # Install qsim from sources.
 # Note: use pip3 here, not python3 -m pip. We need to make sure to get the pip
 # installed inside the venv, because that one has the correct sys.path.
+# hadolint ignore=DL3042
 RUN pip3 install -v /qsim/
 
 # Copy the tests to a non-qsim directory.

--- a/pybind_interface/Dockerfile
+++ b/pybind_interface/Dockerfile
@@ -1,5 +1,5 @@
 # Base OS
-FROM qsim
+FROM qsim-base AS qsim-py-tests
 
 # Copy relevant files
 COPY ./pybind_interface/ /qsim/pybind_interface/

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,5 +1,5 @@
 # Base OS
-FROM qsim
+FROM qsim-base AS qsim-cxx-tests
 
 # Copy relevant files
 COPY ./tests/ /qsim/tests/

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -70,19 +70,19 @@ custatevec-tests: $(CUSTATEVEC_TARGETS)
 hip-tests: $(HIP_TARGETS)
 
 .PHONY: run-cxx-tests
-run-cxx-tests: cxx-tests
+run-cxx-tests: | $(GTEST_DIR)/build cxx-tests
 	for exe in $(CXX_TARGETS); do if ! ./$$exe; then exit 1; fi; done
 
 .PHONY: run-cuda-tests
-run-cuda-tests: cuda-tests
+run-cuda-tests: | $(GTEST_DIR)/build cuda-tests
 	for exe in $(CUDA_TARGETS); do if ! ./$$exe; then exit 1; fi; done
 
 .PHONY: run-custatevec-tests
-run-custatevec-tests: custatevec-tests
+run-custatevec-tests: | $(GTEST_DIR)/build custatevec-tests
 	for exe in $(CUSTATEVEC_TARGETS); do if ! ./$$exe; then exit 1; fi; done
 
 .PHONY: run-hip-tests
-run-hip-tests: hip-tests
+run-hip-tests: | $(GTEST_DIR)/build hip-tests
 	for exe in $(HIP_TARGETS); do if ! ./$$exe; then exit 1; fi; done
 
 $(GTEST_DIR)/build:


### PR DESCRIPTION
Docker builds on GitHub are failing with the problem that Docker build is trying to get qsim images from docker.io:

```
#1 [internal] load local bake definitions
#1 reading from stdin 935B done
#1 DONE 0.0s

#2 [qsim internal] load build definition from Dockerfile
#2 transferring dockerfile: 1.34kB done
#2 DONE 0.0s

#3 [qsim-py-tests internal] load build definition from Dockerfile
#3 transferring dockerfile: 381B done
#3 DONE 0.0s

#4 [qsim-cxx-tests internal] load build definition from Dockerfile
#4 transferring dockerfile: 208B done
#4 DONE 0.0s

#5 [qsim-cxx-tests internal] load metadata for #docker.io/library/qsim:latest
```

Apparently, this happens because the `buildx` plugin, which is the default builder in many modern Docker setups, can build images in parallel and uses an isolated builder environment. An image built for one service (like `qsim`): might not be immediately loaded into the local Docker daemon's image store. When the build for a dependent service (like `qsim-cxx-tests`) starts, it can't find the `qsim` base image locally and falls back to searching Docker Hub.

This is despite the fact that a plain `docker compose build` locally (at least in my Debian Linux environment) works as expected.

After a lot of trial and error, the only solution I could find is to split up the `docker compose build …` into 2 steps, the first being to build the qsim base image separately:

```yaml
- name: Build Docker images
  run: |
    docker compose build qsim-base-image
    docker compose build qsim-cxx-tests-image qsim-py-tests-image
```

In addition to this change, in the process of debugging this I found it useful to make some housekeeping changes to the `Dockerfile` and `docker-compose.yml` files, in particular to change the names of jobs and images to distinguish the different things being run or built. (Having several things all named `qsim` was not helpful.)

Noting here what else I tried and that didn't work:

* What I thought would be the obvious solution (i.e., using the command-line argument `--parallel 1` or setting the env var `COMPOSE_PARALLEL_LIMIT` to tell `buildx` not to build in parallel) did not work on GitHub. Since I can't reproduce the problem locally, I can't be sure if that would have solved it anyway.

* Trying to use the buildx `bake` command first, like this:

  ```shell
  docker buildx bake --load --progress=plain -f docker-compose.yml
  docker compose build
  ```

* Trying to clear the Docker cache.
