### PR TITLE
Fix #930: add a `.gemini/styleguide.md` for Gemini Code Assist

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -246,7 +246,7 @@ Unit and integration tests can be run for the Python portions of this project
 using the following command:
 
 ```shell
-make run-py-tests
+make -j run-py-tests
 ```
 
 ## C++-specific guidance
@@ -254,6 +254,17 @@ make run-py-tests
 This section outlines coding conventions for C++ code in this project.
 
 ### C++ naming conventions
+
+*   _Variables_: Use lowercase with underscores (snake_case). Examples:
+    `user_name`, `total_count`.
+
+*   _Functions_: Use CapWords (CamelCase). Examples: `PrintAmplitudes`,
+    `FillIndices,`.
+
+*   _Classes_/_Structs_: Use CapWords (CamelCase). Examples: `UserManager`,
+    `PaymentProcessor`.
+
+*   _Namespaces_: Use snake_case.
 
 *   _Domain-specific terms_:
 
@@ -276,11 +287,11 @@ Note: the C++ code files use 80-column line widths. (The Python files use 88.)
 If you only want to run tests for the core C++ libraries, use this command:
 
 ```shell
-make run-cxx-tests
+bazel test tests:all
 ```
 
 To build tests without running them, instead use:
 
 ```shell
-make cxx-tests
+bzel build tests:all
 ```


### PR DESCRIPTION
Add a guide for Gemini Code Assist to teach it about the conventions used in this project.

[Gemini Code Assist](https://codeassist.google/) is a coding assistant based on Google Gemini. Among other things, it has an [integration with GitHub](https://developers.google.com/gemini-code-assist/docs/set-up-code-assist-github). Google has enabled it in our organization. It acts as a [code reviewer for pull requests](https://developers.google.com/gemini-code-assist/docs/review-github-code). Its behavior can be [customized](https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github) to some extent, and it can be informed about the practices and conventions used in a project through the use of a [styleguide.md file](https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github#styleguide.md).

The `styleguide.md` file in this PR is essentially a draft contributors' guide for the qsim project. The contents can serve as a starting point for adding a section to the qsim documentation.