### PR TITLE
Fix handling of skippable execution

### DIFF
--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -49,10 +49,6 @@ jobs:
     secrets: inherit
 
   build-wheels:
-    # For efficiency, skip this workflow if there were no code file changes.
-    if: >-
-      ${{needs.find-changes.outputs.code == 'true'
-         || github.event_name == 'workflow_dispatch'}}
     name: ${{matrix.conf.os}}/${{matrix.conf.pyarch}}/py3${{matrix.conf.py}}
     needs: find-changes
     runs-on: ${{matrix.conf.os}}
@@ -90,6 +86,12 @@ jobs:
       # Must use explicit test for true so it works when inputs.debug is null.
       use-verbose: ${{github.event.inputs.debug == true}}
     steps:
+      - if: >-
+          ${{needs.find-changes.outputs.code == 'false'
+            && github.event_name != 'workflow_dispatch'}}
+        name: Exit early if there were no changes to code files
+        run: exit 0
+
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -48,8 +48,8 @@ jobs:
     uses: ./.github/workflows/_find_changes.yaml
     secrets: inherit
 
-  build-wheels:
-    name: ${{matrix.conf.os}}/${{matrix.conf.pyarch}}/py3${{matrix.conf.py}}
+  build-library:
+    name: Build for ${{matrix.conf.os}}/${{matrix.conf.pyarch}}/py3${{matrix.conf.py}}
     needs: find-changes
     runs-on: ${{matrix.conf.os}}
     timeout-minutes: 30

--- a/.github/workflows/ci_build_wheels.yaml
+++ b/.github/workflows/ci_build_wheels.yaml
@@ -48,8 +48,20 @@ jobs:
     uses: ./.github/workflows/_find_changes.yaml
     secrets: inherit
 
+  build-wheels-skip:
+    if: >-
+      ${{needs.find-changes.outputs.code == 'false'
+        && github.event_name != 'workflow_dispatch'}}
+    # Important: the name must be the same as that of the build-wheels job.
+    name: Build & test wheels
+    needs: find-changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Exit with success if there were no changes to code files
+        run: exit 0
+
   build-wheels:
-    # For efficiency, skip this workflow if there were no code file changes.
     if: >-
       ${{needs.find-changes.outputs.code == 'true'
          || github.event_name == 'workflow_dispatch'}}

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -49,11 +49,7 @@ jobs:
     secrets: inherit
 
   build-and-test:
-    # For efficiency, skip this workflow if there were no code file changes.
-    if: >-
-      ${{needs.find-changes.outputs.code == 'true'
-         || github.event_name == 'workflow_dispatch'}}
-    name: Build and test Docker images
+    name: Build & test Docker images
     needs: find-changes
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -61,6 +57,12 @@ jobs:
       # The next environment variable is used by Docker.
       BUILDKIT_PROGRESS: ${{inputs.debug && 'plain' || ''}}
     steps:
+      - if: >-
+          ${{needs.find-changes.outputs.code == 'false'
+            && github.event_name != 'workflow_dispatch'}}
+        name: Exit early if there were no changes to code files
+        run: exit 0
+
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/ci_format_checks.yml
+++ b/.github/workflows/ci_format_checks.yml
@@ -49,10 +49,6 @@ jobs:
     secrets: inherit
 
   check-format:
-    # For efficiency, skip this workflow if there were no Python file changes.
-    if: >-
-      ${{needs.find-changes.outputs.python == 'true'
-         || github.event_name == 'workflow_dispatch'}}
     name: Python format check
     needs: find-changes
     runs-on: ubuntu-24.04
@@ -61,6 +57,12 @@ jobs:
       # Add xtrace to SHELLOPTS for all Bash scripts when doing debug runs.
       SHELLOPTS: ${{inputs.debug && 'xtrace' || '' }}
     steps:
+      - if: >-
+          ${{needs.find-changes.outputs.python == 'false'
+            && github.event_name != 'workflow_dispatch'}}
+        name: Exit early if there were no changes to code files
+        run: exit 0
+
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/ci_hardware_options.yaml
+++ b/.github/workflows/ci_hardware_options.yaml
@@ -49,10 +49,6 @@ jobs:
     secrets: inherit
 
   test-options:
-    # For efficiency, skip this workflow if there were no code file changes.
-    if: >-
-      ${{needs.find-changes.outputs.code == 'true'
-         || github.event_name == 'workflow_dispatch'}}
     name: Test ${{matrix.hardware_opt}} + ${{matrix.parallel_opt}}
     needs: find-changes
     runs-on: ubuntu-24.04
@@ -67,6 +63,12 @@ jobs:
       # Must use explicit test for true so it works when inputs.debug is null.
       use-verbose: ${{github.event.inputs.debug == true}}
     steps:
+      - if: >-
+          ${{needs.find-changes.outputs.code == 'false'
+            && github.event_name != 'workflow_dispatch'}}
+        name: Exit early if there were no changes to code files
+        run: exit 0
+
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/ci_sanitizer_tests.yaml
+++ b/.github/workflows/ci_sanitizer_tests.yaml
@@ -49,10 +49,6 @@ jobs:
     secrets: inherit
 
   sanitizer-tests:
-    # For efficiency, skip this workflow if there were no code file changes.
-    if: >-
-      ${{needs.find-changes.outputs.code == 'true'
-         || github.event_name == 'workflow_dispatch'}}
     name: Test with sanitizers
     needs: find-changes
     runs-on: ubuntu-24.04
@@ -65,6 +61,12 @@ jobs:
       # Must use explicit test for true so it works when inputs.debug is null.
       use-verbose: ${{github.event.inputs.debug == true}}
     steps:
+      - if: >-
+          ${{needs.find-changes.outputs.code == 'false'
+            && github.event_name != 'workflow_dispatch'}}
+        name: Exit early if there were no changes to code files
+        run: exit 0
+
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/ci_tcmalloc_test.yaml
+++ b/.github/workflows/ci_tcmalloc_test.yaml
@@ -49,10 +49,6 @@ jobs:
     secrets: inherit
 
   tcmalloc-test:
-    # For efficiency, skip this workflow if there were no code file changes.
-    if: >-
-      ${{needs.find-changes.outputs.code == 'true'
-         || github.event_name == 'workflow_dispatch'}}
     name: Test with TCMalloc
     needs: find-changes
     runs-on: ubuntu-24.04
@@ -61,6 +57,12 @@ jobs:
       # Must use explicit test for true so it works when inputs.debug is null.
       use-verbose: ${{github.event.inputs.debug == true}}
     steps:
+      - if: >-
+          ${{needs.find-changes.outputs.code == 'false'
+            && github.event_name != 'workflow_dispatch'}}
+        name: Exit early if there were no changes to code files
+        run: exit 0
+
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
The way the conditionals were set up before was never right, and workflows would always execute even if they didn't need to. This should fix the logic.