### PR TITLE
Use new approach to exiting workflows early

### DIFF
--- a/.github/workflows/_success.yaml
+++ b/.github/workflows/_success.yaml
@@ -1,0 +1,33 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Trivial workflow called by other workflows as a kind of no-op-with-success.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: '~ Return success'
+run-name: Return success
+
+on:
+  workflow_call:
+
+permissions: read-all
+
+jobs:
+  finish-with-success:
+    name: Finish successfully
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - run: exit 0

--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -38,7 +38,6 @@ on:
 permissions: read-all
 
 concurrency:
-  # Cancel any previously-started but still active runs on the same branch.
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
 
@@ -48,8 +47,16 @@ jobs:
     uses: ./.github/workflows/_find_changes.yaml
     secrets: inherit
 
+  build-library-skip:
+    if: ${{needs.find-changes.outputs.code == 'false' && ! inputs.debug}}
+    needs: find-changes
+    uses: ./.github/workflows/_success.yaml
+    # Important: the name must be identical to that of the non-skip job below.
+    name: Build library
+
   build-library:
-    name: Build for ${{matrix.conf.os}}/${{matrix.conf.pyarch}}/py3${{matrix.conf.py}}
+    if: ${{needs.find-changes.outputs.code == 'true' || inputs.debug}}
+    name: Build library
     needs: find-changes
     runs-on: ${{matrix.conf.os}}
     timeout-minutes: 30
@@ -83,15 +90,8 @@ jobs:
           {os: windows-2025, pyarch: x64, py: 13},
         ]
     env:
-      # Must use explicit test for true so it works when inputs.debug is null.
-      use-verbose: ${{github.event.inputs.debug == true}}
+      use-verbose: ${{inputs.debug}}
     steps:
-      - if: >-
-          ${{needs.find-changes.outputs.code == 'false'
-            && github.event_name != 'workflow_dispatch'}}
-        name: Exit early if there were no changes to code files
-        run: exit 0
-
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -125,7 +125,7 @@ jobs:
       - if: matrix.conf.os != 'windows-2025'
         name: Run the build and test script (non-Windows case)
         env:
-      # Add xtrace to SHELLOPTS for all Bash scripts when doing debug runs.
+          # Add xtrace to SHELLOPTS for all Bash scripts when doing debug runs.
           SHELLOPTS: ${{inputs.debug && 'xtrace' || '' }}
         run: dev_tools/test_libs.sh ${{env.use-verbose && '--config=verbose'}}
 

--- a/.github/workflows/ci_build_wheels.yaml
+++ b/.github/workflows/ci_build_wheels.yaml
@@ -53,7 +53,7 @@ jobs:
       ${{needs.find-changes.outputs.code == 'false'
         && github.event_name != 'workflow_dispatch'}}
     # Important: the name must be the same as that of the build-wheels job.
-    name: Build & test wheels
+    name: Build & verify wheels
     needs: find-changes
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -65,7 +65,7 @@ jobs:
     if: >-
       ${{needs.find-changes.outputs.code == 'true'
          || github.event_name == 'workflow_dispatch'}}
-    name: Build & test wheels
+    name: Build & verify wheels
     needs: find-changes
     uses: ./.github/workflows/_build_wheels.yaml
     secrets: inherit

--- a/.github/workflows/ci_build_wheels.yaml
+++ b/.github/workflows/ci_build_wheels.yaml
@@ -38,7 +38,6 @@ on:
 permissions: read-all
 
 concurrency:
-  # Cancel any previously-started but still active runs on the same branch.
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
 
@@ -49,22 +48,14 @@ jobs:
     secrets: inherit
 
   build-wheels-skip:
-    if: >-
-      ${{needs.find-changes.outputs.code == 'false'
-        && github.event_name != 'workflow_dispatch'}}
-    # Important: the name must be the same as that of the build-wheels job.
-    name: Build & verify wheels
+    if: ${{needs.find-changes.outputs.code == 'false' && ! inputs.debug}}
     needs: find-changes
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - name: Exit with success if there were no changes to code files
-        run: exit 0
+    uses: ./.github/workflows/_success.yaml
+    # Important: the name must be identical to that of the non-skip job below.
+    name: Build & verify wheels
 
   build-wheels:
