### PR TITLE
Fix #886: avoid Bash-isms in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,9 +171,9 @@ run-tests tests: $(TESTS)
 
 .PHONY: check-cuquantum-root-set
 check-cuquantum-root-set:
-	@if [[ -z "$(CUQUANTUM_ROOT)" ]]; then \
-	    echo Error: '$$CUQUANTUM_ROOT must be set in order to use cuStateVec.' \
-	    exit 1 \
+	@if [ -z "$(CUQUANTUM_ROOT)" ]; then \
+	    echo Error: '$$CUQUANTUM_ROOT must be set in order to use cuStateVec.'; \
+	    exit 1; \
 	fi
 
 eigen:


### PR DESCRIPTION
The shell script fragment for `check-cuquantum-root-set` used Bash syntax, and this failed on some Linux systems. This simply rewrites it to use POSIX syntax.