### PR TITLE
Add configuration for isort to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,11 @@ skip = "*musllinux*"
 [tool.black]
 target-version = ['py310', 'py311', 'py312', 'py313']
 extend-exclude = 'third_party'
+
+[tool.isort]
+profile = 'black'
+order_by_type = false  # Sort alphabetically, irrespective of case.
+skip_gitignore = true
+combine_as_imports = true
+known_first_party = ["qsimcirq*"]
+extend_skip = ["__init__.py"]


### PR DESCRIPTION
`isort` is used in `check/format-incremental`, but there is no configuration for it. This adds a configuration based on what Cirq currently uses.