-    if: >-
-      ${{needs.find-changes.outputs.code == 'true'
-         || github.event_name == 'workflow_dispatch'}}
+    if: ${{needs.find-changes.outputs.code == 'true' || inputs.debug}}
     name: Build & verify wheels
     needs: find-changes
     uses: ./.github/workflows/_build_wheels.yaml

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -38,7 +38,6 @@ on:
 permissions: read-all
 
 concurrency:
-  # Cancel any previously-started but still active runs on the same branch.
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
 
@@ -48,7 +47,15 @@ jobs:
     uses: ./.github/workflows/_find_changes.yaml
     secrets: inherit
 
+  build-and-test-skip:
+    if: ${{needs.find-changes.outputs.code == 'false' && ! inputs.debug}}
+    needs: find-changes
+    uses: ./.github/workflows/_success.yaml
+    # Important: the name must be identical to that of the non-skip job below.
+    name: Build & test Docker images
+
   build-and-test:
+    if: ${{needs.find-changes.outputs.code == 'true' || inputs.debug}}
     name: Build & test Docker images
     needs: find-changes
     runs-on: ubuntu-24.04
@@ -57,12 +64,6 @@ jobs:
       # The next environment variable is used by Docker.
       BUILDKIT_PROGRESS: ${{inputs.debug && 'plain' || ''}}
     steps:
-      - if: >-
-          ${{needs.find-changes.outputs.code == 'false'
-            && github.event_name != 'workflow_dispatch'}}
-        name: Exit early if there were no changes to code files
-        run: exit 0
-
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/ci_format_checks.yml
+++ b/.github/workflows/ci_format_checks.yml
@@ -49,7 +49,7 @@ jobs:
     secrets: inherit
 
   check-format:
-    name: Python format check
+    name: Check Python code format
     needs: find-changes
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/ci_format_checks.yml
+++ b/.github/workflows/ci_format_checks.yml
@@ -38,7 +38,6 @@ on:
 permissions: read-all
 
 concurrency:
-  # Cancel any previously-started but still active runs on the same branch.
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
 
@@ -48,7 +47,15 @@ jobs:
     uses: ./.github/workflows/_find_changes.yaml
     secrets: inherit
 
+  check-format-skip:
+    if: ${{needs.find-changes.outputs.python == 'false' && ! inputs.debug}}
+    needs: find-changes
+    uses: ./.github/workflows/_success.yaml
+    # Important: the name must be identical to that of the non-skip job below.
+    name: Check Python code format
+
   check-format:
+    if: ${{needs.find-changes.outputs.python == 'true' || inputs.debug}}
     name: Check Python code format
     needs: find-changes
     runs-on: ubuntu-24.04
@@ -57,12 +64,6 @@ jobs:
       # Add xtrace to SHELLOPTS for all Bash scripts when doing debug runs.
       SHELLOPTS: ${{inputs.debug && 'xtrace' || '' }}
     steps:
-      - if: >-
-          ${{needs.find-changes.outputs.python == 'false'
-            && github.event_name != 'workflow_dispatch'}}
-        name: Exit early if there were no changes to code files
-        run: exit 0
-
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/ci_hardware_options.yaml
+++ b/.github/workflows/ci_hardware_options.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'CI: test with different hardware options'
+name: 'CI: test hardware options'
 run-name: Test with instruction set extensions and parallelism
 
 on:

--- a/.github/workflows/ci_hardware_options.yaml
+++ b/.github/workflows/ci_hardware_options.yaml
@@ -38,7 +38,6 @@ on:
 permissions: read-all
 
 concurrency:
-  # Cancel any previously-started but still active runs on the same branch.
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
 
@@ -48,8 +47,16 @@ jobs:
     uses: ./.github/workflows/_find_changes.yaml
     secrets: inherit
 
