### PR TITLE
Add new, larger Windows runners to `.github/actionlint.yaml`

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -34,6 +34,10 @@ self-hosted-runner:
     - ubuntu-24.04-x64-8-core
     - ubuntu-24.04-x64-16-core
 
+    - windows-2022-x64-8-core
+    - windows-2025-x64-8-core
+    - windows-2025-x64-16-core
+
     # From https://github.com/actions/partner-runner-images
     - ubuntu-24.04-arm
 


### PR DESCRIPTION
Windows CI jobs are a bottleneck right now, so I defined larger GitHub-hosted runners. This adds the new names to the actionlint config file so that they are recognized by actionlint.