### PR TITLE
Fix the shell script indentation -- should be 4, not 2

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Basic clang-format config for this project.
+
+# Summary: configure clang-format for this project.
 # See https://clang.llvm.org/docs/ClangFormatStyleOptions.html for more info.
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Note: if you change line length or indentation here, update .editorconfig too.
 ---
 Language: Cpp
 BasedOnStyle: Google

--- a/.editorconfig
+++ b/.editorconfig
@@ -38,6 +38,9 @@ indent_size = 4
 [{CMakeLists.txt,*.cmake}]
 indent_size = 4
 
+[{Makefile,makefile,*.mk}]
+indent_size = 4
+
 [{*.cc,*.h}]
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Common editor configurations for this project.
-#
-# EditorConfig is a file format for specifying some common style parameters.
+# Summary: define basic code editor style parameters for this project.
+
 # Many IDEs & editors read .editorconfig files, either natively or via plugins.
 # We mostly follow Google's style guides (https://google.github.io/styleguide/)
 # with only a few deviations for line length and indentation in some files.
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 root = true
 
@@ -51,7 +48,7 @@ indent_size = 2
 indent_size = 4
 
 [*.sh]
-indent_size = 2
+indent_size = 4
 
 [{*.yaml,*.yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -39,6 +39,7 @@ indent_size = 4
 indent_size = 4
 
 [{Makefile,makefile,*.mk}]
+indent_style = tab
 indent_size = 4
 
 [{*.cc,*.h}]

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Hadolint (a Dockerfile linter) used in this project's CI checks.
+# Summary: configure the Dockerfile linter "hadolint" for this project.
 # Info about options can be found at https://github.com/hadolint/hadolint/.
 # Rule/error numbers are described at https://github.com/hadolint/hadolint/wiki
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 format: tty
 no-color: false

--- a/.jsonlintrc.yaml
+++ b/.jsonlintrc.yaml
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Project configuration for jsonlint (https://github.com/prantlf/jsonlint).
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Summary: configure https://github.com/prantlf/jsonlint for this project.
 
 comments: false
 compact: true
 continue: true
 endOfLine: lf
+# Note: if you change indentation or line length, update .editorconfig too.
 indent: 2
 log-files: false
 no-duplicate-keys: true

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -13,8 +13,7 @@
   // See the License for the specific language governing permissions and
   // limitations under the License.
 
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // Markdownlint linter configuration for this project.
+  // Summary: configure markdownlint for this project.
   //
   // Note: there are multiple programs programs named "markdownlint". We use
   // https://github.com/igorshubovych/markdownlint-cli/, which is the one you
@@ -28,7 +27,6 @@
   // https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
   // (Beware that the above looks similar but is NOT the same as the page
   // https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md.)
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
 

--- a/.yamlfmt.yaml
+++ b/.yamlfmt.yaml
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# yamlfmt configuration for this project.
+# Summary: configure yamlfmt for this project.
 # See https://github.com/google/yamlfmt for info about options.
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Read .gitignore for paths to exclude.
 gitignore_excludes: true
@@ -23,6 +21,7 @@ gitignore_excludes: true
 formatter:
   type: basic
   eof_newline: true
+# Note: if you change the line length here, update .editorconfig too.
   max_line_length: 80
   retain_line_breaks: true
   trim_trailing_whitespace: true

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Yamllint configuration to match project settings like line length.
+# Summary: configure yamllint for this project.
 # See https://yamllint.readthedocs.io/ for info about configuration options.
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 rules:
   line-length:
+    # Note: if you change the line length here, update .editorconfig too.
     max: 80
     # When the last item on a line can't be broken (e.g., a URL as a value),
     # it's rarely useful to flag it. The next 2 settings save developer time by


### PR DESCRIPTION
Changes:

* Fix the value for shell indentation in `.editorconfig`. It was incorrectly set to 2, and should be 4 instead.
* Add missing setting for makefiles in `.editorconfig`.
* In some other files, the relevant value of a linter configuration property should match the value of the editor configuration in `.editorconfig`. To help us remember this, I added appropriate comments to other config files.
* In reviewing the files, I now feel that the introductory comments at the tops of several files were too verbose and needlessly hard to maintain. I streamlined the comments.