### PR TITLE
Add check/pylint

### DIFF
--- a/check/pylint
+++ b/check/pylint
@@ -36,4 +36,4 @@ thisdir=$(dirname "${BASH_SOURCE[0]:?}")
 repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel)
 cd "${repo_dir}"
 
-pylint --jobs=0 --recursive=y --ignore-paths=tests/googletest "$@" .
+pylint --jobs=0 --ignore-paths=tests/googletest "$@" .


### PR DESCRIPTION
This is a simple script to help contributors easily run pylint recursively on the right directories. It also passes `--jobs=0` to make it as fast as possible by default.