### PR TITLE
Remove use of `macos-13` runners

### DIFF
--- a/.github/workflows/_build_wheels.yaml
+++ b/.github/workflows/_build_wheels.yaml
@@ -55,7 +55,6 @@ jobs:
       matrix:
         conf: [
           {os: ubuntu-24.04, arch: x86_64},
-          {os: macos-13,     arch: x86_64},
           {os: macos-14,     arch: arm64},
           {os: macos-15,     arch: arm64},
           {os: windows-2025, arch: AMD64},

--- a/.github/workflows/ci_build_library.yaml
+++ b/.github/workflows/ci_build_library.yaml
@@ -62,11 +62,6 @@ jobs:
           {os: ubuntu-24.04, pyarch: x64, py: 12},
           {os: ubuntu-24.04, pyarch: x64, py: 13},
 
-          {os: macos-13, pyarch: x64, py: 10},
-          {os: macos-13, pyarch: x64, py: 11},
-          {os: macos-13, pyarch: x64, py: 12},
-          {os: macos-13, pyarch: x64, py: 13},
-
           {os: macos-14, pyarch: arm64, py: 10},
           {os: macos-14, pyarch: arm64, py: 11},
           {os: macos-14, pyarch: arm64, py: 12},


### PR DESCRIPTION
GitHub has started failing jobs that contain them.