### PR TITLE
Tell cibuildwheel to consider Scientific Python wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,14 @@ pytest -n auto -s -v {package}/qsimcirq_tests/qsimcirq_test.py &&
 mv /tmp/qsimcirq {package}
 """
 
+[[tool.cibuildwheel.overrides]]
+# Help increase the chances that pip will find binary wheels for NumPy.
+# See https://cibuildwheel.pypa.io/en/stable/faq/#building-with-numpy
+select = ["cp314*"]
+inherit.environment = "append"
+environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
+environment.PIP_PRERELEASE = "allow"
+
 [tool.cibuildwheel.macos]
 before-build = """
 brew install -q libomp llvm@19 &&


### PR DESCRIPTION
On some OS + Python version combinations, binary wheels of NumPy and/or Pandas are not available, and qsim builds take extra long. Based on a tip described in the cibuildwheel documentation at https://cibuildwheel.pypa.io/en/stable/faq/#building-with-numpy, it can help to configure cibuildwheel such that it tells pip to look for binary wheels in additional locations such as pypi.anaconda.org.