### PR TITLE
Increase workflow timeouts

### DIFF
--- a/.github/workflows/_build_wheels.yaml
+++ b/.github/workflows/_build_wheels.yaml
@@ -49,7 +49,7 @@ jobs:
   build-wheels:
     name: Build on ${{matrix.conf.os}}/${{matrix.conf.arch}}
     runs-on: ${{matrix.conf.os}}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -53,7 +53,7 @@ jobs:
     needs: find-changes
     runs-on: ${{matrix.conf.os}}
     continue-on-error: true
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_docker_tests.yaml
+++ b/.github/workflows/ci_docker_tests.yaml
@@ -53,7 +53,7 @@ jobs:
     needs: find-changes
     runs-on: ubuntu-24.04
     continue-on-error: true
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       # The next environment variable is used by Docker.
       BUILDKIT_PROGRESS: ${{inputs.debug && 'plain' || ''}}

--- a/.github/workflows/ci_hardware_options.yaml
+++ b/.github/workflows/ci_hardware_options.yaml
@@ -53,7 +53,7 @@ jobs:
     needs: find-changes
     runs-on: ubuntu-24.04
     continue-on-error: true
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       matrix:
         # Hardware optimizers.

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -59,7 +59,7 @@ jobs:
     if: github.repository_owner == 'quantumlib'
     name: OSV scanner
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       # Needed to upload the results to code-scanning dashboard:
       security-events: write

--- a/.github/workflows/release_wheels.yml
+++ b/.github/workflows/release_wheels.yml
@@ -41,7 +41,7 @@ jobs:
     name: Publish wheels
     needs: build-wheels
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
     - name: Retrieve saved wheels
       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0


### PR DESCRIPTION
Some of the workflows are taking unexpectedly long to run on GitHub. (It appears to have to do with dependency installation, and not qsim itself.) We may as well increase the timeouts; doing so does not really harm our status checks.