### PR TITLE
Fix Makefile handling of user CXXFLAGS & also add a DEBUG flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,19 @@ CXXFLAGS := $(BASE_CXXFLAGS) $(CXXFLAGS)
 NVCCFLAGS := $(BASE_NVCCFLAGS) $(NVCCFLAGS)
 HIPCCFLAGS := $(BASE_HIPCCFLAGS) $(HIPCCFLAGS)
 
+LTO_FLAGS := -flto=auto
+USING_CLANG := $(shell $(CXX) --version | grep -isq clang && echo "true")
+ifeq ($(USING_CLANG),"true")
+	LTO_FLAGS := -flto
+endif
+
 ifdef DEBUG
     DEBUG_FLAGS := -g -O0
     CXXFLAGS += $(DEBUG_FLAGS)
     NVCCFLAGS += $(DEBUG_FLAGS)
     HIPCCFLAGS += $(DEBUG_FLAGS)
 else
-    CXXFLAGS += -O3 -flto=auto
+    CXXFLAGS += -O3 $(LTO_FLAGS)
     NVCCFLAGS += -O3
     HIPCCFLAGS += -O3
 endif


### PR DESCRIPTION
The way `CXXFLAGS` and other flags were being set meant that users had to add the default values (`-std=c++17 -fopenmp -O3` etc) if they set the flags at all, or else lose the defaults. This was error-prone and suboptimal. The change here makes it so that the user values are appended at the end of the defaults, so that they can override values.

This PR also adds a DEBUG flag that switches between using `-g -O0` and the regular `-O3` option. Developers can invoke it using, e.g., `make DEBUG=1`.