### PR TITLE
Rename workflows more consistently

### DIFF
--- a/.github/workflows/ci_build_wheels.yaml
+++ b/.github/workflows/ci_build_wheels.yaml
@@ -53,7 +53,7 @@ jobs:
       ${{needs.find-changes.outputs.code == 'false'
         && github.event_name != 'workflow_dispatch'}}
     # Important: the name must be the same as that of the build-wheels job.
-    name: Build & test wheels
+    name: Build & verify wheels
     needs: find-changes
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -65,7 +65,7 @@ jobs:
     if: >-
       ${{needs.find-changes.outputs.code == 'true'
          || github.event_name == 'workflow_dispatch'}}
-    name: Build & test wheels
+    name: Build & verify wheels
     needs: find-changes
     uses: ./.github/workflows/_build_wheels.yaml
     secrets: inherit

--- a/.github/workflows/ci_format_checks.yml
+++ b/.github/workflows/ci_format_checks.yml
@@ -49,7 +49,7 @@ jobs:
     secrets: inherit
 
   check-format:
-    name: Python format check
+    name: Check Python code format
     needs: find-changes
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/ci_hardware_options.yaml
+++ b/.github/workflows/ci_hardware_options.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'CI: test with different hardware options'
+name: 'CI: test hardware options'
 run-name: Test with instruction set extensions and parallelism
 
 on:


### PR DESCRIPTION
The workflow names did not follow a consistent pattern when viewed in the CI checks settings for the repository.