### PR TITLE
Use pytest features to avoid having to use `mv`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,12 +128,9 @@ build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 dependency-versions = "latest"
 enable = ["cpython-prerelease"]
 environment.PIP_PREFER_BINARY = "1"
-# Due to package & module name conflict, temporarily move it away to run tests:
-before-test = "pip install --group dev && mv {package}/qsimcirq /tmp"
-test-command = """
-pytest -n auto -s -v {package}/qsimcirq_tests/qsimcirq_test.py &&
-mv /tmp/qsimcirq {package}
-"""
+before-test = "pip install --group dev"
+# import-mode=importlib prevents local source shadowing when importing qsimcirq.
+test-command = "pytest --import-mode=importlib -n auto -s -v {package}/qsimcirq_tests/qsimcirq_test.py"
 
 [tool.cibuildwheel.macos]
 before-build = """


### PR DESCRIPTION
This updates the `test-command` parameter for cibuildwheel to include the argument `--import-mode=importlib` to pytest. This argument directs pytest not to add the project root to `sys.path` in a way that would cause the local `qsimcirq` source directory to shadow the installed wheel. This makes the manual moving of the directory unnecessary.