### PR TITLE
Make use of larger GitHub job runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -219,7 +219,7 @@ jobs:
           - ubuntu-24.04-x64-8-core
           - macos-14
           - macos-15
-          - windows-2025-x64-16-core
+          - windows-2025-x64-8-core
         python_version:
           - '3.10'
           - '3.13'


### PR DESCRIPTION
This updates some of the jobs in the CI workflow to use the larger runners we've configured for our org, so that CI runs faster.