### PR TITLE
Go back to ubuntu-24.04 for python-checks job in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ permissions: read-all
 jobs:
   python-checks:
     name: 'Python format & lint checks'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Check out a copy of the git repository


### PR DESCRIPTION
Even though this project does not have many Python files, running `pytest` is still slow, and it looks like using a single-core GitHub `ubuntu-slim` runner for that job was a mistake. Let's go back to using the 4-core default so that `pytest` can use parallelism.