### PR TITLE
Need install dev-requirements in test jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -329,7 +329,7 @@ jobs:
             dev-requirements.txt
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt -r dev-requirements.txt
 
       - name: Set up Bazel
         uses: './.github/actions/set-up-bazel'
@@ -384,7 +384,7 @@ jobs:
             dev-requirements.txt
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt -r dev-requirements.txt
 
       - name: Set up Bazel
         uses: './.github/actions/set-up-bazel'


### PR DESCRIPTION
`distutils` is needed by the bazel test jobs, but it was removed in Python 3.12. This is causing those test jobs to fail in CI.

Adding `pip install -r dev-requirements.txt` to those jobs will install `setuptools`, which will in turn satisfy that requirement.