### PR TITLE
Need setuptools version > 78 in the dev environment too

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dev = [
     # mechanism to reference that list. Keep these versions in sync with above.
     "cmake~=3.28.1",
     "pybind11[global]",
-    "setuptools>=78.1.1; python_version >= '3.12'",
+    "setuptools>=78.1.1",
 
     # Other build, packaging, and distribution utilities.
     "cibuildwheel",


### PR DESCRIPTION
There was an inconsistency in the version of setuptools specified for the development environment and the run-time requirements. (Mea culpa.) Setuptools > 78 is needed in all cases, not just for python 3.12+.