### PR TITLE
Add workflow and script to clean Dependabot description bodies

### DIFF
--- a/.github/workflows/dependabot-pr-cleaner.yaml
+++ b/.github/workflows/dependabot-pr-cleaner.yaml
@@ -71,7 +71,7 @@ jobs:
           with open("body.txt", "r", encoding="utf-8") as f:
             content = f.read()
 
-          # Look for the commits list and delete it and everything after it.
+          # Delete everything starting with the commits list onward.
           commits_start_re = r"<details>\s*<summary>Commits</summary>"
           content = re.split(commits_start_re, content, flags=re.IGNORECASE)[0]
 


### PR DESCRIPTION
This adds a simple work to clean up the Dependabot description bodies to remove unwanted sections (like the list of commands) and convert the HTML body to Markdown. 

The algorithm is simple: look for `<details><summary>Commits</summary>`, which marks the beginning of a section listing the commits in the upstream repository, and just delete everything in the Dependabot description from that point to the end. This gets rid of the commits list, the Dependabot command summary, and miscellaneous other bits that we don't find useful.