### PR TITLE
In `setup.py`, don't limit CMake version test to only Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,9 @@ class CMakeBuild(build_ext):
         except subprocess.TimeoutExpired as e:
             raise RuntimeError(f"Command timed out: {e}")
         except OSError as e:
-            raise RuntimeError(f"An OS error occurred when trying to run 'cmake --version': {e}")
+            raise RuntimeError(
+                f"An OS error occurred when trying to run 'cmake --version': {e}"
+            )
 
         for ext in self.extensions:
             self.build_extension(ext)


### PR DESCRIPTION
The `CMakeBuild` class' `run()` method tests the version of CMake; however, it did the test only when on Windows. It seems like this is a test worth doing everywhere, so I removed test for Windows.

In addition, while at it, I slightly updated the way the process output is captured, and expanded the range of exceptions tested in order to provide more specific feedback to users.