### PR TITLE
Add initial `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,10 @@
+# git-blame can be instructed to ignore certain commits, which is useful to do
+# for commits that only involve large refactoring and reformatting operations.
+# The format of this file is one full 40-character commit hash (SHA-1) per line.
+# Blank lines and comments (such as this) are allowed.
+#
+# Usage: run the following command to configure git to use this file as a
+# default ignore file for git blame:
+#
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#


### PR DESCRIPTION
This is a currently-empty ignore file for `git blame`. I want to add it now in anticipation of doing some reformatting operations, so that I can add documentation about its use to the contribution guidelines.