### PR TITLE
Add configuration for `check-wheel-contents`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,7 @@ skip = "*musllinux*"
 [tool.black]
 target-version = ['py310', 'py311', 'py312', 'py313']
 extend-exclude = 'third_party'
+
+[tool.check-wheel-contents]
+# Ignore false positives due to how cibuildwheel adds object files to the wheel.
+ignore = ["W009", "W010"]


### PR DESCRIPTION
The utility `check-wheel-contents` is useful for checking that wheels are constructed correctly; however, it generates false positives because it doesn’t know about how `cibuildwheel` adds object files to wheels.