+  test-options-skip:
+    if: ${{needs.find-changes.outputs.code == 'false' && ! inputs.debug}}
+    needs: find-changes
+    uses: ./.github/workflows/_success.yaml
+    # Important: the name must be identical to that of the non-skip job below.
+    name: Test hardware options
+
   test-options:
-    name: Test ${{matrix.hardware_opt}} + ${{matrix.parallel_opt}}
+    if: ${{needs.find-changes.outputs.code == 'true' || inputs.debug}}
+    name: Test hardware options
     needs: find-changes
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -60,15 +67,8 @@ jobs:
         # Optimizers for parallelism.
         parallel_opt: [openmp, nopenmp]
     env:
-      # Must use explicit test for true so it works when inputs.debug is null.
-      use-verbose: ${{github.event.inputs.debug == true}}
+      use-verbose: ${{inputs.debug}}
     steps:
-      - if: >-
-          ${{needs.find-changes.outputs.code == 'false'
-            && github.event_name != 'workflow_dispatch'}}
-        name: Exit early if there were no changes to code files
-        run: exit 0
-
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/ci_sanitizer_tests.yaml
+++ b/.github/workflows/ci_sanitizer_tests.yaml
@@ -38,7 +38,6 @@ on:
 permissions: read-all
 
 concurrency:
-  # Cancel any previously-started but still active runs on the same branch.
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
 
@@ -48,7 +47,15 @@ jobs:
     uses: ./.github/workflows/_find_changes.yaml
     secrets: inherit
 
+  sanitizer-tests-skip:
+    if: ${{needs.find-changes.outputs.code == 'false' && ! inputs.debug}}
+    needs: find-changes
+    uses: ./.github/workflows/_success.yaml
+    # Important: the name must be identical to that of the non-skip job below.
+    name: Test with sanitizers
+
   sanitizer-tests:
+    if: ${{needs.find-changes.outputs.code == 'true' || inputs.debug}}
     name: Test with sanitizers
     needs: find-changes
     runs-on: ubuntu-24.04
@@ -58,15 +65,8 @@ jobs:
         # Memory and address sanitizers.
         sanitizer_opt: [msan, asan]
     env:
-      # Must use explicit test for true so it works when inputs.debug is null.
-      use-verbose: ${{github.event.inputs.debug == true}}
+      use-verbose: ${{inputs.debug}}
     steps:
-      - if: >-
-          ${{needs.find-changes.outputs.code == 'false'
-            && github.event_name != 'workflow_dispatch'}}
-        name: Exit early if there were no changes to code files
-        run: exit 0
-
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/ci_tcmalloc_test.yaml
+++ b/.github/workflows/ci_tcmalloc_test.yaml
@@ -38,7 +38,6 @@ on:
 permissions: read-all
 
 concurrency:
-  # Cancel any previously-started but still active runs on the same branch.
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
 
@@ -48,21 +47,22 @@ jobs:
     uses: ./.github/workflows/_find_changes.yaml
     secrets: inherit
 
+  tcmalloc-test-skip:
+    if: ${{needs.find-changes.outputs.code == 'false' && ! inputs.debug}}
+    needs: find-changes
+    uses: ./.github/workflows/_success.yaml
+    # Important: the name must be identical to that of the non-skip job below.
+    name: Test with TCMalloc
+
   tcmalloc-test:
+    if: ${{needs.find-changes.outputs.code == 'true' || inputs.debug}}
     name: Test with TCMalloc
     needs: find-changes
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
-      # Must use explicit test for true so it works when inputs.debug is null.
-      use-verbose: ${{github.event.inputs.debug == true}}
+      use-verbose: ${{inputs.debug}}
     steps:
-      - if: >-
-          ${{needs.find-changes.outputs.code == 'false'
-            && github.event_name != 'workflow_dispatch'}}
-        name: Exit early if there were no changes to code files
-        run: exit 0
-
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
Stopping GitHub Actions workflows early with success is difficult, because the only direct mechanisms provided by GitHub for early exit is when there's an error. This PR implements it via an indirect but reasonably easy fashion.