### PR TITLE
Fix #935: warning in gate_appl.h

### DIFF
--- a/lib/gate_appl.h
+++ b/lib/gate_appl.h
@@ -15,6 +15,7 @@
 #ifndef GATE_APPL_H_
 #define GATE_APPL_H_
 
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -221,9 +222,9 @@ inline bool ApplyFusedGate(const typename Simulator::StateSpace& state_space,
                            const Simulator& simulator, const Gate& gate,
                            Rgen& rgen, typename Simulator::State& state) {
   using MeasurementResult = typename Simulator::StateSpace::MeasurementResult;
-  std::vector<MeasurementResult> discarded_results;
+  auto discarded_results = std::make_unique<std::vector<MeasurementResult>>();
   return ApplyFusedGate(
-      state_space, simulator, gate, rgen, state, discarded_results);
+      state_space, simulator, gate, rgen, state, *discarded_results);
 }
 
 }  // namespace qsim


### PR DESCRIPTION
The problem seems to be that `discarded_results` in `ApplyFusedGate` is passed by value to the inner `ApplyFusedGate`. When `std::move(measure_result)` happens inside, it's moving from a stack object into a vector that is also on the stack (because it's a parameter passed by value). Then when the inner `ApplyFusedGate` returns, its copy of `mresults` is destroyed, triggering the warning.

A simple fix for the warning seems to be to simply heap-allocate the `discarded_results` vector in the overload function.