### PR TITLE
Add Python 3.14 to the wheels build list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Quantum Computing",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
@@ -153,7 +154,7 @@ manylinux-i686-image = "manylinux2014"
 skip = "*musllinux*"
 
 [tool.black]
-target-version = ['py310', 'py311', 'py312', 'py313']
+target-version = ['py310', 'py311', 'py312', 'py313', 'py314']
 extend-exclude = 'third_party'
 
 [tool.isort]


### PR DESCRIPTION
In answer to #1017, this adds Python 3.14 to the list of wheels built for qsim.

This does not affect what is on PyPI; updating PyPI needs to be done separately.