### PR TITLE
Constrain package vesions for Python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ cirq-core~=1.0
 # Constrain some versions because they dropped support for Python 3.10.
 # Countourpy is pulled in by Matplotlib, which is pulled in by Cirq.
 contourpy<1.3.0; python_version <= '3.10'
-numpy>=1.26.0,<2.0.0; python_version <= '3.10'
+numpy<2.0.0; python_version <= '3.10'
 numpy>=1.26.0; python_version > '3.10'
 scipy<1.15.0; python_version <= '3.10'


### PR DESCRIPTION
A `pip install -r requirements.txt` has started failing for me in Python 3.10 because the latest versions of some transitive dependencies have dropped support for Python 3.10 (or require Python 3.11+ for their build environments). Constraining Numpy, Contourpy and Scipy resolves the problem.