### PR TITLE
Refactor gate interface.

### DIFF
--- a/apps/qsim_amplitudes.cc
+++ b/apps/qsim_amplitudes.cc
@@ -25,8 +25,8 @@
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_mqubit.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/io_file.h"
+#include "../lib/operation.h"
 #include "../lib/run_qsim.h"
 #include "../lib/simmux.h"
 #include "../lib/util.h"
@@ -160,7 +160,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
   unsigned maxtime = opt.times.back();
   if (!CircuitQsimParser<IOFile>::FromFile(maxtime, opt.circuit_file,
                                            circuit)) {
@@ -191,7 +191,7 @@ int main(int argc, char* argv[]) {
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
-  using Fuser = MultiQubitGateFuser<IO, GateQSim<float>>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory>;
 
   auto measure = [&opt, &circuit](

--- a/apps/qsim_base.cc
+++ b/apps/qsim_base.cc
@@ -22,8 +22,8 @@
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_mqubit.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/io_file.h"
+#include "../lib/operation.h"
 #include "../lib/run_qsim.h"
 #include "../lib/simmux.h"
 #include "../lib/util_cpu.h"
@@ -114,7 +114,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
   if (!CircuitQsimParser<IOFile>::FromFile(opt.maxtime, opt.circuit_file,
                                            circuit)) {
     return 1;
@@ -144,7 +144,7 @@ int main(int argc, char* argv[]) {
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
-  using Fuser = MultiQubitGateFuser<IO, GateQSim<float>>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory>;
 
   StateSpace state_space = Factory(opt.num_threads).CreateStateSpace();

--- a/apps/qsim_base_cuda.cu
+++ b/apps/qsim_base_cuda.cu
@@ -22,8 +22,8 @@
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_mqubit.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/io_file.h"
+#include "../lib/operation.h"
 #include "../lib/run_qsim.h"
 #include "../lib/simulator_cuda.h"
 
@@ -114,7 +114,7 @@ int main(int argc, char* argv[]) {
 
   using fp_type = float;
 
-  Circuit<GateQSim<fp_type>> circuit;
+  Circuit<Operation<fp_type>> circuit;
   if (!CircuitQsimParser<IOFile>::FromFile(opt.maxtime, opt.circuit_file,
                                            circuit)) {
     return 1;
@@ -140,7 +140,7 @@ int main(int argc, char* argv[]) {
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
-  using Fuser = MultiQubitGateFuser<IO, GateQSim<fp_type>>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory>;
 
   StateSpace::Parameter param1;

--- a/apps/qsim_base_custatevec.cu
+++ b/apps/qsim_base_custatevec.cu
@@ -24,8 +24,8 @@
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_mqubit.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/io_file.h"
+#include "../lib/operation.h"
 #include "../lib/run_qsim.h"
 #include "../lib/simulator_custatevec.h"
 #include "../lib/util_custatevec.h"
@@ -108,7 +108,7 @@ int main(int argc, char* argv[]) {
 
   using fp_type = float;
 
-  Circuit<GateQSim<fp_type>> circuit;
+  Circuit<Operation<fp_type>> circuit;
   if (!CircuitQsimParser<IOFile>::FromFile(opt.maxtime, opt.circuit_file,
                                            circuit)) {
     return 1;
@@ -143,7 +143,7 @@ int main(int argc, char* argv[]) {
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
-  using Fuser = MultiQubitGateFuser<IO, GateQSim<fp_type>>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory>;
 
   Factory factory;

--- a/apps/qsim_base_custatevecex.cu
+++ b/apps/qsim_base_custatevecex.cu
@@ -21,9 +21,9 @@
 
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/formux.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/io_file.h"
 #include "../lib/multiprocess_custatevecex.h"
+#include "../lib/operation.h"
 #include "../lib/run_custatevecex.h"
 #include "../lib/simulator_custatevecex.h"
 #include "../lib/util_custatevec.h"
@@ -106,7 +106,7 @@ int main(int argc, char* argv[]) {
 
   using fp_type = float;
 
-  Circuit<GateQSim<fp_type>> circuit;
+  Circuit<Operation<fp_type>> circuit;
   if (!CircuitQsimParser<IOFile>::FromFile(opt.maxtime, opt.circuit_file,
                                            circuit)) {
     return 1;

--- a/apps/qsim_qtrajectory_cuda.cu
+++ b/apps/qsim_qtrajectory_cuda.cu
@@ -27,8 +27,8 @@
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/expect.h"
 #include "../lib/fuser_mqubit.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/io_file.h"
+#include "../lib/operation.h"
 #include "../lib/qtrajectory.h"
 #include "../lib/run_qsim.h"
 #include "../lib/simulator_cuda.h"
@@ -44,10 +44,10 @@ struct Options {
   unsigned verbosity = 0;
 };
 
-constexpr char usage[] = "usage:\n  ./qsim_qtrajectory_cuda.x "
+constexpr char usage[] = "usage:\n  ./qsim_qtrajectory.x "
                          "-c circuit_file -d times_to_calculate_observables "
                          "-a amplitude_damping_const -p phase_damping_const "
-                         "-t traj0 -n num_trajectories -f max_fused_size "
+                         "-0 traj0 -n num_trajectories -f max_fused_size "
                          "-v verbosity\n";
 
 Options GetOptions(int argc, char* argv[]) {
@@ -59,7 +59,7 @@ Options GetOptions(int argc, char* argv[]) {
     return std::atoi(word.c_str());
   };
 
-  while ((k = getopt(argc, argv, "c:d:a:p:t:n:f:v:")) != -1) {
+  while ((k = getopt(argc, argv, "c:d:a:p:0:n:f:v:")) != -1) {
     switch (k) {
       case 'c':
         opt.circuit_file = optarg;
@@ -73,7 +73,7 @@ Options GetOptions(int argc, char* argv[]) {
       case 'p':
         opt.phase_damp_const = std::atof(optarg);
         break;
-      case 't':
+      case '0':
         opt.traj0 = std::atoi(optarg);
         break;
       case 'n':
@@ -84,7 +84,6 @@ Options GetOptions(int argc, char* argv[]) {
         break;
       case 'v':
         opt.verbosity = std::atoi(optarg);
-        break;
         break;
       default:
         qsim::IO::errorf(usage);
@@ -120,47 +119,52 @@ bool ValidateOptions(const Options& opt) {
   return true;
 }
 
-template <typename Gate, typename Channel1, typename Channel2>
-std::vector<qsim::NoisyCircuit<Gate>> AddNoise(
-    const qsim::Circuit<Gate>& circuit, const std::vector<unsigned>& times,
+template <typename FP, typename Channel1, typename Channel2>
+std::vector<qsim::Circuit<qsim::Operation<FP>>> AddNoise(
+    const qsim::Circuit<qsim::Operation<FP>>& circuit,
+    const std::vector<unsigned>& times,
     const Channel1& channel1, const Channel2& channel2) {
-  std::vector<qsim::NoisyCircuit<Gate>> ncircuits;
+  std::vector<qsim::Circuit<qsim::Operation<FP>>> ncircuits;
   ncircuits.reserve(times.size());
 
-  qsim::NoisyCircuit<Gate> ncircuit;
+  qsim::Circuit<qsim::Operation<FP>> ncircuit;
 
   ncircuit.num_qubits = circuit.num_qubits;
-  ncircuit.channels.reserve(5 * circuit.gates.size());
+  ncircuit.ops.reserve(5 * circuit.ops.size());
 
   unsigned cur_time_index = 0;
 
-  for (std::size_t i = 0; i < circuit.gates.size(); ++i) {
-    const auto& gate = circuit.gates[i];
+  for (std::size_t i = 0; i < circuit.ops.size(); ++i) {
+    const auto& op = circuit.ops[i];
 
-    ncircuit.channels.push_back(qsim::MakeChannelFromGate(3 * gate.time, gate));
+    unsigned time = OpTime(op);
+    const auto& qubits = OpQubits(op);
 
-    for (auto q : gate.qubits) {
-      ncircuit.channels.push_back(channel1.Create(3 * gate.time + 1, q));
+    ncircuit.ops.push_back(op);
+    OpBaseOperation(ncircuit.ops.back()).time = 3 * time;
+
+    for (auto q : qubits) {
+      ncircuit.ops.push_back(channel1.Create(3 * time + 1, q));
     }
 
-    for (auto q : gate.qubits) {
-      ncircuit.channels.push_back(channel2.Create(3 * gate.time + 2, q));
+    for (auto q : qubits) {
+      ncircuit.ops.push_back(channel2.Create(3 * time + 2, q));
     }
 
     unsigned t = times[cur_time_index];
 
-    if (i == circuit.gates.size() - 1 || t < circuit.gates[i + 1].time) {
+    if (i == circuit.ops.size() - 1 || t < OpTime(circuit.ops[i + 1])) {
       ncircuits.push_back(std::move(ncircuit));
 
       ncircuit = {};
 
-      if (i < circuit.gates.size() - 1) {
-        if (circuit.gates[i + 1].time > times.back()) {
+      if (i < circuit.ops.size() - 1) {
+        if (OpTime(circuit.ops[i + 1]) > times.back()) {
           break;
         }
 
         ncircuit.num_qubits = circuit.num_qubits;
-        ncircuit.channels.reserve(5 * circuit.gates.size());
+        ncircuit.ops.reserve(5 * circuit.ops.size());
       }
 
       ++cur_time_index;
@@ -170,13 +174,13 @@ std::vector<qsim::NoisyCircuit<Gate>> AddNoise(
   return ncircuits;
 }
 
-template <typename Gate>
-std::vector<std::vector<qsim::OpString<Gate>>> GetObservables(
+template <typename FP>
+std::vector<std::vector<qsim::OpString<FP>>> GetObservables(
     unsigned num_qubits) {
-  std::vector<std::vector<qsim::OpString<Gate>>> observables;
+  std::vector<std::vector<qsim::OpString<FP>>> observables;
   observables.reserve(num_qubits);
 
-  using X = qsim::GateX<typename Gate::fp_type>;
+  using X = qsim::GateX<FP>;
 
   for (unsigned q = 0; q < num_qubits; ++q) {
     observables.push_back({{{1.0, 0.0}, {X::Create(0, q)}}});
@@ -210,18 +214,16 @@ int main(int argc, char* argv[]) {
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
-  using Gate = GateQSim<fp_type>;
-  using Fuser = MultiQubitGateFuser<IO, Gate>;
-  using FuserQT = MultiQubitGateFuser<IO, const Gate*>;
-  using RunnerQT = QSimRunner<IO, FuserQT, Factory>;
-  using QTSimulator = QuantumTrajectorySimulator<IO, Gate, RunnerQT>;
+  using Fuser = MultiQubitGateFuser<IO>;
+  using Runner = QSimRunner<IO, Fuser, Factory>;
+  using QTSimulator = QuantumTrajectorySimulator<IO, Runner>;
 
   auto opt = GetOptions(argc, argv);
   if (!ValidateOptions(opt)) {
     return 1;
   }
 
-  Circuit<Gate> circuit;
+  Circuit<Operation<fp_type>> circuit;
   unsigned maxtime = opt.times.back();
   if (!CircuitQsimParser<IOFile>::FromFile(maxtime, opt.circuit_file,
                                            circuit)) {
@@ -230,7 +232,7 @@ int main(int argc, char* argv[]) {
 
   if (opt.times.size() == 1
       && opt.times[0] == std::numeric_limits<unsigned>::max()) {
-    opt.times[0] = circuit.gates.back().time;
+    opt.times[0] = OpTime(circuit.ops.back());
   }
 
   StateSpace::Parameter param1;
@@ -256,7 +258,7 @@ int main(int argc, char* argv[]) {
 
   auto noisy_circuits = AddNoise(circuit, opt.times, channel1, channel2);
 
-  auto observables = GetObservables<Gate>(circuit.num_qubits);
+  auto observables = GetObservables<fp_type>(circuit.num_qubits);
 
   std::vector<std::vector<std::vector<std::complex<double>>>> results;
   results.reserve(opt.num_trajectories);

--- a/apps/qsim_von_neumann.cc
+++ b/apps/qsim_von_neumann.cc
@@ -24,8 +24,8 @@
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_mqubit.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/io_file.h"
+#include "../lib/operation.h"
 #include "../lib/run_qsim.h"
 #include "../lib/simmux.h"
 #include "../lib/util_cpu.h"
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
   if (!CircuitQsimParser<IOFile>::FromFile(opt.maxtime, opt.circuit_file,
                                            circuit)) {
     return 1;
@@ -129,7 +129,7 @@ int main(int argc, char* argv[]) {
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
-  using Fuser = MultiQubitGateFuser<IO, GateQSim<float>>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory>;
 
   auto measure = [&opt, &circuit](

--- a/apps/qsimh_amplitudes.cc
+++ b/apps/qsimh_amplitudes.cc
@@ -25,8 +25,8 @@
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_basic.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/io_file.h"
+#include "../lib/operation.h"
 #include "../lib/run_qsimh.h"
 #include "../lib/simmux.h"
 #include "../lib/util.h"
@@ -174,7 +174,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
   if (!CircuitQsimParser<IOFile>::FromFile(opt.maxtime, opt.circuit_file,
                                            circuit)) {
     return 1;
@@ -213,9 +213,9 @@ int main(int argc, char* argv[]) {
     unsigned num_threads;
   };
 
-  using HybridSimulator = HybridSimulator<IO, GateQSim<float>, BasicGateFuser,
-                                          For>;
-  using Runner = QSimHRunner<IO, HybridSimulator>;
+  using Fuser = BasicGateFuser<IO>;
+  using HybridSimulator = HybridSimulator<IO, For>;
+  using Runner = QSimHRunner<IO, Fuser, HybridSimulator>;
 
   Runner::Parameter param;
   param.prefix = opt.prefix;

--- a/apps/qsimh_base.cc
+++ b/apps/qsimh_base.cc
@@ -25,8 +25,8 @@
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_basic.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/io_file.h"
+#include "../lib/operation.h"
 #include "../lib/run_qsimh.h"
 #include "../lib/simmux.h"
 #include "../lib/util.h"
@@ -136,7 +136,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
   if (!CircuitQsimParser<IOFile>::FromFile(opt.maxtime, opt.circuit_file,
                                            circuit)) {
     return 1;
@@ -178,9 +178,9 @@ int main(int argc, char* argv[]) {
     unsigned num_threads;
   };
 
-  using HybridSimulator = HybridSimulator<IO, GateQSim<float>, BasicGateFuser,
-                                          For>;
-  using Runner = QSimHRunner<IO, HybridSimulator>;
+  using Fuser = BasicGateFuser<IO>;
+  using HybridSimulator = HybridSimulator<IO, For>;
+  using Runner = QSimHRunner<IO, Fuser, HybridSimulator>;
 
   Runner::Parameter param;
   param.prefix = opt.prefix;

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -251,6 +251,7 @@ cc_library(
     name = "run_qsim_lib",
     hdrs = [
         "bits.h",
+        "channel.h",
         "circuit.h",
         "circuit_qsim_parser.h",
         "expect.h",
@@ -299,6 +300,7 @@ cc_library(
     name = "run_qsimh_lib",
     hdrs = [
         "bits.h",
+        "channel.h",
         "circuit.h",
         "circuit_qsim_parser.h",
         "expect.h",

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -798,6 +798,8 @@ cc_library(
     deps = [
         ":gate",
         ":gate_appl",
+        ":gates_cirq",
+        ":gates_qsim",
     ],
 )
 

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -547,8 +547,8 @@ cc_library(
         ":circuit",
         ":gate",
         ":gate_appl",
-        ":util",
         ":operation_base",
+        ":util",
     ],
 )
 

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -27,6 +27,7 @@ cc_library(
         "bitstring.h",
         "channel.h",
         "channels_cirq.h",
+        "channels_qsim.h",
         "circuit.h",
         "circuit_noisy.h",
         "circuit_qsim_parser.h",
@@ -45,6 +46,8 @@ cc_library(
         "matrix.h",
         "mps_simulator.h",
         "mps_statespace.h",
+        "operation.h",
+        "operation_base.h",
         "parfor.h",
         "qtrajectory.h",
         "run_qsim.h",
@@ -99,6 +102,7 @@ cuda_library(
         "bitstring.h",
         "channel.h",
         "channels_cirq.h",
+        "channels_qsim.h",
         "circuit.h",
         "circuit_noisy.h",
         "circuit_qsim_parser.h",
@@ -117,6 +121,8 @@ cuda_library(
         "matrix.h",
         "mps_simulator.h",
         "mps_statespace.h",
+        "operation.h",
+        "operation_base.h",
         "parfor.h",
         "qtrajectory.h",
         "run_qsim.h",
@@ -168,6 +174,7 @@ cuda_library(
         "bitstring.h",
         "channel.h",
         "channels_cirq.h",
+        "channels_qsim.h",
         "circuit.h",
         "circuit_noisy.h",
         "circuit_qsim_parser.h",
@@ -187,6 +194,8 @@ cuda_library(
         "mps_simulator.h",
         "mps_statespace.h",
         "multiprocess_custatevecex.h",
+        "operation.h",
+        "operation_base.h",
         "parfor.h",
         "qtrajectory.h",
         "run_custatevecex.h",
@@ -255,6 +264,8 @@ cc_library(
         "io.h",
         "io_file.h",
         "matrix.h",
+        "operation.h",
+        "operation_base.h",
         "parfor.h",
         "run_qsim.h",
         "seqfor.h",
@@ -302,6 +313,8 @@ cc_library(
         "io.h",
         "io_file.h",
         "matrix.h",
+        "operation.h",
+        "operation_base.h",
         "parfor.h",
         "run_qsimh.h",
         "seqfor.h",
@@ -408,18 +421,36 @@ cc_library(
 ### Gate libraries ###
 
 cc_library(
+    name = "operation_base",
+    hdrs = ["operation_base.h"],
+)
+
+cc_library(
+    name = "operation",
+    hdrs = ["operation.h"],
+    deps = [
+        ":channel",
+        ":gate",
+        ":operation_base",
+    ],
+)
+
+cc_library(
     name = "gate",
     hdrs = ["gate.h"],
-    deps = [":matrix"],
+    deps = [
+        ":matrix",
+        ":operation_base",
+    ],
 )
 
 cc_library(
     name = "gate_appl",
     hdrs = ["gate_appl.h"],
     deps = [
-        ":fuser",
         ":gate",
         ":matrix",
+        ":operation_base",
     ],
 )
 
@@ -435,7 +466,10 @@ cc_library(
 cc_library(
     name = "gates_qsim",
     hdrs = ["gates_qsim.h"],
-    deps = [":gate"],
+    deps = [
+        ":gate",
+        ":matrix",
+    ],
 )
 
 ### Circuit libraries ###
@@ -452,6 +486,8 @@ cc_library(
     deps = [
         ":circuit",
         ":gates_qsim",
+        ":operation",
+        ":operation_base",
     ],
 )
 
@@ -463,6 +499,7 @@ cc_library(
     deps = [
         ":gate",
         ":matrix",
+        ":operation_base",
     ],
 )
 
@@ -472,6 +509,8 @@ cc_library(
     deps = [
         ":fuser",
         ":gate",
+        ":operation",
+        ":operation_base",
     ],
 )
 
@@ -481,6 +520,8 @@ cc_library(
     deps = [
         ":fuser",
         ":gate",
+        ":operation",
+        ":operation_base",
     ],
 )
 
@@ -491,7 +532,9 @@ cc_library(
     hdrs = ["expect.h"],
     deps = [
         ":fuser",
+        ":gate",
         ":gate_appl",
+        ":operation_base",
     ],
 )
 
@@ -505,6 +548,7 @@ cc_library(
         ":gate",
         ":gate_appl",
         ":util",
+        ":operation_base",
     ],
 )
 
@@ -512,7 +556,9 @@ cc_library(
     name = "run_qsimh",
     hdrs = ["run_qsimh.h"],
     deps = [
+        ":circuit",
         ":hybrid",
+        ":operation",
         ":util",
     ],
 )
@@ -763,6 +809,7 @@ cc_library(
     deps = [
         ":gate",
         ":matrix",
+        ":operation_base",
     ],
 )
 
@@ -770,8 +817,8 @@ cc_library(
     name = "circuit_noisy",
     hdrs = ["circuit_noisy.h"],
     deps = [
-        ":channel",
-        ":circuit",
+        ":operation",
+        ":operation_base",
     ],
 )
 
@@ -784,15 +831,25 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "channels_qsim",
+    hdrs = ["channels_qsim.h"],
+    deps = [
+        ":channel",
+        ":gates_qsim",
+    ],
+)
+
 ### Quantum trajectory simulator ###
 
 cc_library(
     name = "qtrajectory",
     hdrs = ["qtrajectory.h"],
     deps = [
-        ":circuit_noisy",
         ":gate",
         ":gate_appl",
+        ":operation",
+        ":operation_base",
     ],
 )
 

--- a/lib/channel.h
+++ b/lib/channel.h
@@ -20,25 +20,17 @@
 
 #include "gate.h"
 #include "matrix.h"
+#include "operation_base.h"
 
 namespace qsim {
 
 /**
- * Kraus operator.
+ * A Kraus operator.
  */
-template <typename Gate>
+template <typename FP>
 struct KrausOperator {
-  using fp_type = typename Gate::fp_type;
-
-  enum Kind {
-    kNormal = 0,
-    kMeasurement = gate::kMeasurement,
-  };
-
-  /**
-   * Kraus operator type;
-   */
-  Kind kind;
+  using fp_type = FP;
+  using Gate = qsim::Gate<fp_type>;
 
   /**
    * If true, the Kraus operator is a unitary operator times a constant.
@@ -120,10 +112,29 @@ struct KrausOperator {
 };
 
 /**
- * Quantum channel.
+ * A Quantum channel. Currently `BaseOperation`s fields are not used.
  */
-template <typename Gate>
-using Channel = std::vector<KrausOperator<Gate>>;
+template <typename FP>
+struct Channel : public BaseOperation {
+  Channel() {}
+
+  Channel(BaseOperation&& bop, std::vector<KrausOperator<FP>>&& kops)
+      : BaseOperation(std::move(bop)), kops(std::move(kops)) {}
+
+  std::vector<KrausOperator<FP>> kops;
+};
+
+/**
+ * Makes a channel from the gate.
+ * @param gate The input gate.
+ * @return The output channel.
+ */
+template <typename FP>
+Channel<FP> MakeChannelFromGate(const Gate<FP>& gate) {
+  return Channel<FP>{
+    {kChannel, gate.time, gate.qubits}, {{true, 1.0, {gate}}}
+  };
+}
 
 /**
  * Makes a channel from the gate.
@@ -131,14 +142,11 @@ using Channel = std::vector<KrausOperator<Gate>>;
  * @param gate The input gate.
  * @return The output channel.
  */
-template <typename Gate>
-Channel<Gate> MakeChannelFromGate(unsigned time, const Gate& gate) {
-  auto normal = KrausOperator<Gate>::kNormal;
-  auto measurement = KrausOperator<Gate>::kMeasurement;
-
-  auto kind = gate.kind == gate::kMeasurement ? measurement : normal;
-
-  Channel<Gate> channel = {{kind, true, 1, {gate}}};
+template <typename FP>
+Channel<FP> MakeChannelFromGate(unsigned time, const Gate<FP>& gate) {
+  Channel<FP> channel{
+    {kChannel, gate.time, gate.qubits}, {{true, 1.0, {gate}}}
+  };
   channel[0].ops[0].time = time;
 
   return channel;

--- a/lib/channels_cirq.h
+++ b/lib/channels_cirq.h
@@ -26,9 +26,6 @@ namespace qsim {
 
 namespace Cirq {
 
-template <typename fp_type>
-using Channel = qsim::Channel<GateCirq<fp_type>>;
-
 /**
  * Asymmetric depolarizing channel factory.
  */
@@ -43,12 +40,15 @@ struct AsymmetricDepolarizingChannel {
                                  double p_x, double p_y, double p_z) {
     double p1 = 1 - p_x - p_y - p_z;
 
-    auto normal = KrausOperator<GateCirq<fp_type>>::kNormal;
-
-    return {{normal, 1, p1, {}},
-            {normal, 1, p_x, {X<fp_type>::Create(time, q)}},
-            {normal, 1, p_y, {Y<fp_type>::Create(time, q)}},
-            {normal, 1, p_z, {Z<fp_type>::Create(time, q)}}};
+    return {
+      {kChannel, time, {q}},
+      {
+        {true, p1, {}},
+        {true, p_x, {X<fp_type>::Create(time, q)}},
+        {true, p_y, {Y<fp_type>::Create(time, q)}},
+        {true, p_z, {Z<fp_type>::Create(time, q)}},
+      }
+    };
   }
 
   static Channel<fp_type> Create(unsigned time,
@@ -56,16 +56,14 @@ struct AsymmetricDepolarizingChannel {
                                  double p_x, double p_y, double p_z) {
     double p1 = 1 - p_x - p_y - p_z;
 
-    auto normal = KrausOperator<GateCirq<fp_type>>::kNormal;
-
     uint64_t size = uint64_t{1} << (2 * qubits.size());
 
-    Channel<fp_type> channel;
-    channel.reserve(size);
+    Channel<fp_type> channel{{kChannel, time, qubits}, {}};
+    channel.kops.reserve(size);
 
     for (uint64_t i = 0; i < size; ++i) {
-      channel.push_back({normal, 1, 0, {}});
-      auto& kop = channel.back();
+      channel.kops.push_back({true, 0, {}});
+      auto& kop = channel.kops.back();
 
       kop.ops.reserve(qubits.size());
 
@@ -135,12 +133,15 @@ struct DepolarizingChannel {
     double p1 = 1 - p;
     double p2 = p / 3;
 
-    auto normal = KrausOperator<GateCirq<fp_type>>::kNormal;
-
-    return {{normal, 1, p1, {}},
-            {normal, 1, p2, {X<fp_type>::Create(time, q)}},
-            {normal, 1, p2, {Y<fp_type>::Create(time, q)}},
-            {normal, 1, p2, {Z<fp_type>::Create(time, q)}}};
+    return {
+      {kChannel, time, {q}},
+      {
+        {true, p1, {}},
+        {true, p2, {X<fp_type>::Create(time, q)}},
+        {true, p2, {Y<fp_type>::Create(time, q)}},
+        {true, p2, {Z<fp_type>::Create(time, q)}}
+      }
+    };
   }
 
   static Channel<fp_type> Create(
@@ -148,16 +149,14 @@ struct DepolarizingChannel {
     double p1 = 1 - p;
     double p2 = p / 3;
 
-    auto normal = KrausOperator<GateCirq<fp_type>>::kNormal;
-
     uint64_t size = uint64_t{1} << (2 * qubits.size());
 
-    Channel<fp_type> channel;
-    channel.reserve(size);
+    Channel<fp_type> channel{{kChannel, time, qubits}, {}};
+    channel.kops.reserve(size);
 
     for (uint64_t i = 0; i < size; ++i) {
-      channel.push_back({normal, 1, 0, {}});
-      auto& kop = channel.back();
+      channel.kops.push_back({true, 0, {}});
+      auto& kop = channel.kops.back();
 
       kop.ops.reserve(qubits.size());
 
@@ -235,25 +234,20 @@ struct GeneralizedAmplitudeDampingChannel {
     fp_type s2 = std::sqrt((1 - p) * gamma);
 
     using M = Cirq::MatrixGate1<fp_type>;
-    auto normal = KrausOperator<GateCirq<fp_type>>::kNormal;
 
-    return {{normal, 0, p1,
-             {M::Create(time, q, {t1, 0, 0, 0, 0, 0, r1, 0})},
-             {t1 * t1, 0, 0, 0, 0, 0, r1 * r1, 0}, {q},
-            },
-            {normal, 0, p2,
-             {M::Create(time, q, {r2, 0, 0, 0, 0, 0, t2, 0})},
-             {r2 * r2, 0, 0, 0, 0, 0, t2 * t2, 0}, {q},
-            },
-            {normal, 0, p3,
-             {M::Create(time, q, {0, 0, s1, 0, 0, 0, 0, 0})},
-             {0, 0, 0, 0, 0, 0, s1 * s1, 0}, {q},
-            },
-            {normal, 0, p3,
-             {M::Create(time, q, {0, 0, 0, 0, s2, 0, 0, 0})},
-             {s2 * s2, 0, 0, 0, 0, 0, 0, 0}, {q},
-            },
-           };
+    return {
+      {kChannel, time, {q}},
+      {
+        {false, p1, {M::Create(time, q, {t1, 0, 0, 0, 0, 0, r1, 0})},
+            {t1 * t1, 0, 0, 0, 0, 0, r1 * r1, 0}, {q}},
+        {false, p2, {M::Create(time, q, {r2, 0, 0, 0, 0, 0, t2, 0})},
+            {r2 * r2, 0, 0, 0, 0, 0, t2 * t2, 0}, {q}},
+        {false, p3, {M::Create(time, q, {0, 0, s1, 0, 0, 0, 0, 0})},
+            {0, 0, 0, 0, 0, 0, s1 * s1, 0}, {q}},
+        {false, p3, {M::Create(time, q, {0, 0, 0, 0, s2, 0, 0, 0})},
+            {s2 * s2, 0, 0, 0, 0, 0, 0, 0}, {q}},
+      }
+    };
   }
 
   Channel<fp_type> Create(unsigned time, unsigned q) const {
@@ -290,17 +284,16 @@ struct AmplitudeDampingChannel {
     fp_type s = std::sqrt(gamma);
 
     using M = Cirq::MatrixGate1<fp_type>;
-    auto normal = KrausOperator<GateCirq<fp_type>>::kNormal;
 
-    return {{normal, 0, p1,
-             {M::Create(time, q, {1, 0, 0, 0, 0, 0, r, 0})},
-             {1, 0, 0, 0, 0, 0, r * r, 0}, {q},
-            },
-            {normal, 0, p2,
-             {M::Create(time, q, {0, 0, s, 0, 0, 0, 0, 0})},
-             {0, 0, 0, 0, 0, 0, s * s, 0}, {q},
-            },
-           };
+    return {
+      {kChannel, time, {q}},
+      {
+        {false, p1, {M::Create(time, q, {1, 0, 0, 0, 0, 0, r, 0})},
+            {1, 0, 0, 0, 0, 0, r * r, 0}, {q}},
+        {false, p2, {M::Create(time, q, {0, 0, s, 0, 0, 0, 0, 0})},
+            {0, 0, 0, 0, 0, 0, s * s, 0}, {q}},
+      }
+    };
   }
 
   Channel<fp_type> Create(unsigned time, unsigned q) const {
@@ -335,17 +328,16 @@ struct PhaseDampingChannel {
     fp_type s = std::sqrt(gamma);
 
     using M = Cirq::MatrixGate1<fp_type>;
-    auto normal = KrausOperator<GateCirq<fp_type>>::kNormal;
 
-    return {{normal, 0, p1,
-             {M::Create(time, q, {1, 0, 0, 0, 0, 0, r, 0})},
-             {1, 0, 0, 0, 0, 0, r * r, 0}, {q},
-            },
-            {normal, 0, p2,
-             {M::Create(time, q, {0, 0, 0, 0, 0, 0, s, 0})},
-             {0, 0, 0, 0, 0, 0, s * s, 0}, {q},
-            },
-           };
+    return {
+      {kChannel, time, {q}},
+      {
+        {false, p1, {M::Create(time, q, {1, 0, 0, 0, 0, 0, r, 0})},
+            {1, 0, 0, 0, 0, 0, r * r, 0}, {q}},
+        {false, p2, {M::Create(time, q, {0, 0, 0, 0, 0, 0, s, 0})},
+            {0, 0, 0, 0, 0, 0, s * s, 0}, {q}},
+      }
+    };
   }
 
   Channel<fp_type> Create(unsigned time, unsigned q) const {
@@ -372,17 +364,16 @@ struct ResetChannel {
 
   static Channel<fp_type> Create(unsigned time, unsigned q) {
     using M = Cirq::MatrixGate1<fp_type>;
-    auto normal = KrausOperator<GateCirq<fp_type>>::kNormal;
 
-    return {{normal, 0, 0,
-             {M::Create(time, q, {1, 0, 0, 0, 0, 0, 0, 0})},
-             {1, 0, 0, 0, 0, 0, 0, 0}, {q},
-            },
-            {normal, 0, 0,
-             {M::Create(time, q, {0, 0, 1, 0, 0, 0, 0, 0})},
-             {0, 0, 0, 0, 0, 0, 1, 0}, {q},
-            },
-           };
+    return {
+      {kChannel, time, {q}},
+      {
+        {false, 0, {M::Create(time, q, {1, 0, 0, 0, 0, 0, 0, 0})},
+            {1, 0, 0, 0, 0, 0, 0, 0}, {q}},
+        {false, 0, {M::Create(time, q, {0, 0, 1, 0, 0, 0, 0, 0})},
+            {0, 0, 0, 0, 0, 0, 1, 0}, {q}},
+      }
+    };
   }
 };
 
@@ -407,11 +398,10 @@ struct PhaseFlipChannel {
     double p1 = 1 - p;
     double p2 = p;
 
-    auto normal = KrausOperator<GateCirq<fp_type>>::kNormal;
-
-    return {{normal, 1, p1, {}},
-            {normal, 1, p2, {Z<fp_type>::Create(time, q)}}
-           };
+    return {
+      {kChannel, time, {q}},
+      {{true, p1, {}}, {true, p2, {Z<fp_type>::Create(time, q)}}}
+    };
   }
 
   Channel<fp_type> Create(unsigned time, unsigned q) const {
@@ -442,11 +432,10 @@ struct BitFlipChannel {
     double p1 = 1 - p;
     double p2 = p;
 
-    auto normal = KrausOperator<GateCirq<fp_type>>::kNormal;
-
-    return {{normal, 1, p1, {}},
-            {normal, 1, p2, {X<fp_type>::Create(time, q)}}
-           };
+    return {
+      {kChannel, time, {q}},
+      {{true, p1, {}}, {true, p2, {X<fp_type>::Create(time, q)}}}
+    };
   }
 
   Channel<fp_type> Create(unsigned time, unsigned q) const {

--- a/lib/channels_qsim.h
+++ b/lib/channels_qsim.h
@@ -31,7 +31,7 @@ template <typename fp_type>
 struct AmplitudeDampingChannel {
   AmplitudeDampingChannel(double gamma) : gamma(gamma) {}
 
-  static Channel<GateQSim<fp_type>> Create(
+  static Channel<fp_type> Create(
       unsigned time, unsigned q, double gamma) {
     double p1 = 1 - gamma;
     double p2 = 0;
@@ -40,20 +40,19 @@ struct AmplitudeDampingChannel {
     fp_type s = std::sqrt(gamma);
 
     using M = GateMatrix1<fp_type>;
-    auto normal = KrausOperator<GateQSim<fp_type>>::kNormal;
 
-    return {{normal, 0, p1,
-             {M::Create(time, q, {1, 0, 0, 0, 0, 0, r, 0})},
-             {1, 0, 0, 0, 0, 0, r * r, 0}, {q},
-            },
-            {normal, 0, p2,
-             {M::Create(time, q, {0, 0, s, 0, 0, 0, 0, 0})},
-             {0, 0, 0, 0, 0, 0, s * s, 0}, {q},
-            },
-           };
+    return {
+      {kChannel, time, {q}},
+      {
+        {false, p1, {M::Create(time, q, {1, 0, 0, 0, 0, 0, r, 0})},
+            {1, 0, 0, 0, 0, 0, r * r, 0}, {q}},
+        {false, p2, {M::Create(time, q, {0, 0, s, 0, 0, 0, 0, 0})},
+            {0, 0, 0, 0, 0, 0, s * s, 0}, {q}},
+      }
+    };
   }
 
-  Channel<GateQSim<fp_type>> Create(unsigned time, unsigned q) const {
+  Channel<fp_type> Create(unsigned time, unsigned q) const {
     return Create(time, q, gamma);
   }
 
@@ -75,7 +74,7 @@ template <typename fp_type>
 struct PhaseDampingChannel {
   PhaseDampingChannel(double gamma) : gamma(gamma) {}
 
-  static Channel<GateQSim<fp_type>> Create(
+  static Channel<fp_type> Create(
       unsigned time, unsigned q, double gamma) {
     double p1 = 1 - gamma;
     double p2 = 0;
@@ -84,20 +83,19 @@ struct PhaseDampingChannel {
     fp_type s = std::sqrt(gamma);
 
     using M = GateMatrix1<fp_type>;
-    auto normal = KrausOperator<GateQSim<fp_type>>::kNormal;
 
-    return {{normal, 0, p1,
-             {M::Create(time, q, {1, 0, 0, 0, 0, 0, r, 0})},
-             {1, 0, 0, 0, 0, 0, r * r, 0}, {q},
-            },
-            {normal, 0, p2,
-             {M::Create(time, q, {0, 0, 0, 0, 0, 0, s, 0})},
-             {0, 0, 0, 0, 0, 0, s * s, 0}, {q},
-            },
-           };
+    return {
+      {kChannel, time, {q}},
+      {
+        {false, p1, {M::Create(time, q, {1, 0, 0, 0, 0, 0, r, 0})},
+            {1, 0, 0, 0, 0, 0, r * r, 0}, {q}},
+        {false, p2, {M::Create(time, q, {0, 0, 0, 0, 0, 0, s, 0})},
+            {0, 0, 0, 0, 0, 0, s * s, 0}, {q}},
+      }
+    };
   }
 
-  Channel<GateQSim<fp_type>> Create(unsigned time, unsigned q) const {
+  Channel<fp_type> Create(unsigned time, unsigned q) const {
     return Create(time, q, gamma);
   }
 

--- a/lib/circuit.h
+++ b/lib/circuit.h
@@ -20,59 +20,45 @@
 namespace qsim {
 
 /**
- * A collection of gates. This object is consumed by `QSim[h]Runner.Run()`.
+ * A collection of operations.
  */
-template <typename Gate>
+template <typename Operation>
 struct Circuit {
   unsigned num_qubits;
   /**
-   * The set of gates to be run. Gate times should be ordered.
+   * The set of operations to be run. Operation time steps should be ordered.
    */
-  std::vector<Gate> gates;
+  std::vector<Operation> ops;
 };
-
-namespace detail {
 
 /**
- * An adapter for vectors of gates.
+ * An adapter for vectors of operations.
  */
 template <typename Circuit>
-struct Gates;
+struct Operations;
 
-template <typename Gate>
-struct Gates<qsim::Circuit<Gate>> {
-  static const std::vector<Gate>& get(const qsim::Circuit<Gate>& circuit) {
-    return circuit.gates;
-  }
-
-  static const Gate& gate(const Gate& g) {
-    return g;
+template <typename Operation>
+struct Operations<qsim::Circuit<Operation>> {
+  static const std::vector<Operation>& get(
+      const qsim::Circuit<Operation>& circuit) {
+    return circuit.ops;
   }
 };
 
-template <typename Gate>
-struct Gates<std::vector<Gate>> {
-  static const std::vector<Gate>& get(const std::vector<Gate>& gates) {
-    return gates;
-  }
-
-  static const Gate& gate(const Gate& g) {
-    return g;
+template <typename Operation>
+struct Operations<std::vector<Operation>> {
+  static const std::vector<Operation>& get(const std::vector<Operation>& ops) {
+    return ops;
   }
 };
 
-template <typename Gate>
-struct Gates<std::vector<Gate*>> {
-  static const std::vector<Gate*>& get(const std::vector<Gate*>& gates) {
-    return gates;
-  }
-
-  static const Gate& gate(const Gate* g) {
-    return *g;
+template <typename Operation>
+struct Operations<std::vector<Operation*>> {
+  static const std::vector<Operation*>& get(
+      const std::vector<Operation*>& ops) {
+    return ops;
   }
 };
-
-}  // namespace detail
 
 }  // namespace qsim
 

--- a/lib/circuit_noisy.h
+++ b/lib/circuit_noisy.h
@@ -17,22 +17,9 @@
 
 #include <vector>
 
-#include "circuit.h"
-#include "channel.h"
+#include "operation.h"
 
 namespace qsim {
-
-/**
- * Noisy circuit.
- */
-template <typename Gate>
-struct NoisyCircuit {
-  unsigned num_qubits;
-  std::vector<Channel<Gate>> channels;
-};
-
-template <typename Gate>
-using ncircuit_iterator = typename std::vector<Channel<Gate>>::const_iterator;
 
 /**
  * Makes a noisy circuit from the clean circuit.
@@ -43,28 +30,33 @@ using ncircuit_iterator = typename std::vector<Channel<Gate>>::const_iterator;
  * @param A channel factory to construct channels.
  * @return The output noisy circuit.
  */
-template <typename Gate, typename ChannelFactory>
-inline NoisyCircuit<Gate> MakeNoisy(
+template <typename FP, typename ChannelFactory>
+inline Circuit<Operation<FP>> MakeNoisy(
     unsigned num_qubits,
-    typename std::vector<Gate>::const_iterator gbeg,
-    typename std::vector<Gate>::const_iterator gend,
+    typename std::vector<Operation<FP>>::const_iterator obeg,
+    typename std::vector<Operation<FP>>::const_iterator oend,
     const ChannelFactory& channel_factory) {
-  NoisyCircuit<Gate> ncircuit;
+  Circuit<Operation<FP>> ncircuit;
 
   ncircuit.num_qubits = num_qubits;
-  ncircuit.channels.reserve(4 * std::size_t(gend - gbeg));
+  ncircuit.ops.reserve(4 * std::size_t(oend - obeg));
 
-  for (auto it = gbeg; it != gend; ++it) {
-    const auto& gate = *it;
+  for (auto it = obeg; it != oend; ++it) {
+    const auto& op = *it;
 
-    ncircuit.channels.push_back(MakeChannelFromGate(2 * gate.time, gate));
+    const auto& bop = OpBaseOperation(op);
 
-    for (auto q : gate.qubits) {
-      ncircuit.channels.push_back(channel_factory.Create(2 * gate.time + 1, q));
+    ncircuit.ops.push_back(op);
+    OpBaseOperation(ncircuit.ops.back()).time = 2 * bop.time;
+
+    for (auto q : bop.qubits) {
+      ncircuit.ops.push_back(channel_factory.Create(2 * bop.time + 1, q));
     }
 
-    for (auto q : gate.controlled_by) {
-      ncircuit.channels.push_back(channel_factory.Create(2 * gate.time + 1, q));
+    if (const auto* pg = OpGetAlternative<ControlledGate<FP>>(op)) {
+      for (auto q : pg->controlled_by) {
+        ncircuit.ops.push_back(channel_factory.Create(2 * bop.time + 1, q));
+      }
     }
   }
 
@@ -80,12 +72,11 @@ inline NoisyCircuit<Gate> MakeNoisy(
  * @param A channel factory to construct channels.
  * @return The output noisy circuit.
  */
-template <typename Gate, typename ChannelFactory>
-inline NoisyCircuit<Gate> MakeNoisy(unsigned num_qubits,
-                                    const std::vector<Gate>& gates,
-                                    const ChannelFactory& channel_factory) {
-  return
-      MakeNoisy<Gate>(num_qubits, gates.begin(), gates.end(), channel_factory);
+template <typename FP, typename ChannelFactory>
+inline Circuit<Operation<FP>> MakeNoisy(
+    unsigned num_qubits, const std::vector<Operation<FP>>& ops,
+    const ChannelFactory& channel_factory) {
+  return MakeNoisy<FP>(num_qubits, ops.begin(), ops.end(), channel_factory);
 }
 
 /**
@@ -96,11 +87,12 @@ inline NoisyCircuit<Gate> MakeNoisy(unsigned num_qubits,
  * @param A channel factory to construct channels.
  * @return The output noisy circuit.
  */
-template <typename Gate, typename ChannelFactory>
-inline NoisyCircuit<Gate> MakeNoisy(const Circuit<Gate>& circuit,
-                                    const ChannelFactory& channel_factory) {
-  return MakeNoisy<Gate>(circuit.num_qubits, circuit.gates.begin(),
-                         circuit.gates.end(), channel_factory);
+template <typename FP, typename ChannelFactory>
+inline Circuit<Operation<FP>> MakeNoisy(
+    const Circuit<Operation<FP>>& circuit,
+    const ChannelFactory& channel_factory) {
+  return MakeNoisy<FP, ChannelFactory>(circuit.num_qubits, circuit.ops.begin(),
+                       circuit.ops.end(), channel_factory);
 }
 
 }  // namespace qsim

--- a/lib/circuit_qsim_parser.h
+++ b/lib/circuit_qsim_parser.h
@@ -23,6 +23,8 @@
 
 #include "circuit.h"
 #include "gates_qsim.h"
+#include "operation.h"
+#include "operation_base.h"
 
 namespace qsim {
 
@@ -48,11 +50,11 @@ class CircuitQsimParser final {
    */
   template <typename Stream, typename fp_type>
   static bool FromStream(unsigned maxtime, const std::string& provider,
-                         Stream& fs, Circuit<GateQSim<fp_type>>& circuit) {
+                         Stream& fs, Circuit<Operation<fp_type>>& circuit) {
     circuit.num_qubits = 0;
 
-    circuit.gates.resize(0);
-    circuit.gates.reserve(1024);
+    circuit.ops.resize(0);
+    circuit.ops.reserve(1024);
 
     unsigned k = 0;
 
@@ -100,33 +102,34 @@ class CircuitQsimParser final {
       }
 
       if (gate_name == "c") {
-        if (!ParseControlledGate<fp_type>(ss, time,
-                                          circuit.num_qubits, circuit.gates)) {
+        if (!ParseControlledGate(ss, time, circuit.num_qubits, circuit.ops)) {
           InvalidGateError(provider, k);
           return false;
         }
-      } else if (!ParseGate<fp_type>(ss, time, circuit.num_qubits,
-                                     gate_name, circuit.gates)) {
+      } else if (!ParseGate(ss, time, circuit.num_qubits,
+                            gate_name, false, circuit.ops)) {
         InvalidGateError(provider, k);
         return false;
       }
 
-      const auto& gate = circuit.gates.back();
+      const auto& op = circuit.ops.back();
+      bool is_measurement = OpGetAlternative<Measurement>(op) != nullptr;
 
-      if (time < prev_mea_time
-          || (gate.kind == gate::kMeasurement && time < max_time)) {
-        IO::errorf("gate crosses the time boundary set by measurement "
-                   "gates in line %u in %s.\n", k, provider.c_str());
+      if (time < prev_mea_time || (is_measurement && time < max_time)) {
+        IO::errorf("operation crosses the time boundary set by measurement "
+                   "operations in line %u in/ %s.\n", k, provider.c_str());
         return false;
       }
 
-      if (gate.kind == gate::kMeasurement) {
+      if (is_measurement) {
         prev_mea_time = time;
       }
 
-      if (GateIsOutOfOrder(time, gate.qubits, last_times)
-          || GateIsOutOfOrder(time, gate.controlled_by, last_times)) {
-        IO::errorf("gate is out of time order in line %u in %s.\n",
+      const auto* pg = OpGetAlternative<ControlledGate<fp_type>>(op);
+
+      if (GateIsOutOfOrder(time, OpQubits(op), last_times)
+          || (pg && GateIsOutOfOrder(time, pg->controlled_by, last_times))) {
+        IO::errorf("operation is out of time order in line %u in %s.\n",
                    k, provider.c_str());
         return false;
       }
@@ -150,7 +153,7 @@ class CircuitQsimParser final {
    */
   template <typename fp_type>
   static bool FromFile(unsigned maxtime, const std::string& file,
-                       Circuit<GateQSim<fp_type>>& circuit) {
+                       Circuit<Operation<fp_type>>& circuit) {
     auto fs = IO::StreamFromFile(file);
 
     if (!fs) {
@@ -207,13 +210,12 @@ class CircuitQsimParser final {
    * @param qubits Indices of affected qubits.
    */
   static bool ValidateGate(std::stringstream& ss, unsigned num_qubits,
-                           const std::vector<unsigned>& qubits) {
+                           const Qubits& qubits) {
     return ss && ValidateQubits(num_qubits, qubits);
   }
 
   static bool ValidateControlledGate(
-      unsigned num_qubits, const std::vector<unsigned>& qubits,
-      const std::vector<unsigned>& controlled_by) {
+      unsigned num_qubits, const Qubits& qubits, const Qubits& controlled_by) {
     if (!ValidateQubits(num_qubits, controlled_by)) return false;
 
     std::size_t i = 0, j = 0;
@@ -231,8 +233,7 @@ class CircuitQsimParser final {
     return true;
   }
 
-  static bool ValidateQubits(unsigned num_qubits,
-                             const std::vector<unsigned>& qubits) {
+  static bool ValidateQubits(unsigned num_qubits, const Qubits& qubits) {
     if (qubits.size() == 0 || qubits[0] >= num_qubits) return false;
 
     // qubits should be sorted.
@@ -246,8 +247,7 @@ class CircuitQsimParser final {
     return true;
   }
 
-  static bool GateIsOutOfOrder(unsigned time,
-                               const std::vector<unsigned>& qubits,
+  static bool GateIsOutOfOrder(unsigned time, const Qubits& qubits,
                                std::vector<unsigned>& last_times) {
     for (auto q : qubits) {
       if (last_times[q] != unsigned(-1) && time <= last_times[q]) {
@@ -260,103 +260,108 @@ class CircuitQsimParser final {
     return false;
   }
 
-  template <typename fp_type, typename Stream, typename Gate>
+  template <typename Stream, typename fp_type>
   static bool ParseGate(Stream& ss, unsigned time, unsigned num_qubits,
-                        const std::string& gate_name,
-                        std::vector<Gate>& gates) {
+                        const std::string& gate_name, bool controlled,
+                        std::vector<Operation<fp_type>>& ops) {
     unsigned q0, q1;
     fp_type phi, theta;
 
     if (gate_name == "p") {
       ss >> phi;
       if (!ValidateGate(ss)) return false;
-      gates.push_back(GateGPh<fp_type>::Create(time, phi));
+      ops.push_back(GateGPh<fp_type>::Create(time, phi));
     } else if (gate_name == "id1") {
       ss >> q0;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateId1<fp_type>::Create(time, q0));
+      ops.push_back(GateId1<fp_type>::Create(time, q0));
     } else if (gate_name == "h") {
       ss >> q0;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateHd<fp_type>::Create(time, q0));
+      ops.push_back(GateHd<fp_type>::Create(time, q0));
     } else if (gate_name == "t") {
       ss >> q0;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateT<fp_type>::Create(time, q0));
+      ops.push_back(GateT<fp_type>::Create(time, q0));
     } else if (gate_name == "x") {
       ss >> q0;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateX<fp_type>::Create(time, q0));
+      ops.push_back(GateX<fp_type>::Create(time, q0));
     } else if (gate_name == "y") {
       ss >> q0;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateY<fp_type>::Create(time, q0));
+      ops.push_back(GateY<fp_type>::Create(time, q0));
     } else if (gate_name == "z") {
       ss >> q0;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateZ<fp_type>::Create(time, q0));
+      ops.push_back(GateZ<fp_type>::Create(time, q0));
     } else if (gate_name == "x_1_2") {
       ss >> q0;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateX2<fp_type>::Create(time, q0));
+      ops.push_back(GateX2<fp_type>::Create(time, q0));
     } else if (gate_name == "y_1_2") {
       ss >> q0;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateY2<fp_type>::Create(time, q0));
+      ops.push_back(GateY2<fp_type>::Create(time, q0));
     } else if (gate_name == "rx") {
       ss >> q0 >> phi;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateRX<fp_type>::Create(time, q0, phi));
+      ops.push_back(GateRX<fp_type>::Create(time, q0, phi));
     } else if (gate_name == "ry") {
       ss >> q0 >> phi;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateRY<fp_type>::Create(time, q0, phi));
+      ops.push_back(GateRY<fp_type>::Create(time, q0, phi));
     } else if (gate_name == "rz") {
       ss >> q0 >> phi;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateRZ<fp_type>::Create(time, q0, phi));
+      ops.push_back(GateRZ<fp_type>::Create(time, q0, phi));
     } else if (gate_name == "rxy") {
       ss >> q0 >> theta >> phi;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateRXY<fp_type>::Create(time, q0, theta, phi));
+      ops.push_back(GateRXY<fp_type>::Create(time, q0, theta, phi));
     } else if (gate_name == "hz_1_2") {
       ss >> q0;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateHZ2<fp_type>::Create(time, q0));
+      ops.push_back(GateHZ2<fp_type>::Create(time, q0));
     } else if (gate_name == "s") {
       ss >> q0;
       if (!ValidateGate(ss, num_qubits, q0)) return false;
-      gates.push_back(GateS<fp_type>::Create(time, q0));
+      ops.push_back(GateS<fp_type>::Create(time, q0));
     } else if (gate_name == "id2") {
       ss >> q0 >> q1;
       if (!ValidateGate(ss, num_qubits, q0, q1)) return false;
-      gates.push_back(GateId2<fp_type>::Create(time, q0, q1));
+      ops.push_back(GateId2<fp_type>::Create(time, q0, q1));
     } else if (gate_name == "cz") {
       ss >> q0 >> q1;
       if (!ValidateGate(ss, num_qubits, q0, q1)) return false;
-      gates.push_back(GateCZ<fp_type>::Create(time, q0, q1));
+      ops.push_back(GateCZ<fp_type>::Create(time, q0, q1));
     } else if (gate_name == "cnot" || gate_name == "cx") {
       ss >> q0 >> q1;
       if (!ValidateGate(ss, num_qubits, q0, q1)) return false;
-      gates.push_back(GateCNot<fp_type>::Create(time, q0, q1));
+      ops.push_back(GateCNot<fp_type>::Create(time, q0, q1));
     } else if (gate_name == "sw") {
       ss >> q0 >> q1;
       if (!ValidateGate(ss, num_qubits, q0, q1)) return false;
-      gates.push_back(GateSwap<fp_type>::Create(time, q0, q1));
+      ops.push_back(GateSwap<fp_type>::Create(time, q0, q1));
     } else if (gate_name == "is") {
       ss >> q0 >> q1;
       if (!ValidateGate(ss, num_qubits, q0, q1)) return false;
-      gates.push_back(GateIS<fp_type>::Create(time, q0, q1));
+      ops.push_back(GateIS<fp_type>::Create(time, q0, q1));
     } else if (gate_name == "fs") {
       ss >> q0 >> q1 >> theta >> phi;
       if (!ValidateGate(ss, num_qubits, q0, q1)) return false;
-      gates.push_back(GateFS<fp_type>::Create(time, q0, q1, theta, phi));
+      ops.push_back(GateFS<fp_type>::Create(time, q0, q1, theta, phi));
     } else if (gate_name == "cp") {
       ss >> q0 >> q1 >> phi;
       if (!ValidateGate(ss, num_qubits, q0, q1)) return false;
-      gates.push_back(GateCP<fp_type>::Create(time, q0, q1, phi));
+      ops.push_back(GateCP<fp_type>::Create(time, q0, q1, phi));
     } else if (gate_name == "m") {
-      std::vector<unsigned> qubits;
+      if (controlled) {
+        IO::errorf("measurement gate cannot be controlled.\n");
+        return false;
+      }
+
+      Qubits qubits;
       qubits.reserve(num_qubits);
 
       while (ss.good()) {
@@ -368,10 +373,9 @@ class CircuitQsimParser final {
         }
       }
 
-      gates.push_back(gate::Measurement<GateQSim<fp_type>>::Create(
-          time, std::move(qubits)));
+      if (!ValidateQubits(num_qubits, qubits)) return false;
 
-      if (!ValidateQubits(num_qubits, gates.back().qubits)) return false;
+      ops.push_back(CreateMeasurement(time, std::move(qubits)));
     } else {
       return false;
     }
@@ -379,11 +383,11 @@ class CircuitQsimParser final {
     return true;
   }
 
-  template <typename fp_type, typename Stream, typename Gate>
+  template <typename Stream, typename fp_type>
   static bool ParseControlledGate(Stream& ss, unsigned time,
                                   unsigned num_qubits,
-                                  std::vector<Gate>& gates) {
-    std::vector<unsigned> controlled_by;
+                                  std::vector<Operation<fp_type>>& ops) {
+    Qubits controlled_by;
     controlled_by.reserve(64);
 
     std::string gate_name;
@@ -421,17 +425,18 @@ class CircuitQsimParser final {
 
     ss >> gate_name;
 
-    if (!ss.good() || !ParseGate<fp_type>(ss, time,
-                                          num_qubits, gate_name, gates)) {
+    if (!ss.good() || !ParseGate(ss, time, num_qubits, gate_name, true, ops)) {
       return false;
     }
 
-    gates.back().ControlledBy(std::move(controlled_by));
-
-    if (!ValidateControlledGate(num_qubits, gates.back().qubits,
-                                gates.back().controlled_by)) {
+    if (!ValidateControlledGate(num_qubits, OpQubits(ops.back()),
+                                controlled_by)) {
       return false;
     }
+
+    auto& lop = ops.back();
+    lop = OpGetAlternative<Gate<fp_type>>(lop)->ControlledBy(
+        std::move(controlled_by));
 
     return true;
   }

--- a/lib/expect.h
+++ b/lib/expect.h
@@ -18,14 +18,16 @@
 #include <complex>
 
 #include "fuser.h"
+#include "gate.h"
 #include "gate_appl.h"
+#include "operation_base.h"
 
 namespace qsim {
 
-template <typename Gate>
+template <typename FP>
 struct OpString {
   std::complex<double> weight;
-  std::vector<Gate> ops;
+  std::vector<Gate<FP>> ops;
 };
 
 /**
@@ -42,10 +44,10 @@ struct OpString {
  * @param ket Temporary state vector.
  * @return The computed expectation value.
  */
-template <typename IO, typename Fuser, typename Gate, typename Simulator>
+template <typename IO, typename Fuser, typename FP, typename Simulator>
 std::complex<double> ExpectationValue(
     const typename Fuser::Parameter& param,
-    const std::vector<OpString<Gate>>& strings,
+    const std::vector<OpString<FP>>& strings,
     const typename Simulator::StateSpace& state_space,
     const Simulator& simulator, const typename Simulator::State& state,
     typename Simulator::State& ket) {
@@ -78,7 +80,7 @@ std::complex<double> ExpectationValue(
       }
 
       for (const auto& fgate : fused_gates) {
-        ApplyFusedGate(simulator, fgate, ket);
+        ApplyGate(simulator, fgate, ket);
       }
     }
 
@@ -100,9 +102,9 @@ std::complex<double> ExpectationValue(
  * @param state The state of the system.
  * @return The computed expectation value.
  */
-template <typename IO, typename Fuser, typename Gate, typename Simulator>
+template <typename IO, typename Fuser, typename FP, typename Simulator>
 std::complex<double> ExpectationValue(
-    const std::vector<OpString<Gate>>& strings,
+    const std::vector<OpString<FP>>& strings,
     const Simulator& simulator, const typename Simulator::State& state) {
   std::complex<double> eval = 0;
 
@@ -125,18 +127,23 @@ std::complex<double> ExpectationValue(
         break;
       }
 
-      const auto& fgate = fused_gates[0];
+      if (const auto* pg = OpGetAlternative<FusedGate<FP>>(fused_gates[0])) {
+        if (pg->qubits.size() > 6) {
+          IO::errorf("operator string acts on too many qubits; "
+                     "cannot compute the expectation value.\n");
+          eval = 0;
+          break;
+        }
 
-      if (fgate.qubits.size() > 6) {
-        IO::errorf("operator string acts on too many qubits; "
+        auto r = simulator.ExpectationValue(
+            pg->qubits, pg->matrix.data(), state);
+        eval += str.weight * r;
+      } else {
+        IO::errorf("gate fusion error; "
                    "cannot compute the expectation value.\n");
         eval = 0;
         break;
       }
-
-      auto r = simulator.ExpectationValue(
-          fgate.qubits, fgate.matrix.data(), state);
-      eval += str.weight * r;
     }
   }
 

--- a/lib/fuser.h
+++ b/lib/fuser.h
@@ -20,121 +20,94 @@
 
 #include "gate.h"
 #include "matrix.h"
+#include "operation_base.h"
 
 namespace qsim {
 
 /**
- * A collection of "fused" gates which can be multiplied together before being
- * applied to the state vector.
+ * Base class for fuser classes with some common functions.
  */
-template <typename Gate>
-struct GateFused {
-  /**
-   * Kind of the first ("parent") gate.
-   */
-  typename Gate::GateKind kind;
-  /**
-   * The time index of the first ("parent") gate.
-   */
-  unsigned time;
-  /**
-   * A list of qubits these gates act upon. Control qubits for
-   * explicitly-controlled gates are excluded from this list.
-   */
-  std::vector<unsigned> qubits;
-  /**
-   * Pointer to the first ("parent") gate.
-   */
-  const Gate* parent;
-  /**
-   * Ordered list of component gates.
-   */
-  std::vector<const Gate*> gates;
-  /**
-   * Fused gate matrix.
-   */
-  Matrix<typename Gate::fp_type> matrix;
-};
-
-/**
- * A base class for fuser classes with some common functions.
- */
-template <typename IO, typename Gate>
+template <typename IO>
 class Fuser {
  protected:
-  using RGate = typename std::remove_pointer<Gate>::type;
-
-  static const RGate& GateToConstRef(const RGate& gate) {
-    return gate;
+  template <typename Operation>
+  static const Operation& OperationToConstRef(const Operation& op) {
+    return op;
   }
 
-  static const RGate& GateToConstRef(const RGate* gate) {
-    return *gate;
+  template <typename Operation>
+  static const Operation& OperationToConstRef(const Operation* op) {
+    return *op;
   }
 
+  template <typename Operation>
   static std::vector<unsigned> MergeWithMeasurementTimes(
-      typename std::vector<Gate>::const_iterator gfirst,
-      typename std::vector<Gate>::const_iterator glast,
+      typename std::vector<Operation>::const_iterator obeg,
+      typename std::vector<Operation>::const_iterator oend,
       const std::vector<unsigned>& times) {
-    std::vector<unsigned> epochs;
-    epochs.reserve(glast - gfirst + times.size());
+    std::vector<unsigned> windows;
+    windows.reserve(oend - obeg + times.size());
 
     std::size_t last = 0;
     unsigned max_time = 0;
 
-    for (auto gate_it = gfirst; gate_it < glast; ++gate_it) {
-      const auto& gate = GateToConstRef(*gate_it);
+    for (auto op_it = obeg; op_it < oend; ++op_it) {
+      const auto& op = OperationToConstRef(*op_it);
 
-      if (gate.time > max_time) {
-        max_time = gate.time;
+      unsigned time = OpTime(op);
+
+      if (time > max_time) {
+        max_time = time;
       }
 
-      if (epochs.size() > 0 && gate.time < epochs.back()) {
+      if (windows.size() > 0 && time < windows.back()) {
         IO::errorf("gate crosses the time boundary.\n");
-        epochs.resize(0);
-        return epochs;
+        windows.resize(0);
+        return windows;
       }
 
-      if (gate.kind == gate::kMeasurement) {
-        if (epochs.size() == 0 || epochs.back() < gate.time) {
-          if (!AddBoundary(gate.time, max_time, epochs)) {
-            epochs.resize(0);
-            return epochs;
+      if (OpGetAlternative<Measurement>(op)) {
+        if (windows.size() == 0 || windows.back() < time) {
+          if (!AddBoundary(time, max_time, windows)) {
+            windows.resize(0);
+            return windows;
           }
         }
       }
 
-      while (last < times.size() && times[last] <= gate.time) {
+      while (last < times.size() && times[last] <= time) {
         unsigned prev = times[last++];
-        epochs.push_back(prev);
-        if (!AddBoundary(prev, max_time, epochs)) {
-          epochs.resize(0);
-          return epochs;
+        windows.push_back(prev);
+        if (!AddBoundary(prev, max_time, windows)) {
+          windows.resize(0);
+          return windows;
         }
         while (last < times.size() && times[last] <= prev) ++last;
       }
     }
 
-    if (epochs.size() == 0 || epochs.back() < max_time) {
-      epochs.push_back(max_time);
+    if (windows.size() == 0 || windows.back() < max_time) {
+      windows.push_back(max_time);
     }
 
-    return epochs;
+    return windows;
   }
 
-  template <typename GateSeq0, typename Parent, typename GateFused>
+  template <typename GateSeq0, typename Parent, typename OperationF>
   static void FuseZeroQubitGates(const GateSeq0& gate_seq0,
-                                 Parent parent, std::size_t first,
-                                 std::vector<GateFused>& fused_gates) {
-    GateFused* fuse_to = nullptr;
+                                 Parent&& parent, std::size_t first,
+                                 std::vector<OperationF>& fused_ops) {
+    using FusedGate = std::variant_alternative_t<0, OperationF>;
+    using fp_type = typename FusedGate::fp_type;
+    using Gate = qsim::Gate<fp_type>;
 
-    for (std::size_t i = first; i < fused_gates.size(); ++i) {
-      auto& fgate = fused_gates[i];
+    FusedGate* fuse_to = nullptr;
 
-      if (fgate.kind != gate::kMeasurement && fgate.kind != gate::kDecomp
-          && fgate.parent->controlled_by.size() == 0
-          && !fgate.parent->unfusible) {
-        fuse_to = &fgate;
+    for (std::size_t i = first; i < fused_ops.size(); ++i) {
+      auto& fop = fused_ops[i];
+
+      fuse_to = OpGetAlternative<FusedGate>(fop);
+      if (fuse_to != nullptr) {
         break;
       }
     }
@@ -142,15 +115,17 @@ class Fuser {
     if (fuse_to != nullptr) {
       // Fuse zero-qubit gates with the first available fused gate.
       for (const auto& g : gate_seq0) {
-        fuse_to->gates.push_back(parent(g));
+        fuse_to->gates.push_back(OpGetAlternative<Gate>(*parent(g)));
       }
     } else {
-      auto g0 = parent(gate_seq0[0]);
-      fused_gates.push_back({g0->kind, g0->time, {}, g0, {g0}, {}});
+      const auto& gate0 = *OpGetAlternative<Gate>(*parent(gate_seq0[0]));
+      FusedGate fgate{gate0.kind, gate0.time, {}, &gate0, {&gate0}, {}};
 
       for (std::size_t i = 1; i < gate_seq0.size(); ++i) {
-        fused_gates.back().gates.push_back(parent(gate_seq0[i]));
+        fgate.gates.push_back(OpGetAlternative<Gate>(*parent(gate_seq0[i])));
       }
+
+      fused_ops.push_back(std::move(fgate));
     }
   }
 
@@ -171,19 +146,24 @@ class Fuser {
  * Multiplies component gate matrices of a fused gate.
  * @param gate Fused gate.
  */
-template <typename FusedGate>
-inline void CalculateFusedMatrix(FusedGate& gate) {
+template <typename FP>
+inline void CalculateFusedMatrix(FusedGate<FP>& gate) {
   MatrixIdentity(unsigned{1} << gate.qubits.size(), gate.matrix);
 
-  for (auto pgate : gate.gates) {
-    if (pgate->qubits.size() == 0) {
-      MatrixScalarMultiply(pgate->matrix[0], pgate->matrix[1], gate.matrix);
-    } else if (gate.qubits.size() == pgate->qubits.size()) {
-      MatrixMultiply(gate.qubits.size(), pgate->matrix, gate.matrix);
+  for (const auto& pgate : gate.gates) {
+    const auto* pg = OpGetAlternative<Gate<FP>>(pgate);
+    const auto& pqubits = OpQubits(pgate);
+    const auto& pmatrix =
+        pg ? pg->matrix : OpGetAlternative<DecomposedGate<FP>>(pgate)->matrix;
+
+    if (pqubits.size() == 0) {
+      MatrixScalarMultiply(pmatrix[0], pmatrix[1], gate.matrix);
+    } else if (gate.qubits.size() == pqubits.size()) {
+      MatrixMultiply(gate.qubits.size(), pmatrix, gate.matrix);
     } else {
       unsigned mask = 0;
 
-      for (auto q : pgate->qubits) {
+      for (auto q : pqubits) {
         for (std::size_t i = 0; i < gate.qubits.size(); ++i) {
           if (q == gate.qubits[i]) {
             mask |= unsigned{1} << i;
@@ -192,32 +172,10 @@ inline void CalculateFusedMatrix(FusedGate& gate) {
         }
       }
 
-      MatrixMultiply(mask, pgate->qubits.size(), pgate->matrix,
+      MatrixMultiply(mask, pqubits.size(), pmatrix,
                      gate.qubits.size(), gate.matrix);
     }
   }
-}
-
-/**
- * Multiplies component gate matrices for a range of fused gates.
- * @param gbeg, gend The iterator range [gbeg, gend) of fused gates.
- */
-template <typename Iterator>
-inline void CalculateFusedMatrices(Iterator gbeg, Iterator gend) {
-  for (auto g = gbeg; g != gend; ++g) {
-    if (g->kind != gate::kMeasurement) {
-      CalculateFusedMatrix(*g);
-    }
-  }
-}
-
-/**
- * Multiplies component gate matrices for a vector of fused gates.
- * @param gates The vector of fused gates.
- */
-template <typename FusedGate>
-inline void CalculateFusedMatrices(std::vector<FusedGate>& gates) {
-  CalculateFusedMatrices(gates.begin(), gates.end());
 }
 
 }  // namespace qsim

--- a/lib/fuser_basic.h
+++ b/lib/fuser_basic.h
@@ -20,29 +20,27 @@
 #include <utility>
 #include <vector>
 
-#include "gate.h"
 #include "fuser.h"
+#include "gate.h"
+#include "operation.h"
+#include "operation_base.h"
 
 namespace qsim {
 
 /**
- * Stateless object with methods for aggregating `Gate`s into `GateFused`.
- * Measurement gates with equal times are fused together.
- * User-defined controlled gates (controlled_by.size() > 0) and gates acting on
- * more than two qubits are not fused.
- * The template parameter Gate can be Gate type or a pointer to Gate type.
+ * Stateless object with methods for aggregating matrix `Gate`s into
+ * `FusedGate`s. Measurement gates with equal times are fused together.
+ * Non-matrix gates (such as user-defined controlled gates) and matrix-gates
+ * acting on more than two qubits are not fused.
  * This class is deprecated. It is recommended to use MultiQubitGateFuser
  * from fuser_mqubit.h.
  */
-template <typename IO, typename Gate>
-class BasicGateFuser final : public Fuser<IO, Gate> {
+template <typename IO>
+class BasicGateFuser final : public Fuser<IO> {
  private:
-  using Base = Fuser<IO, Gate>;
-  using RGate = typename Base::RGate;
+  using Base = Fuser<IO>;
 
  public:
-  using GateFused = qsim::GateFused<RGate>;
-
   /**
    * User-specified parameters for gate fusion.
    * BasicGateFuser does not use any parameters.
@@ -53,352 +51,432 @@ class BasicGateFuser final : public Fuser<IO, Gate> {
 
   /**
    * Stores sets of gates that can be applied together. Only one- and
-   * two-qubit gates will get fused. To respect specific time boundaries while
-   * fusing gates, use the other version of this method below.
+   * two-qubit matrix gates (represented by the Gate struct) are fused.
+   * To respect specific time boundaries while fusing gates, use the other
+   * version of this method below.
    * @param param Options for gate fusion.
-   * @param max_qubit1 The maximum qubit index (plus one) acted on by 'gates'.
-   * @param gates The gates (or pointers to the gates) to be fused.
-   *   Gate times of the gates that act on the same qubits should be ordered.
-   *   Gates that are out of time order should not cross the time boundaries
-   *   set by measurement gates.
+   * @param max_qubit1 The maximum qubit index (plus one) acted on by
+   *   operations.
+   * @param ops Operations to be fused. Operation times for gates acting
+   *   on the same qubits must be ordered. Operations that are out of time
+   *   order must not cross the time boundaries set by `times_to_split_at`
+   *   or by measurement gates.
    * @param fuse_matrix If true, multiply gate matrices together.
-   * @return A vector of fused gate objects. Each element is a set of gates
-   *   acting on a specific pair of qubits which can be applied as a group.
+   * @return A vector of fused operations. Each element is a variant
+   *   containing:
+   *   - A `FusedGate` object for merged gates.
+   *   - A `Measurement` object (representing a fused measurement).
+   *   - A `const Operation*` pointing to the original operation if it was not
+   *     eligible for fusion (e.g., multi-controlled gates).
+   *   Note: The input operation container must outlive the returned vector,
+   *   as the variant may hold pointers to the original operations.
    */
-  static std::vector<GateFused> FuseGates(const Parameter& param,
-                                          unsigned max_qubit1,
-                                          const std::vector<Gate>& gates,
-                                          bool fuse_matrix = true) {
-    return FuseGates(
-        param, max_qubit1, gates.cbegin(), gates.cend(), {}, fuse_matrix);
+  template <typename Operation>
+  static auto FuseGates(const Parameter& param, unsigned max_qubit1,
+                        const std::vector<Operation>& ops,
+                        bool fuse_matrix = true) {
+    return FuseGates<Operation>(
+        param, max_qubit1, ops.cbegin(), ops.cend(), {}, fuse_matrix);
   }
 
   /**
    * Stores sets of gates that can be applied together. Only one- and
-   * two-qubit gates will get fused.
+   * two-qubit matrix gates (represented by the Gate struct) are fused.
    * @param param Options for gate fusion.
-   * @param max_qubit1 The maximum qubit index (plus one) acted on by 'gates'.
-   * @param gates The gates (or pointers to the gates) to be fused.
-   *   Gate times of the gates that act on the same qubits should be ordered.
-   *   Gates that are out of time order should not cross the time boundaries
-   *   set by `times_to_split_at` or by measurement gates.
+   * @param max_qubit1 The maximum qubit index (plus one) acted on by
+   *   operations.
+   * @param ops Operations to be fused. Operation times for gates acting
+   *   on the same qubits must be ordered. Operations that are out of time
+   *   order must not cross the time boundaries set by `times_to_split_at`
+   *   or by measurement gates.
    * @param times_to_split_at Ordered list of time steps (boundaries) at which
-   *   to separate fused gates. Each element of the output will contain gates
-   *   from a single 'window' in this list.
+   *   to separate fused gates. Each element of the output contains gates
+   *   from a single 'window' defined by this list.
    * @param fuse_matrix If true, multiply gate matrices together.
-   * @return A vector of fused gate objects. Each element is a set of gates
-   *   acting on a specific pair of qubits which can be applied as a group.
+   * @return A vector of fused operations. Each element is a variant
+   *   containing:
+   *   - A `FusedGate` object for merged gates.
+   *   - A `Measurement` object (representing a fused measurement).
+   *   - A `const Operation*` pointing to the original operation if it was not
+   *     eligible for fusion (e.g., multi-controlled gates).
+   *   Note: The input operation container must outlive the returned vector,
+   *   as the variant may hold pointers to the original operations.
    */
-  static std::vector<GateFused> FuseGates(
-      const Parameter& param,
-      unsigned max_qubit1, const std::vector<Gate>& gates,
+  template <typename Operation>
+  static auto FuseGates(const Parameter& param, unsigned max_qubit1,
+                        const std::vector<Operation>& ops,
+                        const std::vector<unsigned>& times_to_split_at,
+                        bool fuse_matrix = true) {
+    return FuseGates<Operation>(param, max_qubit1, ops.cbegin(), ops.cend(),
+                                times_to_split_at, fuse_matrix);
+  }
+
+  /**
+   * Stores sets of gates that can be applied together. Only one- and
+   * two-qubit matrix gates (represented by the Gate struct) are fused.
+   * To respect specific time boundaries while fusing gates, use the other
+   * version of this method below.
+   * @param param Options for gate fusion.
+   * @param max_qubit1 The maximum qubit index (plus one) acted on by
+   *   operations.
+   * @param obeg, oend The iterator range [obeg, oend) of operations
+   *   to be fused. Operation times for gates acting on the same qubits
+   *   must be ordered. Operations that are out of time order must
+   *   not cross the time boundaries set by `times_to_split_at` or
+   *   by measurement gates.
+   * @param fuse_matrix If true, multiply gate matrices together.
+   * @return A vector of fused operations. Each element is a variant
+   *   containing:
+   *   - A `FusedGate` object for merged gates.
+   *   - A `Measurement` object (representing a fused measurement).
+   *   - A `const Operation*` pointing to the original operation if it was not
+   *     eligible for fusion (e.g., multi-controlled gates).
+   *   Note: The input operation container must outlive the returned vector,
+   *   as the variant may hold pointers to the original operations.
+   */
+  template <typename Operation>
+  static auto FuseGates(
+      const Parameter& param, unsigned max_qubit1,
+      typename std::vector<Operation>::const_iterator obeg,
+      typename std::vector<Operation>::const_iterator oend,
+      bool fuse_matrix = true) {
+    return FuseGates<Operation>(
+        param, max_qubit1, obeg, oend, {}, fuse_matrix);
+  }
+
+  /**
+   * Stores sets of gates that can be applied together. Only one- and
+   * two-qubit matrix gates (represented by the Gate struct) are fused.
+   * @param param Options for gate fusion.
+   * @param max_qubit1 The maximum qubit index (plus one) acted on by
+   *   operations.
+   * @param obeg, oend The iterator range [obeg, oend) of operations
+   *   to be fused. Operation times for gates acting on the same qubits
+   *   must be ordered. Operations that are out of time order must
+   *   not cross the time boundaries set by `times_to_split_at` or
+   *   by measurement gates.
+   * @param times_to_split_at Ordered list of time steps (boundaries) at which
+   *   to separate fused gates. Each element of the output contains gates
+   *   from a single 'window' defined by this list.
+   * @param fuse_matrix If true, multiply gate matrices together.
+   * @return A vector of fused operations. Each element is a variant
+   *   containing:
+   *   - A `FusedGate` object for merged gates.
+   *   - A `Measurement` object (representing a fused measurement).
+   *   - A `const Operation*` pointing to the original operation if it was not
+   *     eligible for fusion (e.g., multi-controlled gates).
+   *   Note: The input operation container must outlive the returned vector,
+   *   as the variant may hold pointers to the original operations.
+   */
+  template <typename OperationP>
+  static auto FuseGates(
+      const Parameter& param, unsigned max_qubit1,
+      typename std::vector<OperationP>::const_iterator obeg,
+      typename std::vector<OperationP>::const_iterator oend,
       const std::vector<unsigned>& times_to_split_at,
       bool fuse_matrix = true) {
-    return FuseGates(param, max_qubit1, gates.cbegin(), gates.cend(),
-                     times_to_split_at, fuse_matrix);
-  }
+    using Operation = std::remove_pointer_t<OperationP>;
+    using fp_type = OpFpType<Operation>;
+    using Gate = qsim::Gate<fp_type>;
+    using ControlledGate = qsim::ControlledGate<fp_type>;
+    using DecomposedGate = qsim::DecomposedGate<fp_type>;
+    using FusedGate = qsim::FusedGate<fp_type>;
+    using OperationF = std::variant<FusedGate, Measurement, const Operation*>;
 
-  /**
-   * Stores sets of gates that can be applied together. Only one- and
-   * two-qubit gates will get fused. To respect specific time boundaries while
-   * fusing gates, use the other version of this method below.
-   * @param param Options for gate fusion.
-   * @param max_qubit1 The maximum qubit index (plus one) acted on by 'gates'.
-   * @param gfirst, glast The iterator range [gfirst, glast) to fuse gates
-   *   (or pointers to gates) in. Gate times of the gates that act on the same
-   *   qubits should be ordered. Gates that are out of time order should not
-   *   cross the time boundaries set by measurement gates.
-   * @param fuse_matrix If true, multiply gate matrices together.
-   * @return A vector of fused gate objects. Each element is a set of gates
-   *   acting on a specific pair of qubits which can be applied as a group.
-   */
-  static std::vector<GateFused> FuseGates(
-      const Parameter& param, unsigned max_qubit1,
-      typename std::vector<Gate>::const_iterator gfirst,
-      typename std::vector<Gate>::const_iterator glast,
-      bool fuse_matrix = true) {
-    return FuseGates(param, max_qubit1, gfirst, glast, {}, fuse_matrix);
-  }
+    std::vector<OperationF> fused_ops;
 
-  /**
-   * Stores sets of gates that can be applied together. Only one- and
-   * two-qubit gates will get fused.
-   * @param param Options for gate fusion.
-   * @param max_qubit1 The maximum qubit index (plus one) acted on by 'gates'.
-   * @param gfirst, glast The iterator range [gfirst, glast) to fuse gates
-   *   (or pointers to gates) in. Gate times of the gates that act on the same
-   *   qubits should be ordered. Gates that are out of time order should not
-   *   cross the time boundaries set by `times_to_split_at` or by measurement
-   *   gates.
-   * @param times_to_split_at Ordered list of time steps (boundaries) at which
-   *   to separate fused gates. Each element of the output will contain gates
-   *   from a single 'window' in this list.
-   * @param fuse_matrix If true, multiply gate matrices together.
-   * @return A vector of fused gate objects. Each element is a set of gates
-   *   acting on a specific pair of qubits which can be applied as a group.
-   */
-  static std::vector<GateFused> FuseGates(
-      const Parameter& param, unsigned max_qubit1,
-      typename std::vector<Gate>::const_iterator gfirst,
-      typename std::vector<Gate>::const_iterator glast,
-      const std::vector<unsigned>& times_to_split_at,
-      bool fuse_matrix = true) {
-    std::vector<GateFused> gates_fused;
+    if (obeg >= oend) return fused_ops;
 
-    if (gfirst >= glast) return gates_fused;
+    std::size_t num_ops = oend - obeg;
 
-    std::size_t num_gates = glast - gfirst;
-
-    gates_fused.reserve(num_gates);
+    fused_ops.reserve(num_ops);
 
     // Merge with measurement gate times to separate fused gates at.
-    auto times =
-        Base::MergeWithMeasurementTimes(gfirst, glast, times_to_split_at);
+    auto times = Base::template MergeWithMeasurementTimes<OperationP>(
+        obeg, oend, times_to_split_at);
 
     // Map to keep track of measurement gates with equal times.
-    std::map<unsigned, std::vector<const RGate*>> measurement_gates;
+    std::map<unsigned, std::vector<const Operation*>> measurement_gates;
 
-    // Sequence of top level gates the other gates get fused to.
-    std::vector<const RGate*> gates_seq;
+    // Sequence of top level operations the other gates get fused to.
+    std::vector<const Operation*> ops_seq;
 
     // Sequence of zero-qubit gates.
-    std::vector<const RGate*> gates_seq0;
+    std::vector<const Operation*> ops_seq0;
 
-    // Lattice of gates: qubits "hyperplane" and time direction.
-    std::vector<std::vector<const RGate*>> gates_lat(max_qubit1);
+    // Lattice of operations: qubits "hyperplane" and time direction.
+    std::vector<std::vector<const Operation*>> ops_lat(max_qubit1);
 
-    // Current unfused gate.
-    auto gate_it = gfirst;
+    // Current unfused operation.
+    auto op_it = obeg;
 
-    std::size_t last_fused_gate_index = 0;
+    std::size_t last_fused_op_index = 0;
 
+    // Iterate over time windows.
     for (std::size_t l = 0; l < times.size(); ++l) {
-      gates_seq.resize(0);
-      gates_seq.reserve(num_gates);
+      ops_seq.resize(0);
+      ops_seq.reserve(num_ops);
 
-      gates_seq0.resize(0);
-      gates_seq0.reserve(num_gates);
+      ops_seq0.resize(0);
+      ops_seq0.reserve(num_ops);
 
       for (unsigned k = 0; k < max_qubit1; ++k) {
-        gates_lat[k].resize(0);
-        gates_lat[k].reserve(128);
+        ops_lat[k].resize(0);
+        ops_lat[k].reserve(128);
       }
 
-      // Fill gates_seq and gates_lat in.
-      for (; gate_it < glast; ++gate_it) {
-        const auto& gate = Base::GateToConstRef(*gate_it);
+      // Iterate over input operations and fill ops_seq and ops_lat in.
+      for (; op_it < oend; ++op_it) {
+        const auto& op = Base::OperationToConstRef(*op_it);
+        const auto& bop = OpBaseOperation(op);
 
-        if (gate.time > times[l]) break;
+        if (bop.time > times[l]) break;
 
-        if (!ValidateGate(gate, max_qubit1, gates_lat)) {
-          gates_fused.resize(0);
-          return gates_fused;
+        if (!ValidateOp(op, bop, max_qubit1, ops_lat)) {
+          fused_ops.resize(0);
+          return fused_ops;
         }
 
-        if (gate.kind == gate::kMeasurement) {
-          auto& mea_gates_at_time = measurement_gates[gate.time];
+        if (OpGetAlternative<Measurement>(op)) {
+          auto& mea_gates_at_time = measurement_gates[bop.time];
           if (mea_gates_at_time.size() == 0) {
-            gates_seq.push_back(&gate);
+            ops_seq.push_back(&op);
             mea_gates_at_time.reserve(max_qubit1);
           }
 
-          mea_gates_at_time.push_back(&gate);
-        } else if (gate.controlled_by.size() > 0 || gate.qubits.size() > 2) {
-          for (auto q : gate.qubits) {
-            gates_lat[q].push_back(&gate);
-          }
-          for (auto q : gate.controlled_by) {
-            gates_lat[q].push_back(&gate);
-          }
-          gates_seq.push_back(&gate);
-        } else if (gate.qubits.size() == 1) {
-          gates_lat[gate.qubits[0]].push_back(&gate);
-          if (gate.unfusible) {
-            gates_seq.push_back(&gate);
-          }
-        } else if (gate.qubits.size() == 2) {
-          gates_lat[gate.qubits[0]].push_back(&gate);
-          gates_lat[gate.qubits[1]].push_back(&gate);
-          gates_seq.push_back(&gate);
+          mea_gates_at_time.push_back(&op);
         } else {
-          gates_seq0.push_back(&gate);
+          for (auto q : bop.qubits) {
+            ops_lat[q].push_back(&op);
+          }
+
+          if (const auto* pg = OpGetAlternative<ControlledGate>(op)) {
+            for (auto q : pg->controlled_by) {
+              ops_lat[q].push_back(&op);
+            }
+          }
+
+          bool is_gate = OpGetAlternative<Gate>(op) != nullptr;
+
+          if (is_gate && bop.qubits.size() == 0) {
+            ops_seq0.push_back(&op);
+          } else if (!is_gate || bop.qubits.size() != 1) {
+            ops_seq.push_back(&op);
+          }
         }
       }
 
       std::vector<unsigned> last(max_qubit1, 0);
 
-      const RGate* delayed_measurement_gate = nullptr;
+      const Operation* deferred_measurement = nullptr;
 
       // Fuse gates.
-      for (auto pgate : gates_seq) {
-        if (pgate->kind == gate::kMeasurement) {
-          delayed_measurement_gate = pgate;
-        } else if (pgate->qubits.size() > 2
-                   || pgate->controlled_by.size() > 0) {
+      for (auto pop : ops_seq) {
+        const auto& qubits = OpQubits(*pop);
+
+        if (OpGetAlternative<Measurement>(*pop)) {
+          deferred_measurement = pop;
+        } else if (const auto* pg = OpGetAlternative<DecomposedGate>(*pop)) {
+          unsigned q0 = qubits[0];
+          FusedGate fgate{pg->kind, pg->time, {q0}, pg, {}, {}};
+
+          last[q0] = Advance(last[q0], ops_lat[q0], fgate.gates);
+
+          // Here pop == ops_lat[q0][last[q0]].
+
+          fgate.gates.push_back(pg);
+          last[q0] = Advance(last[q0] + 1, ops_lat[q0], fgate.gates);
+
+          fused_ops.push_back(std::move(fgate));
+        } else if (!OpGetAlternative<Gate>(*pop) || qubits.size() > 2) {
           // Multi-qubit or controlled gate.
 
-          for (auto q : pgate->qubits) {
+          for (auto q : qubits) {
             unsigned l = last[q];
-            if (gates_lat[q][l] != pgate) {
-              last[q] = AddOrphanedQubit(q, l, gates_lat, gates_fused);
+            if (ops_lat[q][l] != pop) {
+              last[q] = AddOrphanedQubit(q, l, ops_lat, fused_ops);
             }
             ++last[q];
           }
 
-          for (auto q : pgate->controlled_by) {
-            unsigned l = last[q];
-            if (gates_lat[q][l] != pgate) {
-              last[q] = AddOrphanedQubit(q, l, gates_lat, gates_fused);
+          if (const auto* pg = OpGetAlternative<ControlledGate>(*pop)) {
+            for (auto q : pg->controlled_by) {
+              unsigned l = last[q];
+              if (ops_lat[q][l] != pop) {
+                last[q] = AddOrphanedQubit(q, l, ops_lat, fused_ops);
+              }
+              ++last[q];
             }
-            ++last[q];
           }
 
-          gates_fused.push_back({pgate->kind, pgate->time, pgate->qubits,
-                                 pgate, {pgate}, {}});
-        } else if (pgate->qubits.size() == 1) {
-          unsigned q0 = pgate->qubits[0];
+          fused_ops.push_back(pop);
+        } else {
+          // Two-qubit gate.
 
-          GateFused gate_f = {pgate->kind, pgate->time, {q0}, pgate, {}, {}};
+          unsigned q0 = qubits[0];
+          unsigned q1 = qubits[1];
 
-          last[q0] = Advance(last[q0], gates_lat[q0], gate_f.gates);
-          gate_f.gates.push_back(gates_lat[q0][last[q0]]);
-          last[q0] = Advance(last[q0] + 1, gates_lat[q0], gate_f.gates);
+          const auto& gate = *OpGetAlternative<Gate>(*pop);
 
-          gates_fused.push_back(std::move(gate_f));
-        } else if (pgate->qubits.size() == 2) {
-          unsigned q0 = pgate->qubits[0];
-          unsigned q1 = pgate->qubits[1];
+          if (Done(last[q0], gate.time, ops_lat[q0])) continue;
 
-          if (Done(last[q0], pgate->time, gates_lat[q0])) continue;
-
-          GateFused gate_f =
-              {pgate->kind, pgate->time, {q0, q1}, pgate, {}, {}};
+          FusedGate fgate = {gate.kind, gate.time, {q0, q1}, &gate, {}, {}};
 
           do {
-            last[q0] = Advance(last[q0], gates_lat[q0], gate_f.gates);
-            last[q1] = Advance(last[q1], gates_lat[q1], gate_f.gates);
-            // Here gates_lat[q0][last[q0]] == gates_lat[q1][last[q1]].
+            last[q0] = Advance(last[q0], ops_lat[q0], fgate.gates);
+            last[q1] = Advance(last[q1], ops_lat[q1], fgate.gates);
 
-            gate_f.gates.push_back(gates_lat[q0][last[q0]]);
+            // Here ops_lat[q0][last[q0]] == ops_lat[q1][last[q1]].
 
-            last[q0] = Advance(last[q0] + 1, gates_lat[q0], gate_f.gates);
-            last[q1] = Advance(last[q1] + 1, gates_lat[q1], gate_f.gates);
-          } while (NextGate(last[q0], gates_lat[q0], last[q1], gates_lat[q1]));
+            const auto& gate2 = *OpGetAlternative<Gate>(*ops_lat[q0][last[q0]]);
+            fgate.gates.push_back(&gate2);
 
-          gates_fused.push_back(std::move(gate_f));
+            last[q0] = Advance(last[q0] + 1, ops_lat[q0], fgate.gates);
+            last[q1] = Advance(last[q1] + 1, ops_lat[q1], fgate.gates);
+          } while (NextGate(last[q0], ops_lat[q0], last[q1], ops_lat[q1]));
+
+          fused_ops.push_back(std::move(fgate));
         }
       }
 
       for (unsigned q = 0; q < max_qubit1; ++q) {
         auto l = last[q];
-        if (l == gates_lat[q].size()) continue;
+        if (l == ops_lat[q].size()) continue;
 
         // Orphaned qubit.
-        AddOrphanedQubit(q, l, gates_lat, gates_fused);
+        AddOrphanedQubit(q, l, ops_lat, fused_ops);
       }
 
-      if (delayed_measurement_gate != nullptr) {
-        auto pgate = delayed_measurement_gate;
+      if (deferred_measurement != nullptr) {
+        const auto& mea_gates_at_time =
+            measurement_gates[OpTime(*deferred_measurement)];
 
-        const auto& mea_gates_at_time = measurement_gates[pgate->time];
+        if (mea_gates_at_time.size() == 1) {
+          fused_ops.push_back(deferred_measurement);
+        } else {
+          Measurement mfused =
+              *OpGetAlternative<Measurement>(*deferred_measurement);
 
-        GateFused gate_f = {pgate->kind, pgate->time, {}, pgate, {}, {}};
-        gate_f.gates.reserve(mea_gates_at_time.size());
+          // Fuse measurement gates with equal times.
+          for (const auto* pop : mea_gates_at_time) {
+            if (pop == deferred_measurement) continue;
 
-        // Fuse measurement gates with equal times.
+            const auto& qs = OpQubits(*pop);
+            mfused.qubits.insert(mfused.qubits.end(), qs.begin(), qs.end());
+          }
 
-        for (const auto* pgate : mea_gates_at_time) {
-          gate_f.qubits.insert(gate_f.qubits.end(),
-                               pgate->qubits.begin(), pgate->qubits.end());
-          gate_f.gates.push_back(pgate);
+          fused_ops.push_back(std::move(mfused));
         }
-
-        gates_fused.push_back(std::move(gate_f));
       }
 
-      if (gates_seq0.size() != 0) {
-        Base::FuseZeroQubitGates(gates_seq0, [](const RGate* g) { return g; },
-                                 last_fused_gate_index, gates_fused);
+      if (ops_seq0.size() != 0) {
+        Base::FuseZeroQubitGates(ops_seq0, [](const Operation* g) { return g; },
+                                 last_fused_op_index, fused_ops);
       }
 
-      if (gate_it == glast) break;
+      if (op_it == oend) break;
 
-      last_fused_gate_index = gates_fused.size();
+      last_fused_op_index = fused_ops.size();
     }
 
     if (fuse_matrix) {
-      for (auto& gate_f : gates_fused) {
-        if (gate_f.kind != gate::kMeasurement && gate_f.kind != gate::kDecomp) {
-          CalculateFusedMatrix(gate_f);
+      for (auto& op : fused_ops) {
+        if (auto* pg = OpGetAlternative<FusedGate>(op)) {
+          if (!pg->ParentIsDecomposed()) {
+            CalculateFusedMatrix(*pg);
+          }
         }
       }
     }
 
-    return gates_fused;
+    return fused_ops;
   }
 
  private:
-  static unsigned Advance(unsigned k, const std::vector<const RGate*>& wl,
-                          std::vector<const RGate*>& gates) {
-    while (k < wl.size() && wl[k]->qubits.size() == 1
-           && wl[k]->controlled_by.size() == 0 && !wl[k]->unfusible) {
-      gates.push_back(wl[k++]);
+  template <typename Operation, typename PGate>
+  static unsigned Advance(unsigned k, const std::vector<const Operation*>& wl,
+                          std::vector<PGate>& gates) {
+    using Gate = qsim::Gate<OpFpType<Operation>>;
+
+    while (k < wl.size()) {
+      if (const auto* pg = OpGetAlternative<Gate>(*wl[k])) {
+        if (pg->qubits.size() == 1) {
+          gates.push_back(pg);
+        } else {
+          break;
+        }
+      } else {
+        break;
+      }
+      ++k;
     }
 
     return k;
   }
 
+  template <typename Operation>
   static bool Done(
-      unsigned k, unsigned t, const std::vector<const RGate*>& wl) {
-    return k >= wl.size() || wl[k]->time > t;
+      unsigned k, unsigned t, const std::vector<const Operation*>& wl) {
+    return k >= wl.size() || OpTime(*wl[k]) > t;
   }
 
-  static bool NextGate(unsigned k1, const std::vector<const RGate*>& wl1,
-                       unsigned k2, const std::vector<const RGate*>& wl2) {
-    return k1 < wl1.size() && k2 < wl2.size() && wl1[k1] == wl2[k2]
-        && wl1[k1]->qubits.size() < 3 && wl1[k1]->controlled_by.size() == 0;
+  template <typename Operation>
+  static bool NextGate(unsigned k1, const std::vector<const Operation*>& wl1,
+                       unsigned k2, const std::vector<const Operation*>& wl2) {
+    return k1 < wl1.size() && k2 < wl2.size()
+        && wl1[k1] == wl2[k2] && OpQubits(*wl1[k1]).size() < 3
+        && OpGetAlternative<Gate<OpFpType<Operation>>>(*wl1[k1]);
   }
 
-  template <typename GatesLat>
+  template <typename OpsLat, typename OperationF>
   static unsigned AddOrphanedQubit(unsigned q, unsigned k,
-                                   const GatesLat& gates_lat,
-                                   std::vector<GateFused>& gates_fused) {
-    auto pgate = gates_lat[q][k];
+                                   const OpsLat& ops_lat,
+                                   std::vector<OperationF>& fused_ops) {
+    using FusedGate = std::variant_alternative_t<0, OperationF>;
+    using fp_type = typename FusedGate::fp_type;
+    using Gate = qsim::Gate<fp_type>;
 
-    GateFused gate_f = {pgate->kind, pgate->time, {q}, pgate, {}, {}};
-    gate_f.gates.push_back(pgate);
+    const auto& gate1 = *OpGetAlternative<Gate>(*ops_lat[q][k]);
 
-    k = Advance(k + 1, gates_lat[q], gate_f.gates);
+    FusedGate fgate{gate1.kind, gate1.time, {q}, &gate1, {}, {}};
+    fgate.gates.push_back(&gate1);
 
-    gates_fused.push_back(std::move(gate_f));
+    k = Advance(k + 1, ops_lat[q], fgate.gates);
+
+    fused_ops.push_back(std::move(fgate));
 
     return k;
   }
 
-  template <typename Gate2, typename GatesLat>
-  static bool ValidateGate(const Gate2& gate, unsigned max_qubit1,
-                           const GatesLat& gates_lat) {
-    for (unsigned q : gate.qubits) {
+  template <typename OpsLat, typename Operation, typename BaseOperation>
+  static bool ValidateOp(const Operation& op, const BaseOperation& bop,
+                         unsigned max_qubit1, const OpsLat& ops_lat) {
+    using ControlledGate = qsim::ControlledGate<OpFpType<Operation>>;
+
+    for (unsigned q : bop.qubits) {
       if (q >= max_qubit1) {
         IO::errorf("fuser: gate qubit %u is out of range "
                    "(should be smaller than %u).\n", q, max_qubit1);
         return false;
       }
-      if (!gates_lat[q].empty() && gate.time <= gates_lat[q].back()->time) {
-        IO::errorf("fuser: gate at time %u is out of time order.\n", gate.time);
+      if (!ops_lat[q].empty() && bop.time <= OpTime(*ops_lat[q].back())) {
+        IO::errorf("fuser: gate at time %u is out of time order.\n", bop.time);
         return false;
       }
     }
 
-    for (unsigned q : gate.controlled_by) {
-      if (q >= max_qubit1) {
-        IO::errorf("fuser: gate qubit %u is out of range "
-                   "(should be smaller than %u).\n", q, max_qubit1);
-        return false;
-      }
-      if (!gates_lat[q].empty() && gate.time <= gates_lat[q].back()->time) {
-        IO::errorf("fuser: gate at time %u is out of time order.\n", gate.time);
-        return false;
+    if (const auto& pg = OpGetAlternative<ControlledGate>(op)) {
+      for (unsigned q : pg->controlled_by) {
+        if (q >= max_qubit1) {
+          IO::errorf("fuser: gate qubit %u is out of range "
+                     "(should be smaller than %u).\n", q, max_qubit1);
+          return false;
+        }
+        if (!ops_lat[q].empty() && bop.time <= OpTime(*ops_lat[q].back())) {
+          IO::errorf(
+              "fuser: gate at time %u is out of time order.\n", bop.time);
+          return false;
+        }
       }
     }
 

--- a/lib/fuser_mqubit.h
+++ b/lib/fuser_mqubit.h
@@ -1219,7 +1219,7 @@ class MultiQubitGateFuser final : public Fuser<IO> {
       }
       if (gates_lat[q] != nullptr
           && bop.time <= OpTime(*gates_lat[q]->val->parent)) {
-        IO::errorf("fuser: gate at time %u is out of time order.\n", time);
+        IO::errorf("fuser: gate at time %u is out of time order.\n", bop.time);
         return false;
       }
     }
@@ -1233,7 +1233,8 @@ class MultiQubitGateFuser final : public Fuser<IO> {
         }
         if (gates_lat[q] != nullptr
             && bop.time <= OpTime(*gates_lat[q]->val->parent)) {
-          IO::errorf("fuser: gate at time %u is out of time order.\n", time);
+          IO::errorf(
+              "fuser: gate at time %u is out of time order.\n", bop.time);
           return false;
         }
       }

--- a/lib/fuser_mqubit.h
+++ b/lib/fuser_mqubit.h
@@ -22,22 +22,23 @@
 #include <utility>
 #include <vector>
 
-#include "gate.h"
 #include "fuser.h"
+#include "gate.h"
+#include "operation.h"
+#include "operation_base.h"
 
 namespace qsim {
 
 /**
- * Multi-qubit gate fuser.
- * Measurement gates with equal times are fused together.
- * User-defined controlled gates (controlled_by.size() > 0) are not fused.
- * The template parameter Gate can be Gate type or a pointer to Gate type.
+ * Stateless object with methods for aggregating matrix `Gate`s into
+ * `FusedGate`s. Measurement gates with equal times are fused together.
+ * Non-matrix gates (such as user-defined controlled gates) are not fused.
+ * This fuser can fuse into up to six-qbuit gates.
  */
-template <typename IO, typename Gate>
-class MultiQubitGateFuser final : public Fuser<IO, Gate> {
+template <typename IO>
+class MultiQubitGateFuser final : public Fuser<IO> {
  private:
-  using Base = Fuser<IO, Gate>;
-  using RGate = typename Base::RGate;
+  using Base = Fuser<IO>;
 
   // Auxillary classes and structs.
 
@@ -79,18 +80,24 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
     std::vector<Link> links_;
   };
 
+  template <typename Parent, typename PGate>
   struct GateF;
 
-  using LinkManager = LinkManagerT<GateF*>;
-  using Link = typename LinkManager::Link;
+  template <typename Parent, typename PGate>
+  using LinkManager = LinkManagerT<GateF<Parent, PGate>*>;
+  template <typename Parent, typename PGate>
+  using Link = typename LinkManager<Parent, PGate>::Link;
 
   // Intermediate representation of a fused gate.
+  template <typename Parent, typename PGate>
   struct GateF {
-    const RGate* parent;
-    std::vector<unsigned> qubits;
-    std::vector<const RGate*> gates;  // Gates that get fused to this gate.
-    std::vector<Link*> links;         // Gate "lattice" links.
-    uint64_t mask;                    // Qubit mask.
+    using fp_type = OpFpType<Parent>;
+
+    const Parent* parent;
+    Qubits qubits;
+    std::vector<PGate> gates;  // Gates that get fused to this gate.
+    std::vector<Link<Parent, PGate>*> links;  // Gate "lattice" links.
+    uint64_t mask;                            // Qubit mask.
     unsigned visited;
   };
 
@@ -98,175 +105,223 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
   // Note that MakeGateSequence assignes values from kSecond to the number of
   // gates in the sequence plus one, see below.
   enum Visited {
-    kZero = 0,             // Start value for "normal" gates.
-    kFirst = 1,            // Value after the first pass for partially fused
-                           // "normal" gates.
-    kSecond = 2,           // Start value to assign values in MakeGateSequence.
-    kCompress = 99999997,  // Used to compress links.
-    kMeaCnt = 99999998,    // Start value for controlled or measurement gates.
-    kFinal = 99999999,     // Value after the second pass for fused "normal"
-                           // gates or for controlled and measurement gates.
+    kZero = 0,              // Start value for matrix gates.
+    kFirst = 1,             // Value after the first pass for partially fused
+                            // matrix gates.
+    kSecond = 2,            // Start value to assign values in MakeGateSequence.
+    kCompress = 99999997,   // Used to compress links.
+    kUnfusible = 99999998,  // Start value for controlled or measurement gates.
+    kFinal = 99999999,      // Value after the first pass for child gates or
+                            // after the second pass for fused matrix gates,
+                            // controlled gates, and measurement gates.
   };
 
   struct Stat {
-    unsigned num_mea_gates = 0;
-    unsigned num_fused_mea_gates = 0;
+    unsigned num_measurements = 0;
+    unsigned num_fused_measurements = 0;
     unsigned num_fused_gates = 0;
-    unsigned num_controlled_gates = 0;
+    unsigned num_unfusible_gates = 0;
     std::vector<unsigned> num_gates;
   };
 
   // Gate that is added to a sequence of gates to fuse together.
+  template <typename Parent, typename PGate>
   struct GateA {
-    GateF* gate;
-    std::vector<unsigned> qubits;  // Added qubits.
-    std::vector<Link*> links;      // Added lattice links.
+    GateF<Parent, PGate>* gate;
+    Qubits qubits;                            // Added qubits.
+    std::vector<Link<Parent, PGate>*> links;  // Added lattice links.
   };
 
+  template <typename Parent, typename PGate>
   struct Scratch {
-    std::vector<GateA> data;
-    std::vector<GateA*> prev1;
-    std::vector<GateA*> prev2;
-    std::vector<GateA*> next1;
-    std::vector<GateA*> next2;
-    std::vector<GateA*> longest_seq;
-    std::vector<GateA*> stack;
-    std::vector<GateF*> gates;
+    std::vector<GateA<Parent, PGate>> data;
+    std::vector<GateA<Parent, PGate>*> prev1;
+    std::vector<GateA<Parent, PGate>*> prev2;
+    std::vector<GateA<Parent, PGate>*> next1;
+    std::vector<GateA<Parent, PGate>*> next2;
+    std::vector<GateA<Parent, PGate>*> longest_seq;
+    std::vector<GateA<Parent, PGate>*> stack;
+    std::vector<GateF<Parent, PGate>*> gates;
     unsigned count = 0;
   };
 
  public:
-  using GateFused = qsim::GateFused<RGate>;
-
   /**
    * User-specified parameters for gate fusion.
    */
   struct Parameter {
     /**
      * Maximum number of qubits in a fused gate. It can take values from 2 to
-     * 6 (0 and 1 are equivalent to 2). It is not recommended to use 5 or 6 as
-     * that might degrade performance for not very fast machines.
+     * 6 (0 and 1 are equivalent to 2). For optimal performance, a value of
+     * 4 or 5 is recommended to balance memory bandwidth and computational
+     * overhead.
      */
     unsigned max_fused_size = 2;
     unsigned verbosity = 0;
   };
 
   /**
-   * Stores sets of gates that can be applied together. To respect specific
-   * time boundaries while fusing gates, use the other version of this method
-   * below.
+   * Stores sets of gates that can be applied together. Only one- and
+   * two-qubit matrix gates (represented by the Gate struct) are fused.
+   * To respect specific time boundaries while fusing gates, use the other
+   * version of this method below.
    * @param param Options for gate fusion.
-   * @param max_qubit1 The maximum qubit index (plus one) acted on by 'gates'.
-   * @param gates The gates (or pointers to the gates) to be fused.
-   *   Gate times of the gates that act on the same qubits should be ordered.
-   *   Gates that are out of time order should not cross the time boundaries
-   *   set by measurement gates.
+   * @param max_qubit1 The maximum qubit index (plus one) acted on by
+   *   operations.
+   * @param ops Operations to be fused. Operation times for gates acting
+   *   on the same qubits must be ordered. Operations that are out of time
+   *   order must not cross the time boundaries set by `times_to_split_at`
+   *   or by measurement gates.
    * @param fuse_matrix If true, multiply gate matrices together.
-   * @return A vector of fused gate objects. Each element is a set of gates
-   *   acting on a specific pair of qubits which can be applied as a group.
+   * @return A vector of fused operations. Each element is a variant
+   *   containing:
+   *   - A `FusedGate` object for merged gates.
+   *   - A `Measurement` object (representing a fused measurement).
+   *   - A `const Operation*` pointing to the original operation if it was not
+   *     eligible for fusion (e.g., multi-controlled gates).
+   *   Note: The input operation container must outlive the returned vector,
+   *   as the variant may hold pointers to the original operations.
    */
-  static std::vector<GateFused> FuseGates(const Parameter& param,
-                                          unsigned max_qubit1,
-                                          const std::vector<Gate>& gates,
-                                          bool fuse_matrix = true) {
-    return FuseGates(
-        param, max_qubit1, gates.cbegin(), gates.cend(), {}, fuse_matrix);
+  template <typename Operation>
+  static auto FuseGates(const Parameter& param, unsigned max_qubit1,
+                        const std::vector<Operation>& ops,
+                        bool fuse_matrix = true) {
+    return FuseGates<Operation>(
+        param, max_qubit1, ops.cbegin(), ops.cend(), {}, fuse_matrix);
   }
 
   /**
-   * Stores sets of gates that can be applied together.
+   * Stores sets of gates that can be applied together. Only one- and
+   * two-qubit matrix gates (represented by the Gate struct) are fused.
    * @param param Options for gate fusion.
-   * @param max_qubit1 The maximum qubit index (plus one) acted on by 'gates'.
-   * @param gates The gates (or pointers to the gates) to be fused.
-   *   Gate times of the gates that act on the same qubits should be ordered.
-   *   Gates that are out of time order should not cross the time boundaries
-   *   set by `times_to_split_at` or by measurement gates.
+   * @param max_qubit1 The maximum qubit index (plus one) acted on by
+   *   operations.
+   * @param ops Operations to be fused. Operation times for gates acting
+   *   on the same qubits must be ordered. Operations that are out of time
+   *   order must not cross the time boundaries set by `times_to_split_at`
+   *   or by measurement gates.
    * @param times_to_split_at Ordered list of time steps (boundaries) at which
-   *   to separate fused gates. Each element of the output will contain gates
-   *   from a single 'window' in this list.
+   *   to separate fused gates. Each element of the output contains gates
+   *   from a single 'window' defined by this list.
    * @param fuse_matrix If true, multiply gate matrices together.
-   * @return A vector of fused gate objects. Each element is a set of gates
-   *   acting on a specific pair of qubits which can be applied as a group.
+   * @return A vector of fused operations. Each element is a variant
+   *   containing:
+   *   - A `FusedGate` object for merged gates.
+   *   - A `Measurement` object (representing a fused measurement).
+   *   - A `const Operation*` pointing to the original operation if it was not
+   *     eligible for fusion (e.g., multi-controlled gates).
+   *   Note: The input operation container must outlive the returned vector,
+   *   as the variant may hold pointers to the original operations.
    */
-  static std::vector<GateFused> FuseGates(
-      const Parameter& param,
-      unsigned max_qubit1, const std::vector<Gate>& gates,
+  template <typename Operation>
+  static auto FuseGates(const Parameter& param, unsigned max_qubit1,
+                        const std::vector<Operation>& ops,
+                        const std::vector<unsigned>& times_to_split_at,
+                        bool fuse_matrix = true) {
+    return FuseGates<Operation>(param, max_qubit1, ops.cbegin(), ops.cend(),
+                                times_to_split_at, fuse_matrix);
+  }
+
+  /**
+   * Stores sets of gates that can be applied together. Only one- and
+   * two-qubit matrix gates (represented by the Gate struct) are fused.
+   * To respect specific time boundaries while fusing gates, use the other
+   * version of this method below.
+   * @param param Options for gate fusion.
+   * @param max_qubit1 The maximum qubit index (plus one) acted on by
+   *   operations.
+   * @param obeg, oend The iterator range [obeg, oend) of operations
+   *   to be fused. Operation times for gates acting on the same qubits
+   *   must be ordered. Operations that are out of time order must
+   *   not cross the time boundaries set by `times_to_split_at` or
+   *   by measurement gates.
+   * @param fuse_matrix If true, multiply gate matrices together.
+   * @return A vector of fused operations. Each element is a variant
+   *   containing:
+   *   - A `FusedGate` object for merged gates.
+   *   - A `Measurement` object (representing a fused measurement).
+   *   - A `const Operation*` pointing to the original operation if it was not
+   *     eligible for fusion (e.g., multi-controlled gates).
+   *   Note: The input operation container must outlive the returned vector,
+   *   as the variant may hold pointers to the original operations.
+   */
+  template <typename Operation>
+  static auto FuseGates(
+      const Parameter& param, unsigned max_qubit1,
+      typename std::vector<Operation>::const_iterator obeg,
+      typename std::vector<Operation>::const_iterator oend,
+      bool fuse_matrix = true) {
+    return FuseGates<Operation>(
+        param, max_qubit1, obeg, oend, {}, fuse_matrix);
+  }
+
+  /**
+   * Stores sets of gates that can be applied together. Only one- and
+   * two-qubit matrix gates (represented by the Gate struct) are fused.
+   * @param param Options for gate fusion.
+   * @param max_qubit1 The maximum qubit index (plus one) acted on by
+   *   operations.
+   * @param obeg, oend The iterator range [obeg, oend) of operations
+   *   to be fused. Operation times for gates acting on the same qubits
+   *   must be ordered. Operations that are out of time order must
+   *   not cross the time boundaries set by `times_to_split_at` or
+   *   by measurement gates.
+   * @param times_to_split_at Ordered list of time steps (boundaries) at which
+   *   to separate fused gates. Each element of the output contains gates
+   *   from a single 'window' defined by this list.
+   * @param fuse_matrix If true, multiply gate matrices together.
+   * @return A vector of fused operations. Each element is a variant
+   *   containing:
+   *   - A `FusedGate` object for merged gates.
+   *   - A `Measurement` object (representing a fused measurement).
+   *   - A `const Operation*` pointing to the original operation if it was not
+   *     eligible for fusion (e.g., multi-controlled gates).
+   *   Note: The input operation container must outlive the returned vector,
+   *   as the variant may hold pointers to the original operations.
+   */
+  template <typename OperationP>
+  static auto FuseGates(
+      const Parameter& param, unsigned max_qubit1,
+      typename std::vector<OperationP>::const_iterator obeg,
+      typename std::vector<OperationP>::const_iterator oend,
       const std::vector<unsigned>& times_to_split_at,
       bool fuse_matrix = true) {
-    return FuseGates(param, max_qubit1, gates.cbegin(), gates.cend(),
-                     times_to_split_at, fuse_matrix);
-  }
+    using Operation = std::remove_pointer_t<OperationP>;
+    using fp_type = OpFpType<Operation>;
+    using Gate = qsim::Gate<fp_type>;
+    using ControlledGate = qsim::ControlledGate<fp_type>;
+    using FusedGate = qsim::FusedGate<fp_type>;
+    using PGate = typename FusedGate::PGate;
+    using OperationF = std::variant<FusedGate, Measurement, const Operation*>;
 
-  /**
-   * Stores sets of gates that can be applied together. To respect specific
-   * time boundaries while fusing gates, use the other version of this method
-   * below.
-   * @param param Options for gate fusion.
-   * @param max_qubit1 The maximum qubit index (plus one) acted on by 'gates'.
-   * @param gfirst, glast The iterator range [gfirst, glast) to fuse gates
-   *   (or pointers to gates) in. Gate times of the gates that act on the same
-   *   qubits should be ordered. Gates that are out of time order should not
-   *   cross the time boundaries set by measurement gates.
-   * @param fuse_matrix If true, multiply gate matrices together.
-   * @return A vector of fused gate objects. Each element is a set of gates
-   *   acting on a specific pair of qubits which can be applied as a group.
-   */
-  static std::vector<GateFused> FuseGates(
-      const Parameter& param, unsigned max_qubit1,
-      typename std::vector<Gate>::const_iterator gfirst,
-      typename std::vector<Gate>::const_iterator glast,
-      bool fuse_matrix = true) {
-    return FuseGates(param, max_qubit1, gfirst, glast, {}, fuse_matrix);
-  }
+    std::vector<OperationF> fused_ops;
 
-  /**
-   * Stores sets of gates that can be applied together.
-   * @param param Options for gate fusion.
-   * @param max_qubit1 The maximum qubit index (plus one) acted on by 'gates'.
-   * @param gfirst, glast The iterator range [gfirst, glast) to fuse gates
-   *   (or pointers to gates) in. Gate times of the gates that act on the same
-   *   qubits should be ordered. Gates that are out of time order should not
-   *   cross the time boundaries set by `times_to_split_at` or by measurement
-   *   gates.
-   * @param times_to_split_at Ordered list of time steps (boundaries) at which
-   *   to separate fused gates. Each element of the output will contain gates
-   *   from a single 'window' in this list.
-   * @param fuse_matrix If true, multiply gate matrices together.
-   * @return A vector of fused gate objects. Each element is a set of gates
-   *   acting on a specific pair of qubits which can be applied as a group.
-   */
-  static std::vector<GateFused> FuseGates(
-      const Parameter& param, unsigned max_qubit1,
-      typename std::vector<Gate>::const_iterator gfirst,
-      typename std::vector<Gate>::const_iterator glast,
-      const std::vector<unsigned>& times_to_split_at,
-      bool fuse_matrix = true) {
-    std::vector<GateFused> fused_gates;
+    if (obeg >= oend) return fused_ops;
 
-    if (gfirst >= glast) return fused_gates;
+    std::size_t num_ops = oend - obeg;
 
-    std::size_t num_gates = glast - gfirst;
-
-    fused_gates.reserve(num_gates);
+    fused_ops.reserve(num_ops);
 
     // Merge with measurement gate times to separate fused gates at.
-    auto epochs =
-        Base::MergeWithMeasurementTimes(gfirst, glast, times_to_split_at);
+    auto times = Base::template MergeWithMeasurementTimes<OperationP>(
+        obeg, oend, times_to_split_at);
 
-    LinkManager link_manager(max_qubit1 * num_gates);
+    using GateF = MultiQubitGateFuser::GateF<Operation, PGate>;
+
+    LinkManager<Operation, PGate> link_manager(max_qubit1 * num_ops);
 
     // Auxillary data structures.
     // Sequence of intermediate fused gates.
     std::vector<GateF> gates_seq;
     // Gate "lattice".
-    std::vector<Link*> gates_lat;
+    std::vector<Link<Operation, PGate>*> gates_lat;
     // Sequences of intermediate fused gates ordered by gate size.
     std::vector<std::vector<GateF*>> fgates(max_qubit1 + 1);
 
-    gates_seq.reserve(num_gates);
+    gates_seq.reserve(num_ops);
     gates_lat.reserve(max_qubit1);
 
-    Scratch scratch;
+    Scratch<Operation, PGate> scratch;
 
     scratch.data.reserve(1024);
     scratch.prev1.reserve(32);
@@ -283,10 +338,10 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
     max_fused_size = std::min(max_fused_size, max_qubit1);
 
     std::size_t last_fused_gate_index = 0;
-    auto gate_it = gfirst;
+    auto op_it = obeg;
 
-    // Iterate over epochs.
-    for (std::size_t l = 0; l < epochs.size(); ++l) {
+    // Iterate over time windows.
+    for (std::size_t l = 0; l < times.size(); ++l) {
       gates_seq.resize(0);
       gates_lat.resize(0);
       gates_lat.resize(max_qubit1, nullptr);
@@ -296,55 +351,57 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
       }
 
       uint64_t max_gate_size = 0;
-      GateF* last_mea_gate = nullptr;
+      GateF* last_measurement = nullptr;
 
-      // Iterate over input gates.
-      for (; gate_it < glast; ++gate_it) {
-        const auto& gate = Base::GateToConstRef(*gate_it);
+      // Iterate over input operations.
+      for (; op_it < oend; ++op_it) {
+        const auto& op = Base::OperationToConstRef(*op_it);
+        const auto& bop = OpBaseOperation(op);
 
-        if (gate.time > epochs[l]) break;
+        if (bop.time > times[l]) break;
 
-        if (!ValidateGate(gate, max_qubit1, gates_lat)) {
-          fused_gates.resize(0);
-          return fused_gates;
+        if (!ValidateOp(op, max_qubit1, gates_lat)) {
+          fused_ops.resize(0);
+          return fused_ops;
         }
 
         // Fill in auxillary data structures.
 
-        if (gate.kind == gate::kMeasurement) {
+        if (OpGetAlternative<Measurement>(op)) {
           // Measurement gate.
 
-          if (last_mea_gate == nullptr
-              || last_mea_gate->parent->time != gate.time) {
-            gates_seq.push_back({&gate, {}, {}, {}, 0, kMeaCnt});
-            last_mea_gate = &gates_seq.back();
+          if (last_measurement == nullptr
+              || OpTime(*last_measurement->parent) != bop.time) {
+            gates_seq.push_back({&op, {}, {}, {}, 0, kUnfusible});
+            last_measurement = &gates_seq.back();
 
-            last_mea_gate->qubits.reserve(max_qubit1);
-            last_mea_gate->links.reserve(max_qubit1);
+            last_measurement->qubits.reserve(max_qubit1);
+            last_measurement->links.reserve(max_qubit1);
 
-            ++stat.num_fused_mea_gates;
+            ++stat.num_fused_measurements;
           }
 
-          for (auto q : gate.qubits) {
-            last_mea_gate->qubits.push_back(q);
-            last_mea_gate->mask |= uint64_t{1} << q;
-            gates_lat[q] = link_manager.AddBack(last_mea_gate, gates_lat[q]);
-            last_mea_gate->links.push_back(gates_lat[q]);
+          for (auto q : bop.qubits) {
+            last_measurement->qubits.push_back(q);
+            last_measurement->mask |= uint64_t{1} << q;
+            gates_lat[q] = link_manager.AddBack(last_measurement, gates_lat[q]);
+            last_measurement->links.push_back(gates_lat[q]);
           }
 
-          last_mea_gate->gates.push_back(&gate);
-
-          ++stat.num_mea_gates;
+          ++stat.num_measurements;
         } else {
-          gates_seq.push_back({&gate, {}, {}, {}, 0, kZero});
+          gates_seq.push_back({&op, {}, {}, {}, 0, kZero});
           auto& fgate = gates_seq.back();
 
-          if (gate.controlled_by.size() == 0) {
-            if (max_gate_size < gate.qubits.size()) {
-              max_gate_size = gate.qubits.size();
+          unsigned num_gate_qubits = bop.qubits.size();
+
+          if (OpGetAlternative<Gate>(op)) {
+            // Matrix gates that are fused.
+
+            if (max_gate_size < num_gate_qubits) {
+              max_gate_size = num_gate_qubits;
             }
 
-            unsigned num_gate_qubits = gate.qubits.size();
             unsigned size = std::max(max_fused_size, num_gate_qubits);
 
             fgate.qubits.reserve(size);
@@ -353,47 +410,52 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
             fgate.links.reserve(size);
 
             if (fgates[num_gate_qubits].empty()) {
-              fgates[num_gate_qubits].reserve(num_gates);
+              fgates[num_gate_qubits].reserve(num_ops);
             }
             fgates[num_gate_qubits].push_back(&fgate);
 
+            for (auto q : bop.qubits) {
+              fgate.qubits.push_back(q);
+            }
+
             ++stat.num_gates[num_gate_qubits];
           } else {
-            // Controlled gate.
-            // Controlled gates are not fused with other gates.
+            // Other gates are not fused.
 
-            uint64_t size = gate.qubits.size() + gate.controlled_by.size();
+            uint64_t size = num_gate_qubits;
 
-            fgate.qubits.reserve(gate.qubits.size());
+            if (const auto* pg = OpGetAlternative<ControlledGate>(op)) {
+              size += pg->controlled_by.size();
+            }
+
             fgate.links.reserve(size);
+            fgate.visited = kUnfusible;
 
-            fgate.visited = kMeaCnt;
-            fgate.gates.push_back(&gate);
-
-            ++stat.num_controlled_gates;
+            ++stat.num_unfusible_gates;
           }
 
-          for (auto q : gate.qubits) {
-            fgate.qubits.push_back(q);
+          for (auto q : bop.qubits) {
             fgate.mask |= uint64_t{1} << q;
             gates_lat[q] = link_manager.AddBack(&fgate, gates_lat[q]);
             fgate.links.push_back(gates_lat[q]);
           }
 
-          for (auto q : gate.controlled_by) {
-            fgate.mask |= uint64_t{1} << q;
-            gates_lat[q] = link_manager.AddBack(&fgate, gates_lat[q]);
-            fgate.links.push_back(gates_lat[q]);
+          if (const auto* pg = OpGetAlternative<ControlledGate>(op)) {
+            for (auto q : pg->controlled_by) {
+              fgate.mask |= uint64_t{1} << q;
+              gates_lat[q] = link_manager.AddBack(&fgate, gates_lat[q]);
+              fgate.links.push_back(gates_lat[q]);
+            }
           }
         }
       }
 
       // Fuse large gates with smaller gates.
-      FuseGates(max_gate_size, fgates);
+      FuseGates<Gate>(max_gate_size, fgates);
 
       if (max_fused_size > 2) {
         FuseGateSequences(
-            max_fused_size, max_qubit1, scratch, gates_seq, stat, fused_gates);
+            max_fused_size, max_qubit1, scratch, gates_seq, stat, fused_ops);
       } else {
         unsigned prev_time = 0;
 
@@ -401,63 +463,71 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
         orphaned_gates.reserve(max_qubit1);
 
         for (auto& fgate : gates_seq) {
-          if (fgate.gates.size() == 0) continue;
+          if (fgate.visited != kUnfusible && fgate.gates.size() == 0) continue;
 
-          if (prev_time != fgate.parent->time) {
+          unsigned time = OpTime(*fgate.parent);
+
+          if (prev_time != time) {
             if (orphaned_gates.size() > 0) {
               FuseOrphanedGates(
-                  max_fused_size, stat, orphaned_gates, fused_gates);
+                  max_fused_size, stat, orphaned_gates, fused_ops);
               orphaned_gates.resize(0);
             }
 
-            prev_time = fgate.parent->time;
+            prev_time = time;
           }
 
           if (fgate.qubits.size() == 1 && max_fused_size > 1
-              && fgate.visited != kMeaCnt && !fgate.parent->unfusible) {
+              && fgate.visited != kUnfusible) {
             orphaned_gates.push_back(&fgate);
             continue;
           }
 
-          // Assume fgate.qubits (gate.qubits) are sorted.
-          fused_gates.push_back({fgate.parent->kind, fgate.parent->time,
-                                 std::move(fgate.qubits), fgate.parent,
-                                 std::move(fgate.gates), {}});
+          if (fgate.visited == kUnfusible) {
+            AddUnfusible(fgate, fused_ops);
+          } else {
+            // Assume fgate.qubits (gate.qubits) are sorted.
+            const Gate& parent = *OpGetAlternative<Gate>(*fgate.parent);
+            fused_ops.push_back(FusedGate{parent.kind, parent.time,
+                                          std::move(fgate.qubits), &parent,
+                                          std::move(fgate.gates), {}});
 
-          if (fgate.visited != kMeaCnt) {
             ++stat.num_fused_gates;
           }
         }
 
         if (orphaned_gates.size() > 0) {
-          FuseOrphanedGates(max_fused_size, stat, orphaned_gates, fused_gates);
+          FuseOrphanedGates(max_fused_size, stat, orphaned_gates, fused_ops);
         }
       }
 
       if (fgates[0].size() != 0) {
         Base::FuseZeroQubitGates(fgates[0],
                                  [](const GateF* g) { return g->parent; },
-                                 last_fused_gate_index, fused_gates);
+                                 last_fused_gate_index, fused_ops);
       }
 
-      last_fused_gate_index = fused_gates.size();
+      last_fused_gate_index = fused_ops.size();
     }
 
     if (fuse_matrix) {
-      for (auto& fgate : fused_gates) {
-        if (fgate.kind != gate::kMeasurement && fgate.kind != gate::kDecomp) {
-          CalculateFusedMatrix(fgate);
+      for (auto& op : fused_ops) {
+        if (auto* pg = OpGetAlternative<FusedGate>(op)) {
+          if (!pg->ParentIsDecomposed()) {
+            CalculateFusedMatrix(*pg);
+          }
         }
       }
     }
 
-    PrintStat(param.verbosity, stat, fused_gates);
+    PrintStat(param.verbosity, stat, fused_ops);
 
-    return fused_gates;
+    return fused_ops;
   }
 
  private:
   // Fuse large gates with smaller gates.
+  template <typename Gate, typename GateF>
   static void FuseGates(uint64_t max_gate_size,
                         std::vector<std::vector<GateF*>>& fgates) {
     // Traverse gates in order of decreasing size.
@@ -465,14 +535,19 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
       std::size_t pos = 0;
 
       for (auto fgate : fgates[max_gate_size - i]) {
-        if (fgate->visited > kZero) continue;
+        if (fgate->visited > kZero) {
+          if (fgate->gates.size() == 0) {
+            fgate->visited = kFinal;
+          }
+          continue;
+        }
 
         fgates[max_gate_size - i][pos++] = fgate;
 
         fgate->visited = kFirst;
 
         FusePrev(0, *fgate);
-        fgate->gates.push_back(fgate->parent);
+        fgate->gates.push_back(OpGetAlternative<Gate>(*fgate->parent));
         FuseNext(0, *fgate);
       }
 
@@ -490,38 +565,48 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
   // max_fused_size = 5: _-_-  or  -_-_
   //
   // max_fused_size = 6: _-_-_
+  template <typename Scratch, typename GateF, typename OperationF>
   static void FuseGateSequences(unsigned max_fused_size,
                                 unsigned max_qubit1, Scratch& scratch,
                                 std::vector<GateF>& gates_seq, Stat& stat,
-                                std::vector<GateFused>& fused_gates) {
+                                std::vector<OperationF>& fused_ops) {
+    using FusedGate = std::variant_alternative_t<0, OperationF>;
+    using fp_type = typename FusedGate::fp_type;
+    using Gate = qsim::Gate<fp_type>;
+
     unsigned prev_time = 0;
 
     std::vector<GateF*> orphaned_gates;
     orphaned_gates.reserve(max_qubit1);
 
     for (auto& fgate : gates_seq) {
-      if (prev_time != fgate.parent->time) {
+      unsigned time = OpTime(*fgate.parent);
+
+      if (prev_time != time) {
         if (orphaned_gates.size() > 0) {
-          FuseOrphanedGates(max_fused_size, stat, orphaned_gates, fused_gates);
+          FuseOrphanedGates(max_fused_size, stat, orphaned_gates, fused_ops);
           orphaned_gates.resize(0);
         }
 
-        prev_time = fgate.parent->time;
+        prev_time = time;
       }
 
-      if (fgate.visited == kFinal || fgate.gates.size() == 0) continue;
+      if (fgate.visited == kFinal) continue;
 
-      if (fgate.visited == kMeaCnt || fgate.qubits.size() >= max_fused_size
-          || fgate.parent->unfusible) {
-        if (fgate.visited != kMeaCnt) {
-          ++stat.num_fused_gates;
-        }
+      if (fgate.visited == kUnfusible) {
+        AddUnfusible(fgate, fused_ops);
+
+        continue;
+      }
+
+      if (fgate.qubits.size() >= max_fused_size) {
+        const Gate& parent = *OpGetAlternative<Gate>(*fgate.parent);
+        fused_ops.push_back(FusedGate{parent.kind, parent.time,
+                                      std::move(fgate.qubits), &parent,
+                                      std::move(fgate.gates), {}});
 
         fgate.visited = kFinal;
-
-        fused_gates.push_back({fgate.parent->kind, fgate.parent->time,
-                               std::move(fgate.qubits), fgate.parent,
-                               std::move(fgate.gates), {}});
+        ++stat.num_fused_gates;
 
         continue;
       }
@@ -544,9 +629,10 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
         for (auto fgate : scratch.gates) {
           std::sort(fgate->qubits.begin(), fgate->qubits.end());
 
-          fused_gates.push_back({fgate->parent->kind, fgate->parent->time,
-                                 std::move(fgate->qubits), fgate->parent,
-                                 std::move(fgate->gates), {}});
+          const Gate& parent = *OpGetAlternative<Gate>(*fgate->parent);
+          fused_ops.push_back(FusedGate{parent.kind, parent.time,
+                                        std::move(fgate->qubits), &parent,
+                                        std::move(fgate->gates), {}});
 
           ++stat.num_fused_gates;
         }
@@ -554,13 +640,18 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
     }
 
     if (orphaned_gates.size() > 0) {
-      FuseOrphanedGates(max_fused_size, stat, orphaned_gates, fused_gates);
+      FuseOrphanedGates(max_fused_size, stat, orphaned_gates, fused_ops);
     }
   }
 
+  template <typename GateF, typename OperationF>
   static void FuseOrphanedGates(unsigned max_fused_size, Stat& stat,
                                 std::vector<GateF*>& orphaned_gates,
-                                std::vector<GateFused>& fused_gates) {
+                                std::vector<OperationF>& fused_ops) {
+    using FusedGate = std::variant_alternative_t<0, OperationF>;
+    using fp_type = typename FusedGate::fp_type;
+    using Gate = qsim::Gate<fp_type>;
+
     for (std::size_t i = 0; i < orphaned_gates.size(); ++i) {
       auto ogate1 = orphaned_gates[i];
 
@@ -601,16 +692,43 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
 
       std::sort(ogate1->qubits.begin(), ogate1->qubits.end());
 
-      fused_gates.push_back({ogate1->parent->kind, ogate1->parent->time,
-                             std::move(ogate1->qubits), ogate1->parent,
-                             std::move(ogate1->gates), {}});
+      const Gate& parent = *OpGetAlternative<Gate>(*ogate1->parent);
+      fused_ops.push_back(FusedGate{parent.kind, parent.time,
+                                    std::move(ogate1->qubits), &parent,
+                                    std::move(ogate1->gates), {}});
 
       ++stat.num_fused_gates;
     }
   }
 
-  static void MakeGateSequence(
-      unsigned max_fused_size, Scratch& scratch, GateF& fgate) {
+  template <typename GateF, typename OperationF>
+  static void AddUnfusible(const GateF& fgate,
+                           std::vector<OperationF>& fused_ops) {
+    using FusedGate = std::variant_alternative_t<0, OperationF>;
+    using fp_type = typename FusedGate::fp_type;
+    using DecomposedGate = qsim::DecomposedGate<fp_type>;
+
+    if (const auto& pg = OpGetAlternative<Measurement>(*fgate.parent)) {
+      if (pg->qubits.size() == fgate.qubits.size()) {
+        fused_ops.push_back(fgate.parent);
+      } else {
+        Measurement mfused = *pg;
+        mfused.qubits = fgate.qubits;
+        fused_ops.push_back(std::move(mfused));
+      }
+    } else {
+      if (const auto* pg = OpGetAlternative<DecomposedGate>(*fgate.parent)) {
+        fused_ops.push_back(
+            FusedGate{pg->kind, pg->time, {pg->qubits[0]}, pg, {pg}, {}});
+      } else {
+        fused_ops.push_back(fgate.parent);
+      }
+    }
+  }
+
+  template <typename Scratch, typename Parent, typename PGate>
+  static void MakeGateSequence(unsigned max_fused_size,
+                               Scratch& scratch, GateF<Parent, PGate>& fgate) {
     unsigned level = kSecond + scratch.count;
 
     FindLongestGateSequence(max_fused_size, level, scratch, fgate);
@@ -644,7 +762,7 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
       }
 
       while (link->next != nullptr && link->next->val->visited == kCompress) {
-        LinkManager::Delete(link->next);
+        LinkManager<Parent, PGate>::Delete(link->next);
       }
     }
 
@@ -679,12 +797,14 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
     scratch.gates.push_back(&fgate);
   }
 
-  static void AddGatesFromNext(std::vector<const RGate*>& gates, GateF& fgate) {
+  template <typename PGate, typename GateF>
+  static void AddGatesFromNext(std::vector<PGate>& gates, GateF& fgate) {
     for (auto gate : gates) {
       fgate.gates.push_back(gate);
     }
   }
 
+  template <typename GateF, typename Scratch>
   static void AddGatesFromPrev(unsigned max_fused_size, const GateF& pfgate,
                                Scratch& scratch, GateF& fgate) {
     for (auto gate : pfgate.gates) {
@@ -702,8 +822,9 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
     }
   }
 
-  static void FindLongestGateSequence(
-      unsigned max_fused_size, unsigned level, Scratch& scratch, GateF& fgate) {
+  template <typename Scratch, typename GateF>
+  static void FindLongestGateSequence(unsigned max_fused_size, unsigned level,
+                                      Scratch& scratch, GateF& fgate) {
     scratch.data.push_back({&fgate, {}, {}});
 
     scratch.longest_seq.resize(0);
@@ -717,7 +838,8 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
 
     unsigned max_size = cur_size;
 
-    GetNextAvailableGates(max_fused_size, cur_size, fgate, nullptr,
+    GetNextAvailableGates(max_fused_size, cur_size, fgate,
+                          (const GateF*) nullptr,
                           scratch.data, scratch.next1);
 
     for (auto n1 : scratch.next1) {
@@ -725,7 +847,8 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
       if (cur_size2 > max_fused_size) continue;
 
       bool feasible = GetPrevAvailableGates(max_fused_size, cur_size,
-                                            level, *n1->gate, nullptr,
+                                            level, *n1->gate,
+                                            (const GateF*) nullptr,
                                             scratch.data, scratch.prev1);
 
       if (!feasible) continue;
@@ -803,6 +926,7 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
     }
   }
 
+  template <typename Scratch, typename GateA>
   static void Push(unsigned level, unsigned cur_size2, unsigned& cur_size,
                    unsigned& max_size, Scratch& scratch, GateA* agate) {
     agate->gate->visited = level;
@@ -815,12 +939,14 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
     }
   }
 
+  template <typename Scratch, typename GateA>
   static void Pop(unsigned& cur_size, Scratch& scratch, GateA* agate) {
     agate->gate->visited = kFirst;
     cur_size -= agate->qubits.size();
     scratch.stack.pop_back();
   }
 
+  template <typename GateF, typename GateA>
   static void GetNextAvailableGates(unsigned max_fused_size, unsigned cur_size,
                                     const GateF& pgate1, const GateF* pgate2,
                                     std::vector<GateA>& scratch,
@@ -832,7 +958,7 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
 
       auto ngate = link->next->val;
 
-      if (ngate->visited > kFirst || ngate->parent->unfusible) continue;
+      if (ngate->visited > kFirst) continue;
 
       GateA next = {ngate, {}, {}};
       next.qubits.reserve(8);
@@ -847,6 +973,7 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
     }
   }
 
+  template <typename GateF, typename GateA>
   static bool GetPrevAvailableGates(unsigned max_fused_size,
                                     unsigned cur_size, unsigned level,
                                     const GateF& ngate1, const GateF* ngate2,
@@ -861,7 +988,7 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
 
       if (pgate->visited == kFinal || pgate->visited == level) continue;
 
-      if (pgate->visited > kFirst || pgate->parent->unfusible) {
+      if (pgate->visited > kFirst) {
         prev_gates.resize(0);
         return false;
       }
@@ -877,7 +1004,7 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
       for (auto link : pgate->links) {
         if (link->prev == nullptr) continue;
 
-        if (link->prev->val->visited <= kMeaCnt) {
+        if (link->prev->val->visited <= kUnfusible) {
           all_prev_visited = false;
           break;
         }
@@ -899,6 +1026,7 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
     return true;
   }
 
+  template <typename GateF, typename GateA>
   static void GetAddedQubits(const GateF& fgate0, const GateF* fgate1,
                              const GateF& fgate2, GateA& added) {
     for (std::size_t i = 0; i < fgate2.qubits.size(); ++i) {
@@ -917,8 +1045,11 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
   }
 
   // Fuse smaller gates with fgate back in gate time.
-  static void FusePrev(unsigned pass, GateF& fgate) {
-    std::vector<const RGate*> gates;
+  template <typename Parent, typename PGate>
+  static void FusePrev(unsigned pass, GateF<Parent, PGate>& fgate) {
+    using Link = Link<Parent, PGate>;
+
+    std::vector<PGate> gates;
     gates.reserve(fgate.gates.capacity());
 
     auto neighbor = [](const Link* link) -> const Link* {
@@ -933,7 +1064,10 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
   }
 
   // Fuse smaller gates with fgate forward in gate time.
-  static void FuseNext(unsigned pass, GateF& fgate) {
+  template <typename Parent, typename PGate>
+  static void FuseNext(unsigned pass, GateF<Parent, PGate>& fgate) {
+    using Link = Link<Parent, PGate>;
+
     auto neighbor = [](const Link* link) -> const Link* {
       return link->next;
     };
@@ -941,9 +1075,13 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
     FusePrevOrNext<std::less<unsigned>>(pass, neighbor, fgate, fgate.gates);
   }
 
-  template <typename R, typename Neighbor>
-  static void FusePrevOrNext(unsigned pass, Neighbor neighb, GateF& fgate,
-                             std::vector<const RGate*>& gates) {
+  template <typename R, typename Neighbor, typename Parent, typename PGate>
+  static void FusePrevOrNext(unsigned pass, Neighbor neighb,
+                             GateF<Parent, PGate>& fgate,
+                             std::vector<PGate>& gates) {
+    using Link = Link<Parent, PGate>;
+    using Gate = qsim::Gate<typename GateF<Parent, PGate>::fp_type>;
+
     uint64_t bad_mask = 0;
     auto links = fgate.links;
 
@@ -958,7 +1096,8 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
                   auto rn = neighb(r);
 
                   if (ln != nullptr && rn != nullptr) {
-                    return R()(ln->val->parent->time, rn->val->parent->time);
+                    return R()(OpTime(*ln->val->parent),
+                               OpTime(*rn->val->parent));
                   } else {
                     // nullptrs are larger than everything else and
                     // equivalent among each other.
@@ -974,13 +1113,14 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
         auto g = n->val;
 
         if (!QubitsAreIn(fgate.mask, g->mask) || (g->mask & bad_mask) != 0
-            || g->visited > pass || g->parent->unfusible) {
+            || g->visited > pass) {
           bad_mask |= g->mask;
         } else {
           g->visited = pass == 0 ? kFirst : kFinal;
 
           if (pass == 0) {
-            gates.push_back(g->parent);
+            // g->parent must hold the type Gate here.
+            gates.push_back(OpGetAlternative<Gate>(*g->parent));
           } else {
             for (auto gate : g->gates) {
               gates.push_back(gate);
@@ -988,7 +1128,7 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
           }
 
           for (auto link : g->links) {
-            LinkManager::Delete(link);
+            LinkManager<Parent, PGate>::Delete(link);
           }
 
           may_have_gates_to_fuse = true;
@@ -1002,20 +1142,25 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
     return ((mask0 | mask) ^ mask0) == 0;
   }
 
+  template <typename OperationF>
   static void PrintStat(unsigned verbosity, const Stat& stat,
-                        const std::vector<GateFused>& fused_gates) {
+                        const std::vector<OperationF>& fused_ops) {
+    using FusedGate = std::variant_alternative_t<0, OperationF>;
+    using fp_type = typename FusedGate::fp_type;
+    using ControlledGate = qsim::ControlledGate<fp_type>;
+
     if (verbosity < 3) return;
 
-    if (stat.num_controlled_gates > 0) {
-      IO::messagef("%u controlled gates\n", stat.num_controlled_gates);
+    if (stat.num_unfusible_gates > 0) {
+      IO::messagef("%u unfusible gates\n", stat.num_unfusible_gates);
     }
 
-    if (stat.num_mea_gates > 0) {
-      IO::messagef("%u measurement gates", stat.num_mea_gates);
-      if (stat.num_fused_mea_gates == stat.num_mea_gates) {
+    if (stat.num_measurements > 0) {
+      IO::messagef("%u measurement gates", stat.num_measurements);
+      if (stat.num_fused_measurements == stat.num_measurements) {
         IO::messagef("\n");
       } else {
-        IO::messagef(" are fused into %u gates\n", stat.num_fused_mea_gates);
+        IO::messagef(" are fused into %u gates\n", stat.num_fused_measurements);
       }
     }
 
@@ -1036,13 +1181,15 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
     if (verbosity < 5) return;
 
     IO::messagef("fused gate qubits:\n");
-    for (const auto& g : fused_gates) {
-      IO::messagef("%6u  ", g.parent->time);
-      if (g.parent->kind == gate::kMeasurement) {
+    for (const auto& op : fused_ops) {
+      const auto& bop = OpBaseOperation(op);
+      IO::messagef("%6u  ", bop.time);
+
+      if (OpGetAlternative<Measurement>(op)) {
         IO::messagef("m");
-      } else if (g.parent->controlled_by.size() > 0) {
+      } else if (const auto* pg = OpGetAlternative<ControlledGate>(op)) {
         IO::messagef("c");
-        for (auto q : g.parent->controlled_by) {
+        for (auto q : pg->controlled_by) {
           IO::messagef("%3u", q);
         }
         IO::messagef("  t");
@@ -1050,39 +1197,45 @@ class MultiQubitGateFuser final : public Fuser<IO, Gate> {
         IO::messagef(" ");
       }
 
-      for (auto q : g.qubits) {
+      for (auto q : bop.qubits) {
         IO::messagef("%3u", q);
       }
       IO::messagef("\n");
     }
   }
 
-  template <typename Gate2, typename GatesLat>
-  static bool ValidateGate(const Gate2& gate, unsigned max_qubit1,
-                           const GatesLat& gates_lat) {
-    for (unsigned q : gate.qubits) {
+  template <typename Operation, typename GatesLat>
+  static bool ValidateOp(const Operation& op, unsigned max_qubit1,
+                         const GatesLat& gates_lat) {
+    using ControlledGate = qsim::ControlledGate<OpFpType<Operation>>;
+
+    const auto& bop = OpBaseOperation(op);
+
+    for (unsigned q : bop.qubits) {
       if (q >= max_qubit1) {
         IO::errorf("fuser: gate qubit %u is out of range "
                    "(should be smaller than %u).\n", q, max_qubit1);
         return false;
       }
       if (gates_lat[q] != nullptr
-          && gate.time <= gates_lat[q]->val->parent->time) {
-        IO::errorf("fuser: gate at time %u is out of time order.\n", gate.time);
+          && bop.time <= OpTime(*gates_lat[q]->val->parent)) {
+        IO::errorf("fuser: gate at time %u is out of time order.\n", time);
         return false;
       }
     }
 
-    for (unsigned q : gate.controlled_by) {
-      if (q >= max_qubit1) {
-        IO::errorf("fuser: gate qubit %u is out of range "
-                   "(should be smaller than %u).\n", q, max_qubit1);
-        return false;
-      }
-      if (gates_lat[q] != nullptr
-          && gate.time <= gates_lat[q]->val->parent->time) {
-        IO::errorf("fuser: gate at time %u is out of time order.\n", gate.time);
-        return false;
+    if (const auto* pg = OpGetAlternative<ControlledGate>(op)) {
+      for (unsigned q : pg->controlled_by) {
+        if (q >= max_qubit1) {
+          IO::errorf("fuser: gate qubit %u is out of range "
+                     "(should be smaller than %u).\n", q, max_qubit1);
+          return false;
+        }
+        if (gates_lat[q] != nullptr
+            && bop.time <= OpTime(*gates_lat[q]->val->parent)) {
+          IO::errorf("fuser: gate at time %u is out of time order.\n", time);
+          return false;
+        }
       }
     }
 

--- a/lib/gate.h
+++ b/lib/gate.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC. All Rights Reserved.
+// Copyright 2026 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,11 +18,220 @@
 #include <algorithm>
 #include <cstdint>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "matrix.h"
+#include "operation_base.h"
 
 namespace qsim {
+
+// Forward declaration of Gate.
+template <typename FP>
+struct Gate;
+
+/**
+ * A matrix gate controlled by a number of qubits.
+ */
+template <typename FP>
+struct ControlledGate : public Gate<FP> {
+  ControlledGate() {}
+
+  /**
+   * Constructs a controlled gate from a base matrix gate. All control values
+   * are set to 1.
+   * @param base The underlying matrix gate (already permuted if necessary).
+   * @param controlled_by The indices of the control qubits.
+   */
+  template <typename Q = Qubits>
+  ControlledGate(const Gate<FP>& base, Q&& controlled_by)
+      : Gate<FP>{base}, controlled_by(std::forward<Q>(controlled_by)),
+        cmask((uint64_t{1} << this->controlled_by.size()) - 1) {}
+
+  /**
+   * Constructs a controlled gate from a base matrix gate.
+   * @param base The underlying matrix gate (already permuted if necessary).
+   * @param controlled_by The indices of the control qubits.
+   * @param cmask A bitmask representing the required control values (0 or 1)
+   *   of the control qubits.
+   */
+  template <typename Q = Qubits>
+  ControlledGate(const Gate<FP>& base, Q&& controlled_by, uint64_t cmask)
+      : Gate<FP>{base}, controlled_by(std::forward<Q>(controlled_by)),
+        cmask(cmask) {}
+
+  /** The indices of the qubits used as controls. */
+  Qubits controlled_by;
+  /**
+   * The required bit values for the control qubits, stored as a bitmask,
+   * where the i-th bit corresponds to the i-th qubit in `controlled_by`.
+   */
+  uint64_t cmask;
+};
+
+/**
+ * Creates a controlled gate from a matrix gate.
+ * @param gate The base gate to be controlled.
+ * @param controlled_by The control qubit indices.
+ * @return The resulting controlled gate object.
+ */
+template <typename FP, typename Q = Qubits>
+inline ControlledGate<FP> MakeControlledGate(
+    const Gate<FP>& gate, Q&& controlled_by) {
+  ControlledGate<FP> cgate{gate, std::forward<Q>(controlled_by)};
+  std::sort(cgate.controlled_by.begin(), cgate.controlled_by.end());
+
+  return cgate;
+}
+
+/**
+ * Creates a controlled gate from a matrix gate.
+ * @param gate The base gate to be controlled.
+ * @param controlled_by The control qubit indices.
+ * @param control_values The control values (0 or 1) for each control qubit.
+ * @return The resulting controlled gate object.
+ */
+template <typename FP, typename Q = Qubits>
+inline ControlledGate<FP> MakeControlledGate(
+    const Gate<FP>& gate, Q&& controlled_by,
+    const std::vector<unsigned>& control_values) {
+  // Assume controlled_by.size() == control_values.size().
+
+  bool sorted = true;
+
+  for (std::size_t i = 1; i < controlled_by.size(); ++i) {
+    if (controlled_by[i - 1] > controlled_by[i]) {
+      sorted = false;
+      break;
+    }
+  }
+
+  if (sorted) {
+    uint64_t cmask = 0;
+
+    for (std::size_t i = 0; i < control_values.size(); ++i) {
+      cmask |= (control_values[i] & 1) << i;
+    }
+
+    return ControlledGate<FP>{gate, std::forward<Q>(controlled_by), cmask};
+  } else {
+    struct ControlPair {
+      unsigned q;
+      unsigned v;
+    };
+
+    std::vector<ControlPair> cpairs;
+    cpairs.reserve(control_values.size());
+
+    for (std::size_t i = 0; i < control_values.size(); ++i) {
+      cpairs.push_back({controlled_by[i], control_values[i]});
+    }
+
+    // Sort control qubits and control values.
+    std::sort(cpairs.begin(), cpairs.end(),
+              [](const ControlPair& l, const ControlPair& r) -> bool {
+                return l.q < r.q;
+              });
+
+    uint64_t cmask = 0;
+
+    Qubits controlled_by;
+    controlled_by.reserve(control_values.size());
+
+    for (std::size_t i = 0; i < cpairs.size(); ++i) {
+      cmask |= (cpairs[i].v & 1) << i;
+      controlled_by.push_back(cpairs[i].q);
+    }
+
+    return ControlledGate<FP>{gate, std::move(controlled_by), cmask};
+  }
+}
+
+/**
+ * A generic matrix gate whose action is defined by a matrix.
+ */
+template <typename FP>
+struct Gate : public BaseOperation {
+  using fp_type = FP;
+
+  /**
+   * Gate parameters (e.g., rotation angles).
+   * Note: Currently utilized only in qsimh.
+   */
+  std::vector<fp_type> params;
+  /**
+   * The (not necessarily unitary) matrix representing the gate operation.
+   */
+  Matrix<fp_type> matrix;
+  /**
+   * Indicates if the qubits were swapped to ensure they are in ascending order.
+   */
+  bool swapped;
+
+  template <typename Q = Qubits>
+  auto ControlledBy(Q&& qubits) const {
+    return MakeControlledGate(*this, std::move(qubits));
+  }
+
+  template <typename Q = Qubits>
+  auto ControlledBy(Q&& qubits,
+                    const std::vector<unsigned>& control_values) const {
+    return MakeControlledGate(*this, std::move(qubits), control_values);
+  }
+};
+
+/**
+ * Represents a gate that has undergone Schmidt decomposition.
+ * Note: This struct is utilized only in the qsimh hybrid simulator.
+ */
+template <typename FP>
+struct DecomposedGate : public Gate<FP> {
+  /** A pointer to the original two-qubit gate that was decomposed. */
+  const Gate<FP>* parent;
+  /**
+   * A unique identifier used to sort decomposed gate pointers into
+   * a specific execution order.
+   */
+  unsigned id;
+};
+
+/**
+ * An operation that measures a specific set of qubits at a given time step.
+ */
+struct Measurement : public BaseOperation {};
+
+
+/**
+ * A collection of gates fused into a single operation.
+ * Component gates are typically multiplied into a single unitary matrix.
+ * Note for qsimh: If the collection contains a `DecomposedGate`, the
+ * `matrix` remains empty during the initial fusion pass. The fused
+ * matrix is computed later once the Schmidt decomposition components
+ * are populated.
+ */
+template <typename FP>
+struct FusedGate : public BaseOperation {
+  using fp_type = FP;
+
+  /** Pointer to either a standard matrix gate or a Schmidt-decomposed gate. */
+  using PGate = std::variant<const Gate<fp_type>*,
+                             const DecomposedGate<fp_type>*>;
+
+  /** The primary gate that initiated this fusion block. */
+  PGate parent;
+  /** Ordered sequence of all component gates in this block. */
+  std::vector<PGate> gates;
+  /**
+   * The fused matrix. May be empty if `fuse_matrix` is false or if the block
+   * contains a `DecomposedGate`.
+   */
+  Matrix<fp_type> matrix;
+
+  /** Returns true if the primary gate is a decomposed gate. */
+  bool ParentIsDecomposed() const {
+    return std::holds_alternative<const DecomposedGate<fp_type>*>(parent);
+  }
+};
 
 namespace detail {
 
@@ -44,172 +253,54 @@ inline void SortQubits(Gate& gate) {
 
 }  // namespace detail
 
-template <typename Qubits = std::vector<unsigned>, typename Gate>
-inline Gate& MakeControlledGate(Qubits&& controlled_by, Gate& gate) {
-  gate.controlled_by = std::forward<Qubits>(controlled_by);
-  gate.cmask = (uint64_t{1} << gate.controlled_by.size()) - 1;
-
-  std::sort(gate.controlled_by.begin(), gate.controlled_by.end());
-
-  return gate;
-}
-
-template <typename Qubits = std::vector<unsigned>, typename Gate>
-inline Gate& MakeControlledGate(Qubits&& controlled_by,
-                               const std::vector<unsigned>& control_values,
-                               Gate& gate) {
-  // Assume controlled_by.size() == control_values.size().
-
-  bool sorted = true;
-
-  for (std::size_t i = 1; i < controlled_by.size(); ++i) {
-    if (controlled_by[i - 1] > controlled_by[i]) {
-      sorted = false;
-      break;
-    }
-  }
-
-  if (sorted) {
-    gate.controlled_by = std::forward<Qubits>(controlled_by);
-    gate.cmask = 0;
-
-    for (std::size_t i = 0; i < control_values.size(); ++i) {
-      gate.cmask |= (control_values[i] & 1) << i;
-    }
-  } else {
-    struct ControlPair {
-      unsigned q;
-      unsigned v;
-    };
-
-    std::vector<ControlPair> cpairs;
-    cpairs.reserve(controlled_by.size());
-
-    for (std::size_t i = 0; i < controlled_by.size(); ++i) {
-      cpairs.push_back({controlled_by[i], control_values[i]});
-    }
-
-    // Sort control qubits and control values.
-    std::sort(cpairs.begin(), cpairs.end(),
-              [](const ControlPair& l, const ControlPair& r) -> bool {
-                return l.q < r.q;
-              });
-
-    gate.cmask = 0;
-    gate.controlled_by.reserve(controlled_by.size());
-
-    for (std::size_t i = 0; i < cpairs.size(); ++i) {
-      gate.cmask |= (cpairs[i].v & 1) << i;
-      gate.controlled_by.push_back(cpairs[i].q);
-    }
-  }
-
-  return gate;
-}
-
-namespace gate {
-
-constexpr int kDecomp = 100001;       // gate from Schmidt decomposition
-constexpr int kMeasurement = 100002;  // measurement gate
-
-}  // namespace gate
-
-enum GateAnyKind {
-  kGateAny = -1,
-};
-
 /**
- * A generic gate to make it easier to use qsim with external gate sets.
+ * A helper function to create a matrix gate. Qubit indices are sorted,
+ * and the gate matrix is permuted accordingly if the gate is non-symmetric.
+ * If a permutation occurs, the gate's `swapped` field is set to true.
+ * @param time The time step at which the gate is applied.
+ * @param qubits The qubit indices the gate acts on.
+ * @param matrix The initial gate matrix (permuted during creation if needed).
+ * @param params The gate parameters (utilized in qsimh).
+ * @return The resulting gate object with a canonical qubit ordering.
  */
-template <typename FP, typename GK = GateAnyKind>
-struct Gate {
-  using fp_type = FP;
-  using GateKind = GK;
-
-  GateKind kind;
-  unsigned time;
-  std::vector<unsigned> qubits;
-  std::vector<unsigned> controlled_by;
-  uint64_t cmask;
-  std::vector<fp_type> params;
-  Matrix<fp_type> matrix;
-  bool unfusible;      // If true, the gate is fused as a parent.
-  bool swapped;        // If true, the gate qubits are swapped to make qubits
-                       // ordered in ascending order. This does not apply to
-                       // control qubits of explicitly-controlled gates.
-
-  template <typename Qubits = std::vector<unsigned>>
-  Gate&& ControlledBy(Qubits&& controlled_by) {
-    MakeControlledGate(std::forward<Qubits>(controlled_by), *this);
-    return std::move(*this);
-  }
-
-  template <typename Qubits = std::vector<unsigned>>
-  Gate&& ControlledBy(Qubits&& controlled_by,
-                      const std::vector<unsigned>& control_values) {
-    MakeControlledGate(
-        std::forward<Qubits>(controlled_by), control_values, *this);
-    return std::move(*this);
-  }
-};
-
-template <typename Gate, typename GateDef,
-          typename Qubits = std::vector<unsigned>,
+template <typename Gate, typename GateDef, typename Q = Qubits,
           typename M = Matrix<typename Gate::fp_type>>
-inline Gate CreateGate(unsigned time, Qubits&& qubits, M&& matrix = {},
+inline Gate CreateGate(unsigned time, Q&& qubits, M&& matrix = {},
                        std::vector<typename Gate::fp_type>&& params = {}) {
-  Gate gate = {GateDef::kind, time, std::forward<Qubits>(qubits), {}, 0,
-               std::move(params), std::forward<M>(matrix), false, false};
+  Gate gate = {GateDef::kind, time, std::forward<Q>(qubits),
+               std::move(params), std::forward<M>(matrix), false};
 
-  if (GateDef::kind != gate::kMeasurement) {
-    switch (gate.qubits.size()) {
-    case 1:
-      break;
-    case 2:
-      if (gate.qubits[0] > gate.qubits[1]) {
-        gate.swapped = true;
-        std::swap(gate.qubits[0], gate.qubits[1]);
-        if (!GateDef::symmetric) {
-          MatrixShuffle({1, 0}, 2, gate.matrix);
-        }
+  switch (gate.qubits.size()) {
+  case 1:
+    break;
+  case 2:
+    if (gate.qubits[0] > gate.qubits[1]) {
+      gate.swapped = true;
+      std::swap(gate.qubits[0], gate.qubits[1]);
+      if (!GateDef::symmetric) {
+        MatrixShuffle({1, 0}, 2, gate.matrix);
       }
-      break;
-    default:
-      detail::SortQubits<Gate, GateDef>(gate);
     }
+    break;
+  default:
+    detail::SortQubits<Gate, GateDef>(gate);
   }
 
   return gate;
 }
 
-namespace gate {
-
-/**
- * A gate that simulates measurement of one or more qubits, collapsing the
- * state vector and storing the measured results.
- */
-template <typename Gate>
-struct Measurement {
-  using GateKind = typename Gate::GateKind;
-
-  static constexpr GateKind kind = GateKind::kMeasurement;
-  static constexpr char name[] = "m";
-  static constexpr bool symmetric = false;
-
-  template <typename Qubits = std::vector<unsigned>>
-  static Gate Create(unsigned time, Qubits&& qubits) {
-    return CreateGate<Gate, Measurement>(time, std::forward<Qubits>(qubits));
-  }
+enum OtherGateKind {
+  kMeasurement = 100002,
+  kChannel = 100003,
 };
 
-}  // namespace gate
+template <typename Q = Qubits>
+inline Measurement CreateMeasurement(unsigned time, Q&& qubits) {
+  return Measurement{kMeasurement, time, std::forward<Q>(qubits)};
+}
 
 template <typename fp_type>
 using schmidt_decomp_type = std::vector<std::vector<std::vector<fp_type>>>;
-
-template <typename fp_type, typename GateKind>
-schmidt_decomp_type<fp_type> GetSchmidtDecomp(
-    GateKind kind, const std::vector<fp_type>& params);
 
 }  // namespace qsim
 

--- a/lib/gate_appl.h
+++ b/lib/gate_appl.h
@@ -18,171 +18,71 @@
 #include <utility>
 #include <vector>
 
-#include "fuser.h"
 #include "gate.h"
 #include "matrix.h"
+#include "operation_base.h"
 
 namespace qsim {
 
 /**
- * Applies the given gate to the simulator state. Ignores measurement gates.
+ * Applies the given operation to the simulator state. Ignores measurement
+ * gates.
  * @param simulator Simulator object. Provides specific implementations for
  *   applying gates.
- * @param gate The gate to be applied.
+ * @param op The operation to be applied.
  * @param state The state of the system, to be updated by this method.
  */
-template <typename Simulator, typename Gate>
-inline void ApplyGate(const Simulator& simulator, const Gate& gate,
+template <typename Simulator, typename Operation>
+inline void ApplyGate(const Simulator& simulator, const Operation& op,
                       typename Simulator::State& state) {
-  if (gate.kind != gate::kMeasurement) {
-    if (gate.controlled_by.size() == 0) {
-      simulator.ApplyGate(gate.qubits, gate.matrix.data(), state);
-    } else {
-      simulator.ApplyControlledGate(gate.qubits, gate.controlled_by,
-                                    gate.cmask, gate.matrix.data(), state);
-    }
+  using FP = typename Simulator::fp_type;
+
+  if (const auto* pg = OpGetAlternative<Gate<FP>>(op)) {
+    simulator.ApplyGate(pg->qubits, pg->matrix.data(), state);
+  } else if (const auto* pg = OpGetAlternative<FusedGate<FP>>(op)) {
+    simulator.ApplyGate(pg->qubits, pg->matrix.data(), state);
+  } else if (const auto* pg = OpGetAlternative<ControlledGate<FP>>(op)) {
+    simulator.ApplyControlledGate(pg->qubits, pg->controlled_by,
+                                  pg->cmask, pg->matrix.data(), state);
   }
 }
 
 /**
- * Applies the given gate dagger to the simulator state. If the gate matrix is
- *   unitary then this is equivalent to applying the inverse gate. Ignores
- *   measurement gates.
- * @param simulator Simulator object. Provides specific implementations for
- *   applying gates.
- * @param gate The gate to be applied.
- * @param state The state of the system, to be updated by this method.
- */
-template <typename Simulator, typename Gate>
-inline void ApplyGateDagger(const Simulator& simulator, const Gate& gate,
-                            typename Simulator::State& state) {
-  if (gate.kind != gate::kMeasurement) {
-    auto matrix = gate.matrix;
-    MatrixDagger(unsigned{1} << gate.qubits.size(), matrix);
-
-    if (gate.controlled_by.size() == 0) {
-      simulator.ApplyGate(gate.qubits, matrix.data(), state);
-    } else {
-      simulator.ApplyControlledGate(gate.qubits, gate.controlled_by,
-                                    gate.cmask, matrix.data(), state);
-    }
-  }
-}
-
-/**
- * Applies the given gate to the simulator state.
- * @param state_space StateSpace object required to perform measurements.
- * @param simulator Simulator object. Provides specific implementations for
- *   applying gates.
- * @param gate The gate to be applied.
- * @param rgen Random number generator to perform measurements.
- * @param state The state of the system, to be updated by this method.
- * @param mresults As an input parameter, this can be empty or this can
- *   contain the results of the previous measurements. If gate is a measurement
- *   gate then after a successful run, the measurement result will be added to
- *   this.
- * @return True if the measurement performed successfully; false otherwise.
- */
-template <typename Simulator, typename Gate, typename Rgen>
-inline bool ApplyGate(
-    const typename Simulator::StateSpace& state_space,
-    const Simulator& simulator, const Gate& gate, Rgen& rgen,
-    typename Simulator::State& state,
-    std::vector<typename Simulator::StateSpace::MeasurementResult>& mresults) {
-  if (gate.kind == gate::kMeasurement) {
-    auto measure_result = state_space.Measure(gate.qubits, rgen, state);
-    if (measure_result.valid) {
-      mresults.push_back(std::move(measure_result));
-    } else {
-      return false;
-    }
-  } else {
-    ApplyGate(simulator, gate, state);
-  }
-
-  return true;
-}
-
-/**
- * Applies the given gate to the simulator state, discarding measurement
- *   results.
- * @param state_space StateSpace object required to perform measurements.
- * @param simulator Simulator object. Provides specific implementations for
- *   applying gates.
- * @param gate The gate to be applied.
- * @param rgen Random number generator to perform measurements.
- * @param state The state of the system, to be updated by this method.
- * @return True if the measurement performed successfully; false otherwise.
- */
-template <typename Simulator, typename Gate, typename Rgen>
-inline bool ApplyGate(const typename Simulator::StateSpace& state_space,
-                      const Simulator& simulator, const Gate& gate, Rgen& rgen,
-                      typename Simulator::State& state) {
-  if (gate.kind == gate::kMeasurement) {
-    auto measure_result = state_space.Measure(gate.qubits, rgen, state);
-    if (!measure_result.valid) {
-      return false;
-    }
-  } else {
-    ApplyGate(state_space, simulator, gate);
-  }
-
-  return true;
-}
-
-/**
- * Applies the given fused gate to the simulator state. Ignores measurement
- *   gates.
- * @param simulator Simulator object. Provides specific implementations for
- *   applying gates.
- * @param gate The gate to be applied.
- * @param state The state of the system, to be updated by this method.
- */
-template <typename Simulator, typename Gate>
-inline void ApplyFusedGate(const Simulator& simulator, const Gate& gate,
-                           typename Simulator::State& state) {
-  if (gate.kind != gate::kMeasurement) {
-    if (gate.parent->controlled_by.size() == 0) {
-      simulator.ApplyGate(gate.qubits, gate.matrix.data(), state);
-    } else {
-      simulator.ApplyControlledGate(gate.qubits, gate.parent->controlled_by,
-                                    gate.parent->cmask, gate.matrix.data(),
-                                    state);
-    }
-  }
-}
-
-/**
- * Applies the given fused gate dagger to the simulator state. If the gate
+ * Applies the given operation dagger to the simulator state. If the gate
  *   matrix is unitary then this is equivalent to applying the inverse gate.
  *   Ignores measurement gates.
  * @param simulator Simulator object. Provides specific implementations for
  *   applying gates.
- * @param gate The gate to be applied.
+ * @param op The operation to be applied.
  * @param state The state of the system, to be updated by this method.
  */
-template <typename Simulator, typename Gate>
-inline void ApplyFusedGateDagger(const Simulator& simulator, const Gate& gate,
-                                 typename Simulator::State& state) {
-  if (gate.kind != gate::kMeasurement) {
-    auto matrix = gate.matrix;
-    MatrixDagger(unsigned{1} << gate.qubits.size(), matrix);
+template <typename Simulator, typename Operation>
+inline void ApplyGateDagger(const Simulator& simulator, const Operation& op,
+                            typename Simulator::State& state) {
+  using FP = typename Simulator::fp_type;
 
-    if (gate.parent->controlled_by.size() == 0) {
-      simulator.ApplyGate(gate.qubits, matrix.data(), state);
-    } else {
-      simulator.ApplyControlledGate(gate.qubits, gate.parent->controlled_by,
-                                    gate.parent->cmask, matrix.data(), state);
-    }
+  if (const auto* pg = OpGetAlternative<Gate<FP>>(op)) {
+    auto matrix = pg->matrix;
+    MatrixDagger(unsigned{1} << pg->qubits.size(), matrix);
+    simulator.ApplyGate(pg->qubits, matrix.data(), state);
+  } else if (const auto* pg = OpGetAlternative<FusedGate<FP>>(op)) {
+    auto matrix = pg->matrix;
+    MatrixDagger(unsigned{1} << pg->qubits.size(), matrix);
+    simulator.ApplyGate(pg->qubits, matrix.data(), state);
+  } else if (const auto* pg = OpGetAlternative<ControlledGate<FP>>(op)) {
+    auto matrix = pg->matrix;
+    MatrixDagger(unsigned{1} << pg->qubits.size(), matrix);
+    simulator.ApplyControlledGate(pg->qubits, pg->controlled_by,
+                                  pg->cmask, matrix.data(), state);
   }
 }
 
 /**
- * Applies the given fused gate to the simulator state.
+ * Applies the given operation to the simulator state.
  * @param state_space StateSpace object required to perform measurements.
  * @param simulator Simulator object. Provides specific implementations for
  *   applying gates.
- * @param gate The gate to be applied.
+ * @param op The operation to be applied.
  * @param rgen Random number generator to perform measurements.
  * @param state The state of the system, to be updated by this method.
  * @param mresults As an input parameter, this can be empty or this can
@@ -191,48 +91,48 @@ inline void ApplyFusedGateDagger(const Simulator& simulator, const Gate& gate,
  *   this.
  * @return True if the measurement performed successfully; false otherwise.
  */
-template <typename Simulator, typename Gate, typename Rgen>
-inline bool ApplyFusedGate(
+template <typename Simulator, typename Operation, typename Rgen>
+inline bool ApplyGate(
     const typename Simulator::StateSpace& state_space,
-    const Simulator& simulator, const Gate& gate, Rgen& rgen,
+    const Simulator& simulator, const Operation& op, Rgen& rgen,
     typename Simulator::State& state,
     std::vector<typename Simulator::StateSpace::MeasurementResult>& mresults) {
-  if (gate.kind == gate::kMeasurement) {
-    auto measure_result = state_space.Measure(gate.qubits, rgen, state);
+  if (const auto* pg = OpGetAlternative<Measurement>(op)) {
+    auto measure_result = state_space.Measure(pg->qubits, rgen, state);
     if (measure_result.valid) {
       mresults.push_back(std::move(measure_result));
     } else {
       return false;
     }
   } else {
-    ApplyFusedGate(simulator, gate, state);
+    ApplyGate(simulator, op, state);
   }
 
   return true;
 }
 
 /**
- * Applies the given fused gate to the simulator state, discarding measurement
+ * Applies the given operation to the simulator state, discarding measurement
  *   results.
  * @param state_space StateSpace object required to perform measurements.
  * @param simulator Simulator object. Provides specific implementations for
  *   applying gates.
- * @param gate The gate to be applied.
+ * @param op The operation to be applied.
  * @param rgen Random number generator to perform measurements.
  * @param state The state of the system, to be updated by this method.
  * @return True if the measurement performed successfully; false otherwise.
  */
-template <typename Simulator, typename Gate, typename Rgen>
-inline bool ApplyFusedGate(const typename Simulator::StateSpace& state_space,
-                           const Simulator& simulator, const Gate& gate,
-                           Rgen& rgen, typename Simulator::State& state) {
-  if (gate.kind == gate::kMeasurement) {
-    auto measure_result = state_space.Measure(gate.qubits, rgen, state);
+template <typename Simulator, typename Operation, typename Rgen>
+inline bool ApplyGate(const typename Simulator::StateSpace& state_space,
+                      const Simulator& simulator, const Operation& op,
+                      Rgen& rgen, typename Simulator::State& state) {
+  if (const auto* pg = OpGetAlternative<Measurement>(op)) {
+    auto measure_result = state_space.Measure(pg->qubits, rgen, state);
     if (!measure_result.valid) {
       return false;
     }
   } else {
-    ApplyFusedGate(simulator, gate, state);
+    ApplyGate(simulator, op, state);
   }
 
   return true;

--- a/lib/gates_cirq.h
+++ b/lib/gates_cirq.h
@@ -75,12 +75,10 @@ enum GateKind {
   kMatrixGate2,  // Two-qubit matrix gate.
   kMatrixGate,   // Multi-qubit matrix gate.
   kGlobalPhaseGate,
-  kDecomp = gate::kDecomp,
-  kMeasurement = gate::kMeasurement,
 };
 
 template <typename fp_type>
-using GateCirq = Gate<fp_type, GateKind>;
+using GateCirq = Gate<fp_type>;
 
 constexpr double h_double = 0.5;
 constexpr double pi_double = 3.14159265358979323846264338327950288;
@@ -95,7 +93,7 @@ template <typename fp_type>
 struct GlobalPhaseGate {
   static constexpr GateKind kind = kGlobalPhaseGate;
   static constexpr char name[] = "GlobalPhaseGate";
-  static constexpr unsigned num_qubits = 1;
+  static constexpr unsigned num_qubits = 0;
   static constexpr bool symmetric = true;
 
   static GateCirq<fp_type> Create(unsigned time, fp_type phi) {
@@ -163,11 +161,12 @@ struct I {
   static constexpr char name[] = "I";
   static constexpr bool symmetric = true;
 
-  static GateCirq<fp_type> Create(unsigned time,
-                                  const std::vector<unsigned>& qubits) {
+  template <typename Q = Qubits>
+  static GateCirq<fp_type> Create(unsigned time, Q&& qubits) {
     Matrix<fp_type> matrix;
     MatrixIdentity(1 << qubits.size(), matrix);
-    return CreateGate<GateCirq<fp_type>, I>(time, qubits, std::move(matrix));
+    return CreateGate<GateCirq<fp_type>, I>(
+        time, std::forward<Q>(qubits), std::move(matrix));
   }
 };
 
@@ -1540,11 +1539,10 @@ struct MatrixGate1 {
   static constexpr unsigned num_qubits = 1;
   static constexpr bool symmetric = true;
 
-  static GateCirq<fp_type> Create(unsigned time, unsigned q0,
-                                  const Matrix<fp_type>& m) {
-    auto m2 = m;
-    return
-        CreateGate<GateCirq<fp_type>, MatrixGate1>(time, {q0}, std::move(m2));
+  template <typename M = Matrix<fp_type>>
+  static GateCirq<fp_type> Create(unsigned time, unsigned q0, M&& m) {
+    return CreateGate<GateCirq<fp_type>, MatrixGate1>(
+        time, {q0}, std::forward<M>(m));
   }
 };
 
@@ -1561,8 +1559,8 @@ struct MatrixGate2 {
   template <typename M = Matrix<fp_type>>
   static GateCirq<fp_type> Create(
       unsigned time, unsigned q0, unsigned q1, M&& m) {
-    return CreateGate<GateCirq<fp_type>, MatrixGate2>(time, {q1, q0},
-                                                      std::forward<M>(m));
+    return CreateGate<GateCirq<fp_type>, MatrixGate2>(
+        time, {q1, q0}, std::forward<M>(m));
   }
 };
 
@@ -1579,61 +1577,61 @@ struct MatrixGate {
   static GateCirq<fp_type> Create(unsigned time,
                                   std::vector<unsigned> qubits, M&& m) {
     std::reverse(qubits.begin(), qubits.end());
-    return CreateGate<GateCirq<fp_type>, MatrixGate>(time, std::move(qubits),
-                                                     std::forward<M>(m));
+    return CreateGate<GateCirq<fp_type>, MatrixGate>(
+        time, qubits, std::forward<M>(m));
   }
 };
 
-}  // namesapce Cirq
-
 template <typename fp_type>
 inline schmidt_decomp_type<fp_type> GetSchmidtDecomp(
-    Cirq::GateKind kind, const std::vector<fp_type>& params) {
+    unsigned kind, const std::vector<fp_type>& params) {
   switch (kind) {
-  case Cirq::kI2:
-    return Cirq::I2<fp_type>::SchmidtDecomp();
-  case Cirq::kCZPowGate:
-    return Cirq::CZPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
-  case Cirq::kCXPowGate:
-    return Cirq::CXPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
-  case Cirq::kCZ:
-    return Cirq::CZ<fp_type>::SchmidtDecomp();
-  case Cirq::kCX:
-    return Cirq::CX<fp_type>::SchmidtDecomp();
-  case Cirq::kXXPowGate:
-    return Cirq::XXPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
-  case Cirq::kYYPowGate:
-    return Cirq::YYPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
-  case Cirq::kZZPowGate:
-    return Cirq::ZZPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
-  case Cirq::kXX:
-    return Cirq::XX<fp_type>::SchmidtDecomp();
-  case Cirq::kYY:
-    return Cirq::YY<fp_type>::SchmidtDecomp();
-  case Cirq::kZZ:
-    return Cirq::ZZ<fp_type>::SchmidtDecomp();
-  case Cirq::kSwapPowGate:
-    return Cirq::SwapPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
-  case Cirq::kISwapPowGate:
-    return Cirq::ISwapPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
-  case Cirq::kriswap:
-    return Cirq::riswap<fp_type>::SchmidtDecomp(params[0]);
-  case Cirq::kSWAP:
-    return Cirq::SWAP<fp_type>::SchmidtDecomp();
-  case Cirq::kISWAP:
-    return Cirq::ISWAP<fp_type>::SchmidtDecomp();
-  case Cirq::kPhasedISwapPowGate:
-    return Cirq::PhasedISwapPowGate<fp_type>::SchmidtDecomp(
+  case kI2:
+    return I2<fp_type>::SchmidtDecomp();
+  case kCZPowGate:
+    return CZPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
+  case kCXPowGate:
+    return CXPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
+  case kCZ:
+    return CZ<fp_type>::SchmidtDecomp();
+  case kCX:
+    return CX<fp_type>::SchmidtDecomp();
+  case kXXPowGate:
+    return XXPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
+  case kYYPowGate:
+    return YYPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
+  case kZZPowGate:
+    return ZZPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
+  case kXX:
+    return XX<fp_type>::SchmidtDecomp();
+  case kYY:
+    return YY<fp_type>::SchmidtDecomp();
+  case kZZ:
+    return ZZ<fp_type>::SchmidtDecomp();
+  case kSwapPowGate:
+    return SwapPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
+  case kISwapPowGate:
+    return ISwapPowGate<fp_type>::SchmidtDecomp(params[0], params[1]);
+  case kriswap:
+    return riswap<fp_type>::SchmidtDecomp(params[0]);
+  case kSWAP:
+    return SWAP<fp_type>::SchmidtDecomp();
+  case kISWAP:
+    return ISWAP<fp_type>::SchmidtDecomp();
+  case kPhasedISwapPowGate:
+    return PhasedISwapPowGate<fp_type>::SchmidtDecomp(
         params[0], params[1]);
-  case Cirq::kgivens:
-    return Cirq::givens<fp_type>::SchmidtDecomp(params[0]);
-  case Cirq::kFSimGate:
-    return Cirq::FSimGate<fp_type>::SchmidtDecomp(params[0], params[1]);
+  case kgivens:
+    return givens<fp_type>::SchmidtDecomp(params[0]);
+  case kFSimGate:
+    return FSimGate<fp_type>::SchmidtDecomp(params[0], params[1]);
   default:
     // Single qubit gates of gates with unimplemented Schmidt decomposition.
     return schmidt_decomp_type<fp_type>{};
   }
 }
+
+}  // namesapce Cirq
 
 }  // namespace qsim
 

--- a/lib/gates_qsim.h
+++ b/lib/gates_qsim.h
@@ -20,12 +20,13 @@
 #include <vector>
 
 #include "gate.h"
+#include "matrix.h"
 
 namespace qsim {
 
 // Gate set implemented in qsim contains the following gates.
 enum GateKind {
-  kGateId1 = 0, // one-qubit Id
+  kGateId1 = 1000,  // one-qubit Id
   kGateHd,      // Hadamard
   kGateT,       // T
   kGateX,       // X
@@ -49,13 +50,11 @@ enum GateKind {
   kGateMatrix1, // one-qubit matrix gate
   kGateMatrix2, // two-qubit matrix gate
   kGateGPh,     // global phase gate
-  kDecomp = gate::kDecomp,
-  kMeasurement = gate::kMeasurement,
 };
 
 // Specialization of Gate (defined in gate.h) for the qsim gate set.
 template <typename fp_type>
-using GateQSim = Gate<fp_type, GateKind>;
+using GateQSim = Gate<fp_type>;
 
 constexpr double h_double = 0.5;
 constexpr double is2_double = 0.7071067811865475;
@@ -69,7 +68,7 @@ template <typename fp_type>
 struct GateGPh {
   static constexpr GateKind kind = kGateGPh;
   static constexpr char name[] = "p";
-  static constexpr unsigned num_qubits = 1;
+  static constexpr unsigned num_qubits = 0;
   static constexpr bool symmetric = true;
 
   static GateQSim<fp_type> Create(unsigned time, fp_type phi) {
@@ -634,7 +633,7 @@ struct GateMatrix2 {
 
 template <typename fp_type>
 inline schmidt_decomp_type<fp_type> GetSchmidtDecomp(
-    GateKind kind, const std::vector<fp_type>& params) {
+    unsigned kind, const std::vector<fp_type>& params) {
   switch (kind) {
   case kGateId2:
     return GateId2<fp_type>::SchmidtDecomp();

--- a/lib/hybrid.h
+++ b/lib/hybrid.h
@@ -22,68 +22,66 @@
 
 #include "gate.h"
 #include "gate_appl.h"
+#include "gates_cirq.h"
+#include "gates_qsim.h"
 
 namespace qsim {
+
+namespace detail {
+
+template <typename fp_type>
+inline schmidt_decomp_type<fp_type> GetSchmidtDecomp(
+    unsigned kind, const std::vector<fp_type>& params) {
+  if (kind >= kGateId1) {
+    return qsim::GetSchmidtDecomp(kind, params);
+  } else {
+    return qsim::Cirq::GetSchmidtDecomp(kind, params);
+  }
+}
+
+}  // namespace detail
 
 /**
  * Hybrid Feynman-Schrodinger simulator.
  */
-template <typename IO, typename GateT,
-          template <typename, typename> class FuserT, typename For>
+template <typename IO, typename For>
 struct HybridSimulator final {
- public:
-  using Gate = GateT;
-  using GateKind = typename Gate::GateKind;
-  using fp_type = typename Gate::fp_type;
-
  private:
-  // Note that one can use "struct GateHybrid : public Gate {" in C++17.
-  struct GateHybrid {
-    using GateKind = HybridSimulator::GateKind;
-    using fp_type = HybridSimulator::fp_type;
-
-    GateKind kind;
-    unsigned time;
-    std::vector<unsigned> qubits;
-    std::vector<unsigned> controlled_by;
-    uint64_t cmask;
-    std::vector<fp_type> params;
-    Matrix<fp_type> matrix;
-    bool unfusible;
-    bool swapped;
-
-    const Gate* parent;
-    unsigned id;
-  };
-
+  template <typename FP>
   struct GateX {
-    GateHybrid* decomposed0;
-    GateHybrid* decomposed1;
+    using fp_type = FP;
+
+    DecomposedGate<fp_type>* decomposed0;
+    DecomposedGate<fp_type>* decomposed1;
     schmidt_decomp_type<fp_type> schmidt_decomp;
     unsigned schmidt_bits;
     unsigned swapped;
   };
 
- public:
-  using Fuser = FuserT<IO, GateHybrid>;
-  using GateFused = typename Fuser::GateFused;
+  struct Empty {};
 
+ public:
   /**
    * Contextual data for hybrid simulation.
    */
+  template <typename FP>
   struct HybridData {
+    using fp_type = FP;
+    using OperationD = detail::append_to_variant_t<Operation<fp_type>,
+                                                   DecomposedGate<fp_type>>;
+
     /**
-     * List of gates on the "0" side of the cut.
+     * List of operations on the "0" side of the cut.
      */
-    std::vector<GateHybrid> gates0;
+    std::vector<OperationD> ops0;
     /**
-     * List of gates on the "1" side of the cut.
+     * List of operations on the "1" side of the cut.
      */
-    std::vector<GateHybrid> gates1;
+    std::vector<OperationD> ops1;
     /**
      * List of gates on the cut.
      */
-    std::vector<GateX> gatexs;
+    std::vector<GateX<fp_type>> gatexs;
     /**
      * Global qubit index to local qubit index map.
      */
@@ -105,7 +103,8 @@ struct HybridSimulator final {
   /**
    * User-specified parameters for gate fusion and hybrid simulation.
    */
-  struct Parameter : public Fuser::Parameter {
+  template <typename ParameterF = Empty>
+  struct Parameter : public ParameterF {
     /**
      * Fixed bitstring indicating values to assign to Schmidt decomposition
      * indices of prefix gates.
@@ -131,18 +130,25 @@ struct HybridSimulator final {
    * Splits the lattice into two parts, using Schmidt decomposition for gates
    * on the cut.
    * @param parts Lattice sections to be simulated.
-   * @param gates List of all gates in the circuit.
+   * @param ops List of all operations in the circuit. Only matrix gates are
+   *   supported.
    * @param hd Output data with split parts.
    * @return True if the splitting done successfully; false otherwise.
    */
+  template <typename Operation, typename FP>
   static bool SplitLattice(const std::vector<unsigned>& parts,
-                           const std::vector<Gate>& gates, HybridData& hd) {
+                           const std::vector<Operation>& ops,
+                           HybridData<FP>& hd) {
+    using fp_type = FP;
+    using Gate = qsim::Gate<fp_type>;
+    using DecomposedGate = qsim::DecomposedGate<fp_type>;
+
     hd.num_gatexs = 0;
     hd.num_qubits0 = 0;
     hd.num_qubits1 = 0;
 
-    hd.gates0.reserve(gates.size());
-    hd.gates1.reserve(gates.size());
+    hd.ops0.reserve(ops.size());
+    hd.ops1.reserve(ops.size());
     hd.qubit_map.reserve(parts.size());
 
     unsigned count0 = 0;
@@ -155,68 +161,60 @@ struct HybridSimulator final {
     }
 
     // Split the lattice.
-    for (const auto& gate : gates) {
-      if (gate.kind == gate::kMeasurement) {
-        IO::errorf("measurement gates are not suported by qsimh.\n");
+    for (const auto& op : ops) {
+      if (!OpGetAlternative<Gate>(op)) {
+        IO::errorf("measurement, controlled or other non-matrix gates "
+                   "are not suported by qsimh.\n");
         return false;
       }
 
-      if (gate.controlled_by.size() > 0) {
-        IO::errorf("controlled gates are not suported by qsimh.\n");
-        return false;
-      }
+      const auto& gate = *OpGetAlternative<Gate>(op);
 
       switch (gate.qubits.size()) {
       case 1:  // Single qubit gates.
         switch (parts[gate.qubits[0]]) {
         case 0:
-          hd.gates0.emplace_back(GateHybrid{gate.kind, gate.time,
-            {hd.qubit_map[gate.qubits[0]]}, {}, 0, gate.params, gate.matrix,
-            false, false, nullptr, 0});
+          hd.ops0.push_back(Gate{gate.kind, gate.time,
+              {hd.qubit_map[gate.qubits[0]]}, gate.params, gate.matrix});
           break;
         case 1:
-          hd.gates1.emplace_back(GateHybrid{gate.kind, gate.time,
-            {hd.qubit_map[gate.qubits[0]]}, {}, 0, gate.params, gate.matrix,
-            false, false, nullptr, 0});
+          hd.ops1.push_back(Gate{gate.kind, gate.time,
+              {hd.qubit_map[gate.qubits[0]]}, gate.params, gate.matrix});
           break;
         }
         break;
       case 2:  // Two qubit gates.
-        {
-          switch ((parts[gate.qubits[1]] << 1) | parts[gate.qubits[0]]) {
-          case 0:  // Both qubits in part 0.
-            hd.gates0.emplace_back(GateHybrid{gate.kind, gate.time,
+        switch ((parts[gate.qubits[1]] << 1) | parts[gate.qubits[0]]) {
+        case 0:  // Both qubits in part 0.
+          hd.ops0.push_back(Gate{gate.kind, gate.time,
               {hd.qubit_map[gate.qubits[0]], hd.qubit_map[gate.qubits[1]]},
-              {}, 0, gate.params, gate.matrix, false, gate.swapped,
-              nullptr, 0});
-            break;
-          case 1:  // Gate on the cut, qubit 0 in part 1, qubit 1 in part 0.
-            hd.gates0.emplace_back(GateHybrid{GateKind::kDecomp, gate.time,
-              {hd.qubit_map[gate.qubits[1]]}, {}, 0, gate.params, {},
-              true, gate.swapped, &gate, hd.num_gatexs});
-            hd.gates1.emplace_back(GateHybrid{GateKind::kDecomp, gate.time,
-              {hd.qubit_map[gate.qubits[0]]}, {}, 0, gate.params, {},
-              true, gate.swapped, &gate, hd.num_gatexs});
+              gate.params, gate.matrix});
+          break;
+        case 1:  // Gate on the cut, qubit 0 in part 1, qubit 1 in part 0.
+          hd.ops0.push_back(DecomposedGate{gate.kind, gate.time,
+              {hd.qubit_map[gate.qubits[1]]}, gate.params, {},
+              gate.swapped, &gate, hd.num_gatexs});
+          hd.ops1.push_back(DecomposedGate{gate.kind, gate.time,
+              {hd.qubit_map[gate.qubits[0]]}, gate.params, {},
+              gate.swapped, &gate, hd.num_gatexs});
 
-            ++hd.num_gatexs;
-            break;
-          case 2:  // Gate on the cut, qubit 0 in part 0, qubit 1 in part 1.
-            hd.gates0.emplace_back(GateHybrid{GateKind::kDecomp, gate.time,
-              {hd.qubit_map[gate.qubits[0]]}, {}, 0, gate.params, {},
-              true, gate.swapped, &gate, hd.num_gatexs});
-            hd.gates1.emplace_back(GateHybrid{GateKind::kDecomp, gate.time,
-              {hd.qubit_map[gate.qubits[1]]}, {}, 0, gate.params, {},
-              true, gate.swapped, &gate, hd.num_gatexs});
+          ++hd.num_gatexs;
+          break;
+        case 2:  // Gate on the cut, qubit 0 in part 0, qubit 1 in part 1.
+          hd.ops0.push_back(DecomposedGate{gate.kind, gate.time,
+              {hd.qubit_map[gate.qubits[0]]}, gate.params, {},
+              gate.swapped, &gate, hd.num_gatexs});
+          hd.ops1.push_back(DecomposedGate{gate.kind, gate.time,
+              {hd.qubit_map[gate.qubits[1]]}, gate.params, {},
+              gate.swapped, &gate, hd.num_gatexs});
 
-            ++hd.num_gatexs;
-            break;
-          case 3:  // Both qubits in part 1.
-            hd.gates1.emplace_back(GateHybrid{gate.kind, gate.time,
+          ++hd.num_gatexs;
+          break;
+        case 3:  // Both qubits in part 1.
+          hd.ops1.push_back(Gate{gate.kind, gate.time,
               {hd.qubit_map[gate.qubits[0]], hd.qubit_map[gate.qubits[1]]},
-              {}, 0, gate.params, gate.matrix, false, gate.swapped,
-              nullptr, 0});
-            break;
-          }
+              gate.params, gate.matrix});
+          break;
         }
         break;
       default:
@@ -225,45 +223,54 @@ struct HybridSimulator final {
       }
     }
 
-    auto compare = [](const GateHybrid& l, const GateHybrid& r) -> bool {
-      return l.time < r.time || (l.time == r.time &&
-          (l.parent < r.parent || (l.parent == r.parent && l.id < r.id)));
+    using OperationD = typename HybridData<fp_type>::OperationD;
+
+    auto compare = [](const OperationD& lop, const OperationD& rop) -> bool {
+      unsigned ltime = OpTime(lop);
+      unsigned rtime = OpTime(rop);
+
+      const auto* ld = OpGetAlternative<DecomposedGate>(lop);
+      const auto* rd = OpGetAlternative<DecomposedGate>(rop);
+
+      return ltime < rtime ||
+          (ltime == rtime && ((!ld && rd) || (ld && rd && ld->id < rd->id)));
     };
 
-    // Sort gates.
-    std::sort(hd.gates0.begin(), hd.gates0.end(), compare);
-    std::sort(hd.gates1.begin(), hd.gates1.end(), compare);
+    // Sort ops.
+    std::sort(hd.ops0.begin(), hd.ops0.end(), compare);
+    std::sort(hd.ops1.begin(), hd.ops1.end(), compare);
 
     hd.gatexs.reserve(hd.num_gatexs);
 
     // Get Schmidt matrices.
-    for (auto& gate0 : hd.gates0) {
-      if (gate0.parent != nullptr) {
-        auto d = GetSchmidtDecomp(gate0.parent->kind, gate0.parent->params);
+    for (auto& op0 : hd.ops0) {
+      if (auto* pg = OpGetAlternative<DecomposedGate>(op0)) {
+        auto d = detail::GetSchmidtDecomp(pg->parent->kind, pg->parent->params);
         if (d.size() == 0) {
           IO::errorf("no Schmidt decomposition for gate kind %u.\n",
-                     gate0.parent->kind);
+                     pg->parent->kind);
           return false;
         }
 
         unsigned schmidt_bits = SchmidtBits(d.size());
         if (schmidt_bits > 2) {
           IO::errorf("Schmidt rank is too large for gate kind %u.\n",
-                     gate0.parent->kind);
+                     pg->parent->kind);
           return false;
         }
 
-        unsigned swapped = parts[gate0.parent->qubits[0]];
-        if (gate0.parent->swapped) swapped = 1 - swapped;
-        hd.gatexs.emplace_back(GateX{&gate0, nullptr, std::move(d),
-                                     schmidt_bits, swapped});
+        unsigned swapped = parts[pg->parent->qubits[0]];
+        if (pg->parent->swapped) swapped = 1 - swapped;
+
+        hd.gatexs.push_back(GateX<fp_type>{pg, nullptr, std::move(d),
+                                           schmidt_bits, swapped});
       }
     }
 
     unsigned count = 0;
-    for (auto& gate1 : hd.gates1) {
-      if (gate1.parent != nullptr) {
-        hd.gatexs[count++].decomposed1 = &gate1;
+    for (auto& op1 : hd.ops1) {
+      if (auto* pg = OpGetAlternative<DecomposedGate>(op1)) {
+        hd.gatexs[count++].decomposed1 = pg;
       }
     }
 
@@ -284,18 +291,20 @@ struct HybridSimulator final {
    * @param hd Container object for gates on the boundary between lattice
    *   sections.
    * @param parts Lattice sections to be simulated.
-   * @param fgates0 List of gates from one section of the lattice.
-   * @param fgates1 List of gates from the other section of the lattice.
+   * @param ops0 List of (fused) operations from one section of the lattice.
+   * @param ops1 List of (fused) operations from the other section of
+   *   the lattice.
    * @param bitstrings List of output states to simulate, as bitstrings.
    * @param results Output vector of amplitudes. After a successful run, this
    *   will be populated with amplitudes for each state in 'bitstrings'.
    * @return True if the simulation completed successfully; false otherwise.
    */
-  template <typename Factory, typename Results>
-  bool Run(const Parameter& param, const Factory& factory,
-           HybridData& hd, const std::vector<unsigned>& parts,
-           const std::vector<GateFused>& fgates0,
-           const std::vector<GateFused>& fgates1,
+  template <typename ParameterF, typename Factory, typename FP,
+            typename OperationF, typename Results>
+  bool Run(const Parameter<ParameterF>& param, const Factory& factory,
+           HybridData<FP>& hd, const std::vector<unsigned>& parts,
+           const std::vector<OperationF>& ops0,
+           const std::vector<OperationF>& ops1,
            const std::vector<uint64_t>& bitstrings, Results& results) const {
     using Simulator = typename Factory::Simulator;
     using StateSpace = typename Simulator::StateSpace;
@@ -309,8 +318,8 @@ struct HybridSimulator final {
     uint64_t rmax = uint64_t{1} << bits.num_r_bits;
     uint64_t smax = uint64_t{1} << bits.num_s_bits;
 
-    auto loc0 = CheckpointLocations(param, fgates0);
-    auto loc1 = CheckpointLocations(param, fgates1);
+    auto loc0 = CheckpointLocations(param, ops0);
+    auto loc1 = CheckpointLocations(param, ops1);
 
     struct Index {
       unsigned i0;
@@ -374,8 +383,8 @@ struct HybridSimulator final {
 
     if (gatex_index == 0) {
       // Apply gates before the first checkpoint.
-      ApplyGates(fgates0, 0, loc0[0], simulator, state0p);
-      ApplyGates(fgates1, 0, loc1[0], simulator, state1p);
+      ApplyGates(ops0, 0, loc0[0], simulator, state0p);
+      ApplyGates(ops1, 0, loc1[0], simulator, state1p);
     } else {
       IO::errorf("invalid prefix %lu for prefix gate index %u.\n",
                  param.prefix, gatex_index - 1);
@@ -392,8 +401,8 @@ struct HybridSimulator final {
       if (SetSchmidtMatrices(num_p_gates, num_pr_gates,
                              r, prev, hd.gatexs) == 0) {
         // Apply gates before the second checkpoint.
-        ApplyGates(fgates0, loc0[0], loc0[1], simulator, state0r);
-        ApplyGates(fgates1, loc1[0], loc1[1], simulator, state1r);
+        ApplyGates(ops0, loc0[0], loc0[1], simulator, state0r);
+        ApplyGates(ops1, loc1[0], loc1[1], simulator, state1r);
       } else {
         continue;
       }
@@ -408,8 +417,8 @@ struct HybridSimulator final {
         if (SetSchmidtMatrices(num_pr_gates, hd.num_gatexs,
                                s, prev, hd.gatexs) == 0) {
           // Apply the rest of the gates.
-          ApplyGates(fgates0, loc0[1], fgates0.size(), simulator, state0s);
-          ApplyGates(fgates1, loc1[1], fgates1.size(), simulator, state1s);
+          ApplyGates(ops0, loc0[1], ops0.size(), simulator, state0s);
+          ApplyGates(ops1, loc1[1], ops1.size(), simulator, state1s);
         } else {
           continue;
         }
@@ -429,7 +438,6 @@ struct HybridSimulator final {
                  state_space, *rstate0, *rstate1, indices, results);
       }
     }
-
     return true;
   }
 
@@ -439,24 +447,26 @@ struct HybridSimulator final {
    * runs with different cut-index values to reuse parts of the simulation.
    * @param param Options for parallelism and logging. Also specifies the size
    *   of the 'prefix' and 'root' sections of the lattice.
-   * @param fgates Set of gates for which to find checkpoint locations.
+   * @param ops Set of (fused) operations for which to find checkpoint
+   *   locations.
    * @return A pair of numbers specifying how many gates to apply before the
    *   first and second checkpoints, respectively.
    */
+  template <typename Parameter, typename OperationF>
   static std::array<unsigned, 2> CheckpointLocations(
-      const Parameter& param, const std::vector<GateFused>& fgates) {
+      const Parameter& param, const std::vector<OperationF>& ops) {
+    using FusedGate = std::variant_alternative_t<0, OperationF>;
+
     std::array<unsigned, 2> loc{0, 0};
 
     unsigned num_decomposed = 0;
     unsigned num_p_gates = param.num_prefix_gatexs;
     unsigned num_pr_gates = num_p_gates + param.num_root_gatexs;
 
-    for (std::size_t i = 0; i < fgates.size(); ++i) {
-      for (auto gate: fgates[i].gates) {
-        if (gate->parent != nullptr) {
+    for (std::size_t i = 0; i < ops.size(); ++i) {
+      if (const auto* pg = OpGetAlternative<FusedGate>(ops[i])) {
+        if (pg->ParentIsDecomposed()) {
           ++num_decomposed;
-          // There should be only one decomposed gate in fused gate.
-          break;
         }
       }
 
@@ -478,6 +488,7 @@ struct HybridSimulator final {
     unsigned num_s_bits;
   };
 
+  template <typename Parameter, typename GateX>
   static Bits CountSchmidtBits(
       const Parameter& param, const std::vector<GateX>& gatexs) {
     Bits bits{0, 0, 0};
@@ -499,6 +510,7 @@ struct HybridSimulator final {
     return bits;
   }
 
+  template <typename GateX>
   static unsigned SetSchmidtMatrices(std::size_t i0, std::size_t i1,
                                      uint64_t path,
                                      std::vector<unsigned>& prev_k,
@@ -532,6 +544,7 @@ struct HybridSimulator final {
     return 0;
   }
 
+  template <typename GateX>
   static void FillSchmidtMatrices(unsigned k, const GateX& gatex) {
     unsigned part0 = gatex.swapped;
     unsigned part1 = 1 - part0;
@@ -549,18 +562,24 @@ struct HybridSimulator final {
     }
   }
 
-  template <typename Simulator>
-  static void ApplyGates(const std::vector<GateFused>& gates,
+  template <typename OperationF, typename Simulator>
+  static void ApplyGates(const std::vector<OperationF>& ops,
                          std::size_t i0, std::size_t i1,
                          const Simulator& simulator,
                          typename Simulator::State& state) {
+    using FusedGate = std::variant_alternative_t<0, OperationF>;
+
     for (std::size_t i = i0; i < i1; ++i) {
-      if (gates[i].matrix.size() > 0) {
-        ApplyFusedGate(simulator, gates[i], state);
+      if (const auto* pg = OpGetAlternative<FusedGate>(ops[i])) {
+        if (!pg->ParentIsDecomposed()) {
+          ApplyGate(simulator, ops[i], state);
+        } else {
+          auto fgate = *pg;
+          CalculateFusedMatrix(fgate);
+          ApplyGate(simulator, fgate, state);
+        }
       } else {
-        auto gate = gates[i];
-        CalculateFusedMatrix(gate);
-        ApplyFusedGate(simulator, gate, state);
+        ApplyGate(simulator, ops[i], state);
       }
     }
   }

--- a/lib/operation.h
+++ b/lib/operation.h
@@ -1,0 +1,72 @@
+// Copyright 2026 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPERATION_H_
+#define OPERATION_H_
+
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+#include "channel.h"
+#include "gate.h"
+#include "operation_base.h"
+
+namespace qsim {
+
+// Forward declaration of classically controlled operation.
+template <typename>
+struct ClassicallyControlledOperation;
+
+/**
+ * A generic operation.
+ */
+template <typename FP>
+using Operation = std::variant<Gate<FP>, ControlledGate<FP>, Measurement,
+                               Channel<FP>, ClassicallyControlledOperation<FP>>;
+
+/**
+ * A classically controlled operation. Not implemented yet.
+ */
+template <typename FP>
+struct ClassicallyControlledOperation : public BaseOperation {
+  std::vector<Operation<FP>> sub_ops;
+};
+
+namespace detail {
+
+template <typename T>
+struct op_fp_type {
+  using type = typename T::fp_type;
+};
+
+template <typename T>
+struct op_fp_type<T*> {
+  using type = typename T::fp_type;
+};
+
+template <typename... Ts>
+struct op_fp_type<std::variant<Ts...>> {
+  using T = std::variant_alternative_t<0, std::variant<Ts...>>;
+  using type = typename op_fp_type<T>::type;
+};
+
+}  // namespace detail
+
+template <typename Operation>
+using OpFpType = typename detail::op_fp_type<std::decay_t<Operation>>::type;
+
+}  // namespace qsim
+
+#endif  // OPERATION_H_

--- a/lib/operation_base.h
+++ b/lib/operation_base.h
@@ -201,7 +201,7 @@ inline unsigned OpTime(const Operation& op) {
     return std::visit(f, op);
   } else {
     static_assert(
-        detail::always_false<O>, "OpQubits encountered an invalid type");
+        detail::always_false<O>, "OpTime encountered an invalid type");
   }
 }
 

--- a/lib/operation_base.h
+++ b/lib/operation_base.h
@@ -1,0 +1,331 @@
+// Copyright 2026 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPERATION_BASE_H_
+#define OPERATION_BASE_H_
+
+#include <cstdio>
+#include <exception>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+namespace qsim {
+
+using Qubits = std::vector<unsigned>;
+
+/**
+ * A base operation acting on a specific set of qubits at a given time step.
+ * Note: The `kind` field is currently utilized only in qsimh.
+ */
+struct BaseOperation {
+  unsigned kind;
+  unsigned time;
+  Qubits qubits;
+};
+
+namespace detail {
+
+template <typename V, typename A>
+struct append_to_variant {};
+
+template <typename... T, typename A>
+struct append_to_variant<std::variant<T...>, A> {
+  using type = std::variant<T..., A>;
+};
+
+template <typename V, typename A>
+using append_to_variant_t = typename append_to_variant<V, A>::type;
+
+template <typename V, typename A>
+struct is_type_in_variant {};
+
+template <typename... T, typename A>
+struct is_type_in_variant<std::variant<T...>, A>
+    : std::disjunction<std::is_same<T, A>...> {};
+
+template <typename V, typename A>
+inline constexpr bool is_type_in_variant_v = is_type_in_variant<V, A>::value;
+
+template <typename T>
+struct is_variant : std::false_type {};
+
+template <typename... T>
+struct is_variant<std::variant<T...>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_variant_v = is_variant<T>::value;
+
+}  // namespace detail
+
+/**
+ * Recursively searches for a value of type T within a (potentially nested)
+ * variant. Traverses the provided `op` to find an alternative that matches
+ * type T. This function handles recursive `std::variant` structures and can
+ * transparently dereference pointers (e.g., `std::variant<A, B*>`;
+ * note, however, that `std::variant<A, const B*>` does not work) to
+ * find the target type.
+ *
+ * @tparam T The target type to extract.
+ * @tparam Operation One of gate types, an `std::variant`, or a pointer
+ *   to one of these.
+ * @param op The input operation, variant container, or pointer to search.
+ * @return A pointer to the value of type T if found; otherwise, nullptr.
+ */
+template <typename T, typename Operation>
+T* OpGetAlternative(Operation& op) {
+  using O = std::decay_t<decltype(op)>;
+
+  auto f = [](auto& v) -> T* {
+    return OpGetAlternative<T>(v);
+  };
+
+  if constexpr (std::is_pointer_v<O>) {
+    if constexpr (std::is_const_v<std::remove_pointer_t<O>>) {
+      return nullptr;
+    } else {
+      return OpGetAlternative<T>(*op);
+    }
+  } else if constexpr (std::is_same_v<T, O>) {
+    return &op;
+  } else if constexpr (detail::is_variant_v<O>) {
+    if constexpr (detail::is_type_in_variant_v<O, T>) {
+      if (auto* p = std::get_if<T>(&op)) {
+        return p;
+      } else {
+        return std::visit(f, op);
+      }
+    } else if constexpr (detail::is_type_in_variant_v<O, T*>) {
+      if (auto* p = std::get_if<T*>(&op)) {
+        return *p;
+      } else {
+        return std::visit(f, op);
+      }
+    } else {
+      return std::visit(f, op);
+    }
+  } else {
+    return nullptr;
+  }
+}
+
+/**
+ * Recursively searches for a value of type T within a (potentially nested)
+ * variant. Traverses the provided `op` to find an alternative that matches
+ * type T. This function handles recursive `std::variant` structures and can
+ * transparently dereference pointers (e.g., `std::variant<A, const B*>` or
+ * `std::variant<A, B*>`) to find the target type.
+ *
+ * @tparam T The target type to extract.
+ * @tparam Operation One of gate types, an `std::variant`, or a pointer
+ *   to one of these.
+ * @param op The input operation, variant container, or pointer to search.
+ * @return A const pointer to the value of type T if found; otherwise, nullptr.
+ */
+template <typename T, typename Operation>
+const T* OpGetAlternative(const Operation& op) {
+  using O = std::decay_t<decltype(op)>;
+
+  auto f = [](const auto& v) -> const T* {
+    return OpGetAlternative<T>(v);
+  };
+
+  if constexpr (std::is_pointer_v<O>) {
+    return OpGetAlternative<T>(*op);
+  } else if constexpr (std::is_same_v<T, O>) {
+    return &op;
+  } else if constexpr (detail::is_variant_v<O>) {
+    if constexpr (detail::is_type_in_variant_v<O, T>) {
+      if (const auto* p = std::get_if<T>(&op)) {
+        return p;
+      } else {
+        return std::visit(f, op);
+      }
+    } else if constexpr (detail::is_type_in_variant_v<O, const T*>) {
+      if (const auto* p = std::get_if<const T*>(&op)) {
+        return *p;
+      } else {
+        return std::visit(f, op);
+      }
+    } else {
+      return std::visit(f, op);
+    }
+  } else {
+    return nullptr;
+  }
+}
+
+/**
+ * Recursively retrieves the time step from a (nested) variant.
+ * This function traverses the provided `op` (concrete type, pointer,
+ * or variant) to access the `time` memeber in the underlying `BaseOperation`.
+ * This function handles recursive `std::variant` structures and can
+ * transparently dereference pointers (e.g., `std::variant<A, const B*>`
+ * or `std::variant<A, B*>`) to find the target value.
+ *
+ * Note: this function assumes that the input contains a type that is
+ * derived from `BaseOperation`. If an incompatible type is encountered,
+ * the program will terminate.
+ *
+ * @tparam Operation A type derived from `BaseOperation`, an `std::variant`,
+ *   or a pointer to one of these.
+ * @param op The input operation, variant container, or pointer to search.
+ * @return The time step of the underlying `BaseOperation`.
+ */
+template <typename Operation>
+inline unsigned OpTime(const Operation& op) {
+  using O = std::decay_t<decltype(op)>;
+
+  if constexpr (std::is_pointer_v<O>) {
+    return OpTime(*op);
+  } else if constexpr (std::is_base_of_v<BaseOperation, O>) {
+    return op.time;
+  } else if constexpr (detail::is_variant_v<O>) {
+    auto f = [](const auto& v) {
+      return OpTime(v);
+    };
+
+    return std::visit(f, op);
+  } else {
+    // This branch is reached if the input contains a type that is not derived
+    // from BaseOperation.
+    std::fprintf(stderr, "fatal error: OpTime encountered an invalid type.\n");
+    std::terminate();
+  }
+}
+
+/**
+ * Recursively retrieves the qubit indices from a (nested) variant.
+ * This function traverses the provided `op` (concrete type, pointer,
+ * or variant) to access the `qubits` memeber in the underlying `BaseOperation`.
+ * This function handles recursive `std::variant` structures and can
+ * transparently dereference pointers (e.g., `std::variant<A, const B*>`
+ * or `std::variant<A, B*>`) to find the target value.
+ *
+ * Note: this function assumes that the input contains a type that is
+ * derived from `BaseOperation`. If an incompatible type is encountered,
+ * the program will terminate.
+ *
+ * @tparam Operation A type derived from `BaseOperation`, an `std::variant`,
+ *   or a pointer to one of these.
+ * @param op The input operation, variant container, or pointer to search.
+ * @return A const reference to qubit indices of the underlying `BaseOperation`.
+ */
+template <typename Operation>
+inline const Qubits& OpQubits(const Operation& op) {
+  using O = std::decay_t<decltype(op)>;
+
+  if constexpr (std::is_pointer_v<O>) {
+    return OpQubits(*op);
+  } else if constexpr (std::is_base_of_v<BaseOperation, O>) {
+    return op.qubits;
+  } else if constexpr (detail::is_variant_v<O>) {
+    auto f = [](const auto& v) -> const Qubits& {
+      return OpQubits(v);
+    };
+
+    return std::visit(f, op);
+  } else {
+    // This branch is reached if the input contains a type that is not derived
+    // from BaseOperation.
+    std::fprintf(
+        stderr, "fatal error: OpQubits encountered an invalid type.\n");
+    std::terminate();
+  }
+}
+
+/**
+ * Recursively retrieves the BaseOperation from a (nested) variant.
+ * This function traverses the provided `op` (concrete type, pointer,
+ * or variant) to access the underlying BaseOperation.
+ * This function handles recursive `std::variant` structures and can
+ * transparently dereference pointers (e.g., `std::variant<A, B*>`;
+ * note, however, that `std::variant<A, const B*>` does not work) to
+ * find the target value.
+ *
+ * Note: this function assumes that the input contains a type that is
+ * derived from `BaseOperation`. If an incompatible type is encountered,
+ * the program will terminate.
+ *
+ * @tparam Operation A type derived from `BaseOperation`, an `std::variant`,
+ *   or a pointer to one of these.
+ * @param op The input operation, variant container, or pointer to search.
+ * @return A reference to the underlying `BaseOperation`.
+ */
+template <typename Operation>
+inline BaseOperation& OpBaseOperation(Operation& op) {
+  using O = std::decay_t<decltype(op)>;
+
+  if constexpr (std::is_pointer_v<O>) {
+    return OpBaseOperation(*op);
+  } else if constexpr (std::is_base_of_v<BaseOperation, O>) {
+    return op;
+  } else if constexpr (detail::is_variant_v<O>) {
+    auto f = [](auto& v) -> BaseOperation& {
+      return OpBaseOperation(v);
+    };
+
+    return std::visit(f, op);
+  } else {
+    // This branch is reached if the input contains a type that is not derived
+    // from BaseOperation.
+    std::fprintf(
+        stderr, "fatal error: OpBaseOperation encountered an invalid type.\n");
+    std::terminate();
+  }
+}
+
+/**
+ * Recursively retrieves the BaseOperation from a (nested) variant.
+ * This function traverses the provided `op` (concrete type, pointer,
+ * or variant) to access the underlying BaseOperation.
+ * This function handles recursive `std::variant` structures and can
+ * transparently dereference pointers (e.g., `std::variant<A, const B*>`
+ * or `std::variant<A, B*>`) to find the target value.
+ *
+ * Note: this function assumes that the input contains a type that is
+ * derived from `BaseOperation`. If an incompatible type is encountered,
+ * the program will terminate.
+ *
+ * @tparam Operation A type derived from `BaseOperation`, an `std::variant`,
+ *   or a pointer to one of these.
+ * @param op The input operation, variant container, or pointer to search.
+ * @return A const reference to the underlying `BaseOperation`.
+ */
+template <typename Operation>
+inline const BaseOperation& OpBaseOperation(const Operation& op) {
+  using O = std::decay_t<decltype(op)>;
+
+  if constexpr (std::is_pointer_v<O>) {
+    return OpBaseOperation(*op);
+  } else if constexpr (std::is_base_of_v<BaseOperation, O>) {
+    return op;
+  } else if constexpr (detail::is_variant_v<O>) {
+    auto f = [](const auto& v) -> const BaseOperation& {
+      return OpBaseOperation(v);
+    };
+
+    return std::visit(f, op);
+  } else {
+    // This branch is reached if the input contains a type that is not derived
+    // from BaseOperation.
+    std::fprintf(
+        stderr, "fatal error: OpBaseOperation encountered an invalid type.\n");
+    std::terminate();
+  }
+}
+
+}  // namespace qsim
+
+#endif  // OPERATION_BASE_H_

--- a/lib/operation_base.h
+++ b/lib/operation_base.h
@@ -197,7 +197,7 @@ inline unsigned OpTime(const Operation& op) {
 
     return std::visit(f, op);
   } else {
-    static_assert(0, "OpBaseOperation encountered an invalid type");
+    static_assert(0, "OpQubits encountered an invalid type");
   }
 }
 
@@ -232,7 +232,7 @@ inline const Qubits& OpQubits(const Operation& op) {
 
     return std::visit(f, op);
   } else {
-    static_assert(0, "OpBaseOperation encountered an invalid type");
+    static_assert(0, "OpQubits encountered an invalid type");
   }
 }
 

--- a/lib/operation_base.h
+++ b/lib/operation_base.h
@@ -175,8 +175,7 @@ const T* OpGetAlternative(const Operation& op) {
  * or `std::variant<A, B*>`) to find the target value.
  *
  * Note: this function assumes that the input contains a type that is
- * derived from `BaseOperation`. If an incompatible type is encountered,
- * the program will terminate.
+ * derived from `BaseOperation`.
  *
  * @tparam Operation A type derived from `BaseOperation`, an `std::variant`,
  *   or a pointer to one of these.
@@ -198,10 +197,7 @@ inline unsigned OpTime(const Operation& op) {
 
     return std::visit(f, op);
   } else {
-    // This branch is reached if the input contains a type that is not derived
-    // from BaseOperation.
-    std::fprintf(stderr, "fatal error: OpTime encountered an invalid type.\n");
-    std::terminate();
+    static_assert(0, "OpBaseOperation encountered an invalid type");
   }
 }
 
@@ -214,8 +210,7 @@ inline unsigned OpTime(const Operation& op) {
  * or `std::variant<A, B*>`) to find the target value.
  *
  * Note: this function assumes that the input contains a type that is
- * derived from `BaseOperation`. If an incompatible type is encountered,
- * the program will terminate.
+ * derived from `BaseOperation`.
  *
  * @tparam Operation A type derived from `BaseOperation`, an `std::variant`,
  *   or a pointer to one of these.
@@ -237,11 +232,7 @@ inline const Qubits& OpQubits(const Operation& op) {
 
     return std::visit(f, op);
   } else {
-    // This branch is reached if the input contains a type that is not derived
-    // from BaseOperation.
-    std::fprintf(
-        stderr, "fatal error: OpQubits encountered an invalid type.\n");
-    std::terminate();
+    static_assert(0, "OpBaseOperation encountered an invalid type");
   }
 }
 
@@ -255,8 +246,7 @@ inline const Qubits& OpQubits(const Operation& op) {
  * find the target value.
  *
  * Note: this function assumes that the input contains a type that is
- * derived from `BaseOperation`. If an incompatible type is encountered,
- * the program will terminate.
+ * derived from `BaseOperation`.
  *
  * @tparam Operation A type derived from `BaseOperation`, an `std::variant`,
  *   or a pointer to one of these.
@@ -278,11 +268,7 @@ inline BaseOperation& OpBaseOperation(Operation& op) {
 
     return std::visit(f, op);
   } else {
-    // This branch is reached if the input contains a type that is not derived
-    // from BaseOperation.
-    std::fprintf(
-        stderr, "fatal error: OpBaseOperation encountered an invalid type.\n");
-    std::terminate();
+    static_assert(0, "OpBaseOperation encountered an invalid type");
   }
 }
 
@@ -295,8 +281,7 @@ inline BaseOperation& OpBaseOperation(Operation& op) {
  * or `std::variant<A, B*>`) to find the target value.
  *
  * Note: this function assumes that the input contains a type that is
- * derived from `BaseOperation`. If an incompatible type is encountered,
- * the program will terminate.
+ * derived from `BaseOperation`.
  *
  * @tparam Operation A type derived from `BaseOperation`, an `std::variant`,
  *   or a pointer to one of these.
@@ -318,11 +303,7 @@ inline const BaseOperation& OpBaseOperation(const Operation& op) {
 
     return std::visit(f, op);
   } else {
-    // This branch is reached if the input contains a type that is not derived
-    // from BaseOperation.
-    std::fprintf(
-        stderr, "fatal error: OpBaseOperation encountered an invalid type.\n");
-    std::terminate();
+    static_assert(0, "OpBaseOperation encountered an invalid type");
   }
 }
 

--- a/lib/operation_base.h
+++ b/lib/operation_base.h
@@ -67,6 +67,9 @@ struct is_variant<std::variant<T...>> : std::true_type {};
 template <typename T>
 inline constexpr bool is_variant_v = is_variant<T>::value;
 
+template <typename...>
+inline constexpr bool always_false = false;
+
 }  // namespace detail
 
 /**
@@ -197,7 +200,8 @@ inline unsigned OpTime(const Operation& op) {
 
     return std::visit(f, op);
   } else {
-    static_assert(0, "OpQubits encountered an invalid type");
+    static_assert(
+        detail::always_false<O>, "OpQubits encountered an invalid type");
   }
 }
 
@@ -232,7 +236,8 @@ inline const Qubits& OpQubits(const Operation& op) {
 
     return std::visit(f, op);
   } else {
-    static_assert(0, "OpQubits encountered an invalid type");
+    static_assert(
+        detail::always_false<O>, "OpQubits encountered an invalid type");
   }
 }
 
@@ -268,7 +273,8 @@ inline BaseOperation& OpBaseOperation(Operation& op) {
 
     return std::visit(f, op);
   } else {
-    static_assert(0, "OpBaseOperation encountered an invalid type");
+    static_assert(
+        detail::always_false<O>, "OpBaseOperation encountered an invalid type");
   }
 }
 
@@ -303,7 +309,8 @@ inline const BaseOperation& OpBaseOperation(const Operation& op) {
 
     return std::visit(f, op);
   } else {
-    static_assert(0, "OpBaseOperation encountered an invalid type");
+    static_assert(
+        detail::always_false<O>, "OpBaseOperation encountered an invalid type");
   }
 }
 

--- a/lib/qtrajectory.h
+++ b/lib/qtrajectory.h
@@ -21,18 +21,22 @@
 #include <random>
 #include <vector>
 
-#include "circuit_noisy.h"
 #include "gate.h"
 #include "gate_appl.h"
+#include "operation.h"
+#include "operation_base.h"
 
 namespace qsim {
 
 /**
  * Quantum trajectory simulator.
  */
-template <typename IO, typename Gate,
-          typename Runner, typename RGen = std::mt19937>
+template <typename IO, typename Runner, typename RGen = std::mt19937>
 class QuantumTrajectorySimulator {
+ private:
+  template <typename FP, typename Operation>
+  using GateOrOperation = std::variant<const Gate<FP>*, const Operation*>;
+
  public:
   using Simulator = typename Runner::Simulator;
   using StateSpace = typename Simulator::StateSpace;
@@ -105,15 +109,15 @@ class QuantumTrajectorySimulator {
    * @param args Optional arguments for the 'measure' function.
    * @return True if the simulation completed successfully; false otherwise.
    */
-  template <typename MeasurementFunc, typename... Args>
+  template <typename Operation, typename MeasurementFunc, typename... Args>
   static bool RunBatch(const Parameter& param,
-                       const NoisyCircuit<Gate>& circuit,
-                       uint64_t r0, uint64_t r1, const StateSpace& state_space,
+                       const Circuit<Operation>& circuit, uint64_t r0,
+                       uint64_t r1, const StateSpace& state_space,
                        const Simulator& simulator, MeasurementFunc&& measure,
                        Args&&... args) {
-    return RunBatch(param, circuit.num_qubits, circuit.channels.begin(),
-                    circuit.channels.end(), r0, r1, state_space, simulator,
-                    measure, args...);
+    return RunBatch<Operation>(param, circuit.num_qubits, circuit.ops.begin(),
+                               circuit.ops.end(), r0, r1, state_space,
+                               simulator, measure, args...);
   }
 
   /**
@@ -121,7 +125,7 @@ class QuantumTrajectorySimulator {
    * seeded by repetition ID.
    * @param param Options for the quantum trajectory simulator.
    * @param num_qubits The number of qubits acted on by the circuit.
-   * @param cbeg, cend The range of channels [cbeg, cend) to run the circuit.
+   * @param obeg, oend The range of operations [obeg, oend) to run the circuit.
    * @param r0, r1 The range of repetition IDs [r0, r1) to perform repetitions.
    * @param state_space StateSpace object required to manipulate state vector.
    * @param simulator Simulator object. Provides specific implementations for
@@ -134,15 +138,17 @@ class QuantumTrajectorySimulator {
    * @param args Optional arguments for the 'measure' function.
    * @return True if the simulation completed successfully; false otherwise.
    */
-  template <typename MeasurementFunc, typename... Args>
+  template <typename Operation, typename MeasurementFunc, typename... Args>
   static bool RunBatch(const Parameter& param, unsigned num_qubits,
-                       ncircuit_iterator<Gate> cbeg,
-                       ncircuit_iterator<Gate> cend,
+                       typename std::vector<Operation>::const_iterator obeg,
+                       typename std::vector<Operation>::const_iterator oend,
                        uint64_t r0, uint64_t r1, const StateSpace& state_space,
                        const Simulator& simulator, MeasurementFunc&& measure,
                        Args&&... args) {
-    std::vector<const Gate*> gates;
-    gates.reserve(4 * std::size_t(cend - cbeg));
+    using fp_type = OpFpType<Operation>;
+
+    std::vector<GateOrOperation<fp_type, Operation>> deferred_ops;
+    deferred_ops.reserve(4 * std::size_t(oend - obeg));
 
     State state = state_space.Null();
 
@@ -157,8 +163,9 @@ class QuantumTrajectorySimulator {
       bool apply_last_deferred_ops =
           param.apply_last_deferred_ops || !had_primary_realization;
 
-      if (!RunIteration(param, apply_last_deferred_ops, num_qubits, cbeg, cend,
-                        r, state_space, simulator, gates, state, stat)) {
+      if (!RunIteration<Operation>(param, apply_last_deferred_ops,
+                                   num_qubits, obeg, oend, r, state_space,
+                                   simulator, deferred_ops, state, stat)) {
         return false;
       }
 
@@ -185,20 +192,20 @@ class QuantumTrajectorySimulator {
    *   bitstrings, to be populated by this method.
    * @return True if the simulation completed successfully; false otherwise.
    */
-  static bool RunOnce(const Parameter& param,
-                      const NoisyCircuit<Gate>& circuit, uint64_t r,
-                      const StateSpace& state_space, const Simulator& simulator,
-                      State& state, Stat& stat) {
-    return RunOnce(param, circuit.num_qubits, circuit.channels.begin(),
-                   circuit.channels.end(), r, state_space, simulator,
-                   state, stat);
+  template <typename Operation>
+  static bool RunOnce(const Parameter& param, const Circuit<Operation>& circuit,
+                      uint64_t r, const StateSpace& state_space,
+                      const Simulator& simulator,State& state, Stat& stat) {
+    return RunOnce<Operation>(param, circuit.num_qubits, circuit.ops.begin(),
+                              circuit.ops.end(), r, state_space, simulator,
+                              state, stat);
   }
 
   /**
    * Runs the given noisy circuit one time.
    * @param param Options for the quantum trajectory simulator.
    * @param num_qubits The number of qubits acted on by the circuit.
-   * @param cbeg, cend The range of channels [cbeg, cend) to run the circuit.
+   * @param obeg, oend The range of operations [obeg, oend) to run the circuit.
    * @param circuit The noisy circuit to be simulated.
    * @param r The repetition ID. The random number generator is seeded by 'r'.
    * @param state_space StateSpace object required to manipulate state vector.
@@ -209,16 +216,20 @@ class QuantumTrajectorySimulator {
    *   bitstrings, to be populated by this method.
    * @return True if the simulation completed successfully; false otherwise.
    */
+  template <typename Operation>
   static bool RunOnce(const Parameter& param, unsigned num_qubits,
-                      ncircuit_iterator<Gate> cbeg,
-                      ncircuit_iterator<Gate> cend,
+                      typename std::vector<Operation>::const_iterator obeg,
+                      typename std::vector<Operation>::const_iterator oend,
                       uint64_t r, const StateSpace& state_space,
                       const Simulator& simulator, State& state, Stat& stat) {
-    std::vector<const Gate*> gates;
-    gates.reserve(4 * std::size_t(cend - cbeg));
+    using fp_type = OpFpType<Operation>;
 
-    if (!RunIteration(param, param.apply_last_deferred_ops, num_qubits, cbeg,
-                      cend, r, state_space, simulator, gates, state, stat)) {
+    std::vector<GateOrOperation<fp_type, Operation>> deferred_ops;
+    deferred_ops.reserve(4 * std::size_t(oend - obeg));
+
+    if (!RunIteration<Operation>(param, param.apply_last_deferred_ops,
+                                 num_qubits, obeg, oend, r, state_space,
+                                 simulator, deferred_ops, state, stat)) {
       return false;
     }
 
@@ -226,16 +237,20 @@ class QuantumTrajectorySimulator {
   }
 
  private:
+  template <typename Operation, typename Deferred>
   static bool RunIteration(const Parameter& param,
                            bool apply_last_deferred_ops, unsigned num_qubits,
-                           ncircuit_iterator<Gate> cbeg,
-                           ncircuit_iterator<Gate> cend,
+                           typename std::vector<Operation>::const_iterator obeg,
+                           typename std::vector<Operation>::const_iterator oend,
                            uint64_t rep, const StateSpace& state_space,
                            const Simulator& simulator,
-                           std::vector<const Gate*>& gates,
+                           std::vector<Deferred>& deferred_ops,
                            State& state, Stat& stat) {
+    using fp_type = OpFpType<Operation>;
+    using Channel = qsim::Channel<fp_type>;
+
     if (param.collect_kop_stat || param.collect_mea_stat) {
-      stat.samples.reserve(std::size_t(cend - cbeg));
+      stat.samples.reserve(std::size_t(oend - obeg));
       stat.samples.resize(0);
     }
 
@@ -248,7 +263,7 @@ class QuantumTrajectorySimulator {
       state_space.SetStateZero(state);
     }
 
-    gates.resize(0);
+    deferred_ops.resize(0);
 
     RGen rgen(rep);
     std::uniform_real_distribution<double> distr(0.0, 1.0);
@@ -256,24 +271,22 @@ class QuantumTrajectorySimulator {
     bool unitary = true;
     stat.primary = true;
 
-    for (auto it = cbeg; it != cend; ++it) {
-      const auto& channel = *it;
+    for (auto it = obeg; it != oend; ++it) {
+      const auto& op = *it;
 
-      if (channel.size() == 0) continue;
+      if (const auto* pg = OpGetAlternative<Measurement>(op)) {
+        // Measurement gate.
 
-      if (channel[0].kind == gate::kMeasurement) {
-        // Measurement channel.
-
-        if (!ApplyDeferredOps(
-                 param, num_qubits, state_space, simulator, gates, state)) {
+        if (!ApplyDeferredOps(param, num_qubits,
+                              state_space, simulator, deferred_ops, state)) {
           return false;
         }
 
         bool normalize = !unitary && param.normalize_before_mea_gates;
         NormalizeState(normalize, state_space, unitary, state);
 
-        auto mresult = ApplyMeasurementGate(state_space, channel[0].ops[0],
-                                            rgen, state);
+        auto mresult =
+            ApplyMeasurementGate(state_space, pg->qubits, rgen, state);
 
         if (!mresult.valid) {
           return false;
@@ -286,19 +299,29 @@ class QuantumTrajectorySimulator {
         continue;
       }
 
-      // "Normal" channel.
-
       double r = distr(rgen);
       double cp = 0;
 
+      const auto* pg = OpGetAlternative<Channel>(op);
+
+      if (!pg) {
+        DeferOp(op, deferred_ops);
+        CollectStat(param.collect_kop_stat, 0, stat);
+        continue;
+      }
+
+      // Channel.
+
+      const auto& channel = *pg;
+
       // Perform sampling of Kraus operators using probability bounds.
-      for (std::size_t i = 0; i < channel.size(); ++i) {
-        const auto& kop = channel[i];
+      for (std::size_t i = 0; i < channel.kops.size(); ++i) {
+        const auto& kop = channel.kops[i];
 
         cp += kop.prob;
 
         if (r < cp) {
-          DeferOps(kop.ops, gates);
+          DeferOps(kop.ops, deferred_ops);
           CollectStat(param.collect_kop_stat, i, stat);
 
           unitary = unitary && kop.unitary;
@@ -309,8 +332,8 @@ class QuantumTrajectorySimulator {
 
       if (r < cp) continue;
 
-      if (!ApplyDeferredOps(
-               param, num_qubits, state_space, simulator, gates, state)) {
+      if (!ApplyDeferredOps(param, num_qubits,
+                            state_space, simulator, deferred_ops, state)) {
         return false;
       }
 
@@ -320,8 +343,8 @@ class QuantumTrajectorySimulator {
       std::size_t max_prob_index = 0;
 
       // Perform sampling of Kraus operators using norms of updated states.
-      for (std::size_t i = 0; i < channel.size(); ++i) {
-        const auto& kop = channel[i];
+      for (std::size_t i = 0; i < channel.kops.size(); ++i) {
+        const auto& kop = channel.kops[i];
 
         if (kop.unitary) continue;
 
@@ -335,13 +358,13 @@ class QuantumTrajectorySimulator {
 
         cp += prob - kop.prob;
 
-        if (r < cp || i == channel.size() - 1) {
+        if (r < cp || i == channel.kops.size() - 1) {
           // Sample ith Kraus operator if r < cp
           // Sample the highest probability Kraus operator if r is greater
           // than the sum of all probablities due to round-off errors.
           uint64_t k = r < cp ? i : max_prob_index;
 
-          DeferOps(channel[k].ops, gates);
+          DeferOps(channel.kops[k].ops, deferred_ops);
           CollectStat(param.collect_kop_stat, k, stat);
 
           unitary = false;
@@ -352,8 +375,8 @@ class QuantumTrajectorySimulator {
     }
 
     if (apply_last_deferred_ops || !stat.primary) {
-      if (!ApplyDeferredOps(
-               param, num_qubits, state_space, simulator, gates, state)) {
+      if (!ApplyDeferredOps(param, num_qubits,
+                            state_space, simulator, deferred_ops, state)) {
         return false;
       }
 
@@ -373,13 +396,14 @@ class QuantumTrajectorySimulator {
     return state;
   }
 
+  template <typename Deferred>
   static bool ApplyDeferredOps(
       const Parameter& param, unsigned num_qubits,
       const StateSpace& state_space, const Simulator& simulator,
-      std::vector<const Gate*>& gates, State& state) {
-    if (gates.size() > 0) {
-      bool rc = Runner::Run(param, gates, state_space, simulator, state);
-      gates.resize(0);
+      std::vector<Deferred>& deferred_ops, State& state) {
+    if (deferred_ops.size() > 0) {
+      bool rc = Runner::Run(param, deferred_ops, state_space, simulator, state);
+      deferred_ops.resize(0);
       return rc;
     }
 
@@ -387,9 +411,9 @@ class QuantumTrajectorySimulator {
   }
 
   static MeasurementResult ApplyMeasurementGate(
-      const StateSpace& state_space, const Gate& gate,
+      const StateSpace& state_space, const Qubits& qubits,
       RGen& rgen, State& state) {
-    auto result = state_space.Measure(gate.qubits, rgen, state);
+    auto result = state_space.Measure(qubits, rgen, state);
 
     if (!result.valid) {
       IO::errorf("measurement failed.\n");
@@ -398,10 +422,17 @@ class QuantumTrajectorySimulator {
     return result;
   }
 
+  template <typename Operation, typename Deferred>
+  static void DeferOp(
+      const Operation& op, std::vector<Deferred>& deferred_ops) {
+    deferred_ops.push_back(&op);
+  }
+
+  template <typename Gate, typename Deferred>
   static void DeferOps(
-      const std::vector<Gate>& ops, std::vector<const Gate*>& gates) {
-    for (const auto& op : ops) {
-      gates.push_back(&op);
+      const std::vector<Gate>& gates, std::vector<Deferred>& deferred_ops) {
+    for (const auto& gate : gates) {
+      deferred_ops.push_back(&gate);
     }
   }
 

--- a/lib/run_custatevecex.h
+++ b/lib/run_custatevecex.h
@@ -22,6 +22,8 @@
 #include <custatevecEx.h>
 
 #include "circuit.h"
+#include "gate.h"
+#include "operation_base.h"
 #include "util.h"
 #include "util_custatevec.h"
 #include "util_custatevecex.h"
@@ -39,6 +41,12 @@ struct CuStateVecExRunner final {
   using State = typename StateSpace::State;
   using MeasurementResult = typename StateSpace::MeasurementResult;
 
+ private:
+  using fp_type = typename Simulator::fp_type;
+  using Gate = qsim::Gate<fp_type>;
+  using ControlledGate = qsim::ControlledGate<fp_type>;
+
+ public:
   /**
    * User-specified parameters for simulation.
    */
@@ -53,7 +61,7 @@ struct CuStateVecExRunner final {
 
   /**
    * Runs the given circuit, only measuring at the end.
-   * @param param Options for gate fusion, parallelism and logging.
+   * @param param Options for the random number generator seed.
    * @param factory Object to create simulators and state spaces.
    * @param circuit The circuit to be simulated.
    * @param measure Function that performs measurements (in the sense of
@@ -63,12 +71,12 @@ struct CuStateVecExRunner final {
   template <typename Circuit, typename MeasurementFunc>
   static bool Run(const Parameter& param, const Factory& factory,
                   const Circuit& circuit, MeasurementFunc measure) {
-    return Run(param, factory, {circuit.gates.back().time}, circuit, measure);
+    return Run(param, factory, {OpTime(circuit.ops.back())}, circuit, measure);
   }
 
   /**
    * Runs the given circuit, measuring at user-specified times.
-   * @param param Options for gate fusion, parallelism and logging.
+   * @param param Options for the random number generator seed.
    * @param factory Object to create simulators and state spaces.
    * @param times_to_measure_at Time steps at which to perform measurements.
    * @param circuit The circuit to be simulated.
@@ -100,7 +108,7 @@ struct CuStateVecExRunner final {
   /**
    * Runs the given circuit and make the final state available to the caller,
    * recording the result of any intermediate measurements in the circuit.
-   * @param param Options for gate fusion, parallelism and logging.
+   * @param param Options for the random number generator seed.
    * @param factory Object to create simulators and state spaces.
    * @param circuit The circuit to be simulated.
    * @param state As an input parameter, this should contain the initial state
@@ -127,7 +135,7 @@ struct CuStateVecExRunner final {
   /**
    * Runs the given circuit and make the final state available to the caller,
    * discarding the result of any intermediate measurements in the circuit.
-   * @param param Options for gate fusion, parallelism and logging.
+   * @param param Options for the random number generator seed.
    * @param factory Object to create simulators and state spaces.
    * @param circuit The circuit to be simulated.
    * @param state As an input parameter, this should contain the initial state
@@ -152,7 +160,7 @@ struct CuStateVecExRunner final {
   /**
    * Runs the given circuit and make the final state available to the caller,
    * recording the result of any intermediate measurements in the circuit.
-   * @param param Options for gate fusion, parallelism and logging.
+   * @param param Options for the random number generator seed.
    * @param circuit The circuit to be simulated.
    * @param state_space StateSpace object required to perform measurements.
    * @param simulator Simulator object. Provides specific implementations for
@@ -179,7 +187,7 @@ struct CuStateVecExRunner final {
   /**
    * Runs the given circuit and make the final state available to the caller,
    * discarding the result of any intermediate measurements in the circuit.
-   * @param param Options for gate fusion, parallelism and logging.
+   * @param param Options for the random number generator seed.
    * @param circuit The circuit to be simulated.
    * @param state_space StateSpace object required to perform measurements.
    * @param simulator Simulator object. Provides specific implementations for
@@ -229,60 +237,60 @@ struct CuStateVecExRunner final {
 
     unsigned cur_time_index = 0;
 
-    using Gates = detail::Gates<Circuit>;
-    const auto& gates = Gates::get(circuit);
+    const auto& ops = Operations<Circuit>::get(circuit);
 
-    for (std::size_t i = 0; i < gates.size(); ++i) {
-      const auto& gate = Gates::gate(gates[i]);
-      unsigned num_qubits = gate.qubits.size();
-      unsigned num_cqubits = gate.controlled_by.size();
+    for (std::size_t i = 0; i < ops.size(); ++i) {
+      const auto& op = ops[i];
 
-      if (gate.kind == gate::kMeasurement) {
+      if (const auto* pg = OpGetAlternative<Measurement>(op)) {
         ErrorCheck(
             custatevecExSVUpdaterApply(sv_updater, state.get(), nullptr, 0));
         ErrorCheck(custatevecExSVUpdaterClear(sv_updater));
 
-        auto measure_result = state_space.Measure(gate.qubits, rgen, state);
+        auto measure_result = state_space.Measure(pg->qubits, rgen, state);
         if (measure_result.valid) {
           measure_results.push_back(std::move(measure_result));
         } else {
           IO::errorf("measurement failed.\n");
           return false;
         }
-      } else if (num_cqubits == 0) {
-        if (num_qubits == 0) {
+      } else if (const auto* pg = OpGetAlternative<Gate>(op)) {
+        if (pg->qubits.size() == 0) {
           ErrorCheck(
             custatevecExSVUpdaterApply(sv_updater, state.get(), nullptr, 0));
           ErrorCheck(custatevecExSVUpdaterClear(sv_updater));
 
-          simulator.ApplyGate(gate.qubits, gate.matrix.data(), state);
+          simulator.ApplyGate(pg->qubits, pg->matrix.data(), state);
         } else {
           ErrorCheck(custatevecExSVUpdaterEnqueueMatrix(
-              sv_updater, gate.matrix.data(), StateSpace::kMatrixDataType,
+              sv_updater, pg->matrix.data(), StateSpace::kMatrixDataType,
               StateSpace::kExMatrixType, StateSpace::kMatrixLayout, 0,
-              reinterpret_cast<const int32_t*>(gate.qubits.data()),
-              num_qubits, nullptr, nullptr, 0));
+              reinterpret_cast<const int32_t*>(pg->qubits.data()),
+              pg->qubits.size(), nullptr, nullptr, 0));
         }
-      } else {
+      } else if (const auto* pg = OpGetAlternative<ControlledGate>(op)) {
+        unsigned num_qubits = pg->qubits.size();
+        unsigned num_cqubits = pg->controlled_by.size();
+
         std::vector<int32_t> control_bits;
         control_bits.reserve(num_cqubits);
 
         for (std::size_t i = 0; i < num_cqubits; ++i) {
-          control_bits.push_back((gate.cmask >> i) & 1);
+          control_bits.push_back((pg->cmask >> i) & 1);
         }
 
         ErrorCheck(custatevecExSVUpdaterEnqueueMatrix(
-            sv_updater, gate.matrix.data(), StateSpace::kMatrixDataType,
+            sv_updater, pg->matrix.data(), StateSpace::kMatrixDataType,
             StateSpace::kExMatrixType, StateSpace::kMatrixLayout, 0,
-            reinterpret_cast<const int32_t*>(gate.qubits.data()), num_qubits,
-            reinterpret_cast<const int32_t*>(gate.controlled_by.data()),
+            reinterpret_cast<const int32_t*>(pg->qubits.data()), num_qubits,
+            reinterpret_cast<const int32_t*>(pg->controlled_by.data()),
             control_bits.data(), num_cqubits));
       }
 
       if (times_to_measure_at.size() > 0) {
         unsigned t = times_to_measure_at[cur_time_index];
 
-        if (i == gates.size() - 1 || t < Gates::gate(gates[i + 1]).time) {
+        if (i == ops.size() - 1 || t < OpTime(ops[i + 1])) {
           ErrorCheck(
               custatevecExSVUpdaterApply(sv_updater, state.get(), nullptr, 0));
           ErrorCheck(custatevecExSVUpdaterClear(sv_updater));

--- a/lib/run_qsim.h
+++ b/lib/run_qsim.h
@@ -22,6 +22,7 @@
 #include "circuit.h"
 #include "gate.h"
 #include "gate_appl.h"
+#include "operation_base.h"
 #include "util.h"
 
 namespace qsim {
@@ -60,7 +61,8 @@ struct QSimRunner final {
   template <typename Circuit, typename MeasurementFunc>
   static bool Run(const Parameter& param, const Factory& factory,
                   const Circuit& circuit, MeasurementFunc measure) {
-    return Run(param, factory, {circuit.gates.back().time}, circuit, measure);
+    unsigned time = OpTime(circuit.ops.back());
+    return Run(param, factory, {time}, circuit, measure);
   }
 
   /**
@@ -103,10 +105,11 @@ struct QSimRunner final {
       t0 = GetTime();
     }
 
-    auto fused_gates = Fuser::FuseGates(param, circuit.num_qubits,
-                                        circuit.gates, times_to_measure_at);
+    const auto& ops = Operations<Circuit>::get(circuit);
+    auto fused_ops = Fuser::FuseGates(param, circuit.num_qubits,
+                                      ops, times_to_measure_at);
 
-    if (fused_gates.size() == 0 && circuit.gates.size() > 0) {
+    if (fused_ops.size() == 0 && circuit.ops.size() > 0) {
       return false;
     }
 
@@ -121,14 +124,13 @@ struct QSimRunner final {
 
     unsigned cur_time_index = 0;
 
-    // Apply fused gates.
-    for (std::size_t i = 0; i < fused_gates.size(); ++i) {
+    // Apply fused operations.
+    for (std::size_t i = 0; i < fused_ops.size(); ++i) {
       if (param.verbosity > 3) {
         t1 = GetTime();
       }
 
-      if (!ApplyFusedGate(state_space, simulator, fused_gates[i], rgen,
-                          state)) {
+      if (!ApplyGate(state_space, simulator, fused_ops[i], rgen, state)) {
         IO::errorf("measurement failed.\n");
         return false;
       }
@@ -141,7 +143,7 @@ struct QSimRunner final {
 
       unsigned t = times_to_measure_at[cur_time_index];
 
-      if (i == fused_gates.size() - 1 || t < fused_gates[i + 1].time) {
+      if (i == fused_ops.size() - 1 || t < OpTime(fused_ops[i + 1])) {
         // Call back to perform measurements.
         measure(cur_time_index, state_space, state);
         ++cur_time_index;
@@ -240,16 +242,14 @@ struct QSimRunner final {
       t0 = GetTime();
     }
 
-    using Gates = detail::Gates<Circuit>;
-    const auto& gates = Gates::get(circuit);
+    const auto& ops = Operations<Circuit>::get(circuit);
+    auto fused_ops = Fuser::FuseGates(param, state.num_qubits(), ops);
 
-    auto fused_gates = Fuser::FuseGates(param, state.num_qubits(), gates);
-
-    if (fused_gates.size() == 0 && gates.size() > 0) {
+    if (fused_ops.size() == 0 && ops.size() > 0) {
       return false;
     }
 
-    measure_results.reserve(fused_gates.size());
+    measure_results.reserve(fused_ops.size());
 
     if (param.verbosity > 1) {
       t1 = GetTime();
@@ -260,14 +260,14 @@ struct QSimRunner final {
       t0 = GetTime();
     }
 
-    // Apply fused gates.
-    for (std::size_t i = 0; i < fused_gates.size(); ++i) {
+    // Apply fused operations.
+    for (std::size_t i = 0; i < fused_ops.size(); ++i) {
       if (param.verbosity > 3) {
         t1 = GetTime();
       }
 
-      if (!ApplyFusedGate(state_space, simulator, fused_gates[i], rgen, state,
-                          measure_results)) {
+      if (!ApplyGate(state_space, simulator, fused_ops[i], rgen, state,
+                     measure_results)) {
         IO::errorf("measurement failed.\n");
         return false;
       }

--- a/lib/run_qsimh.h
+++ b/lib/run_qsimh.h
@@ -28,7 +28,8 @@ namespace qsim {
  */
 template <typename IO, typename Fuser, typename HybridSimulator>
 struct QSimHRunner final {
-  using Parameter = typename HybridSimulator::Parameter<typename Fuser::Parameter>;
+  using Parameter =
+      typename HybridSimulator::template Parameter<typename Fuser::Parameter>;
 
   /**
    * Evaluates the amplitudes for a given circuit and set of output states.

--- a/lib/run_qsimh.h
+++ b/lib/run_qsimh.h
@@ -26,14 +26,9 @@ namespace qsim {
 /**
  * Helper struct for running qsimh.
  */
-template <typename IO, typename HybridSimulator>
+template <typename IO, typename Fuser, typename HybridSimulator>
 struct QSimHRunner final {
-  using Gate = typename HybridSimulator::Gate;
-  using fp_type = typename HybridSimulator::fp_type;
-
-  using Parameter = typename HybridSimulator::Parameter;
-  using HybridData = typename HybridSimulator::HybridData;
-  using Fuser = typename HybridSimulator::Fuser;
+  using Parameter = typename HybridSimulator::Parameter<typename Fuser::Parameter>;
 
   /**
    * Evaluates the amplitudes for a given circuit and set of output states.
@@ -47,11 +42,11 @@ struct QSimHRunner final {
    *   will be populated with amplitudes for each state in 'bitstrings'.
    * @return True if the simulation completed successfully; false otherwise.
    */
-  template <typename Factory, typename Circuit>
+  template <typename Factory, typename Circuit, typename FP>
   static bool Run(const Parameter& param, const Factory& factory,
                   const Circuit& circuit, const std::vector<unsigned>& parts,
                   const std::vector<uint64_t>& bitstrings,
-                  std::vector<std::complex<fp_type>>& results) {
+                  std::vector<std::complex<FP>>& results) {
     if (circuit.num_qubits != parts.size()) {
       IO::errorf("parts size is not equal to the number of qubits.");
       return false;
@@ -63,8 +58,12 @@ struct QSimHRunner final {
       t0 = GetTime();
     }
 
-    HybridData hd;
-    bool rc = HybridSimulator::SplitLattice(parts, circuit.gates, hd);
+    const auto& ops = Operations<Circuit>::get(circuit);
+
+    using fp_type = OpFpType<decltype(ops[0])>;
+
+    typename HybridSimulator::HybridData<fp_type> hd;
+    bool rc = HybridSimulator::SplitLattice(parts, ops, hd);
 
     if (!rc) {
       return false;
@@ -82,18 +81,18 @@ struct QSimHRunner final {
       PrintInfo(param, hd);
     }
 
-    auto fgates0 = Fuser::FuseGates(param, hd.num_qubits0, hd.gates0);
-    if (fgates0.size() == 0 && hd.gates0.size() > 0) {
+    auto fops0 = Fuser::FuseGates(param, hd.num_qubits0, hd.ops0);
+    if (fops0.size() == 0 && hd.ops0.size() > 0) {
       return false;
     }
 
-    auto fgates1 = Fuser::FuseGates(param, hd.num_qubits1, hd.gates1);
-    if (fgates1.size() == 0 && hd.gates1.size() > 0) {
+    auto fops1 = Fuser::FuseGates(param, hd.num_qubits1, hd.ops1);
+    if (fops1.size() == 0 && hd.ops1.size() > 0) {
       return false;
     }
 
     rc = HybridSimulator(param.num_threads).Run(
-        param, factory, hd, parts, fgates0, fgates1, bitstrings, results);
+        param, factory, hd, parts, fops0, fops1, bitstrings, results);
 
     if (rc && param.verbosity > 0) {
       double t1 = GetTime();
@@ -104,6 +103,7 @@ struct QSimHRunner final {
   }
 
  private:
+  template <typename HybridData>
   static void PrintInfo(const Parameter& param, const HybridData& hd) {
     unsigned num_suffix_gates =
         hd.num_gatexs - param.num_prefix_gatexs - param.num_root_gatexs;

--- a/lib/run_qsimh.h
+++ b/lib/run_qsimh.h
@@ -63,7 +63,7 @@ struct QSimHRunner final {
 
     using fp_type = OpFpType<decltype(ops[0])>;
 
-    typename HybridSimulator::HybridData<fp_type> hd;
+    typename HybridSimulator::template HybridData<fp_type> hd;
     bool rc = HybridSimulator::SplitLattice(parts, ops, hd);
 
     if (!rc) {

--- a/pybind_interface/avx2/CMakeLists.txt
+++ b/pybind_interface/avx2/CMakeLists.txt
@@ -46,6 +46,8 @@ if(APPLE)
     )
 endif()
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(../GetPybind11.cmake)
 pybind11_add_module(qsim_avx2 pybind_main_avx2.cpp)
 

--- a/pybind_interface/avx2/pybind_main_avx2.cpp
+++ b/pybind_interface/avx2/pybind_main_avx2.cpp
@@ -35,11 +35,10 @@ namespace qsim {
     using StateSpace = Simulator::StateSpace;
 
     using Gate = Cirq::GateCirq<float>;
-    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Gate>, Factory>;
-    using RunnerQT =
-        QSimRunner<IO, MultiQubitGateFuser<IO, const Gate*>, Factory>;
+    using Operation = qsim::Operation<float>;
+    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO>, Factory>;
     using RunnerParameter = Runner::Parameter;
-    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Gate, RunnerQT>;
+    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Runner>;
     using NoisyRunnerParameter = NoisyRunner::Parameter;
 
     StateSpace CreateStateSpace() const {

--- a/pybind_interface/avx512/CMakeLists.txt
+++ b/pybind_interface/avx512/CMakeLists.txt
@@ -36,6 +36,8 @@ if(APPLE)
     )
 endif()
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(../GetPybind11.cmake)
 pybind11_add_module(qsim_avx512 pybind_main_avx512.cpp)
 

--- a/pybind_interface/avx512/pybind_main_avx512.cpp
+++ b/pybind_interface/avx512/pybind_main_avx512.cpp
@@ -35,11 +35,10 @@ namespace qsim {
     using StateSpace = Simulator::StateSpace;
 
     using Gate = Cirq::GateCirq<float>;
-    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Gate>, Factory>;
-    using RunnerQT =
-        QSimRunner<IO, MultiQubitGateFuser<IO, const Gate*>, Factory>;
+    using Operation = qsim::Operation<float>;
+    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO>, Factory>;
     using RunnerParameter = Runner::Parameter;
-    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Gate, RunnerQT>;
+    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Runner>;
     using NoisyRunnerParameter = NoisyRunner::Parameter;
 
     StateSpace CreateStateSpace() const {

--- a/pybind_interface/basic/CMakeLists.txt
+++ b/pybind_interface/basic/CMakeLists.txt
@@ -36,6 +36,8 @@ if(APPLE)
     )
 endif()
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(../GetPybind11.cmake)
 pybind11_add_module(qsim_basic pybind_main_basic.cpp)
 

--- a/pybind_interface/basic/pybind_main_basic.cpp
+++ b/pybind_interface/basic/pybind_main_basic.cpp
@@ -35,11 +35,10 @@ namespace qsim {
     using StateSpace = Simulator::StateSpace;
 
     using Gate = Cirq::GateCirq<float>;
-    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Gate>, Factory>;
-    using RunnerQT =
-        QSimRunner<IO, MultiQubitGateFuser<IO, const Gate*>, Factory>;
+    using Operation = qsim::Operation<float>;
+    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO>, Factory>;
     using RunnerParameter = Runner::Parameter;
-    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Gate, RunnerQT>;
+    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Runner>;
     using NoisyRunnerParameter = NoisyRunner::Parameter;
 
     StateSpace CreateStateSpace() const {

--- a/pybind_interface/cuda/CMakeLists.txt
+++ b/pybind_interface/cuda/CMakeLists.txt
@@ -37,6 +37,8 @@ if(APPLE)
     )
 endif()
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(../GetPybind11.cmake)
 include(../GetCUDAARCHS.cmake)
 

--- a/pybind_interface/cuda/pybind_main_cuda.cpp
+++ b/pybind_interface/cuda/pybind_main_cuda.cpp
@@ -33,11 +33,10 @@ namespace qsim {
     using StateSpace = Simulator::StateSpace;
 
     using Gate = Cirq::GateCirq<float>;
-    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Gate>, Factory>;
-    using RunnerQT =
-        QSimRunner<IO, MultiQubitGateFuser<IO, const Gate*>, Factory>;
+    using Operation = qsim::Operation<float>;
+    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO>, Factory>;
     using RunnerParameter = Runner::Parameter;
-    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Gate, RunnerQT>;
+    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Runner>;
     using NoisyRunnerParameter = NoisyRunner::Parameter;
 
     StateSpace CreateStateSpace() const {

--- a/pybind_interface/custatevec/CMakeLists.txt
+++ b/pybind_interface/custatevec/CMakeLists.txt
@@ -36,6 +36,8 @@ if(APPLE)
     )
 endif()
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(../GetPybind11.cmake)
 find_package(Python3 3.10 REQUIRED)
 

--- a/pybind_interface/custatevec/pybind_main_custatevec.cpp
+++ b/pybind_interface/custatevec/pybind_main_custatevec.cpp
@@ -41,11 +41,10 @@ namespace qsim {
     using StateSpace = Simulator::StateSpace;
 
     using Gate = Cirq::GateCirq<float>;
-    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Gate>, Factory>;
-    using RunnerQT =
-        QSimRunner<IO, MultiQubitGateFuser<IO, const Gate*>, Factory>;
+    using Operation = qsim::Operation<float>;
+    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO>, Factory>;
     using RunnerParameter = Runner::Parameter;
-    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Gate, RunnerQT>;
+    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Runner>;
     using NoisyRunnerParameter = NoisyRunner::Parameter;
 
     StateSpace CreateStateSpace() const {

--- a/pybind_interface/custatevecex/CMakeLists.txt
+++ b/pybind_interface/custatevecex/CMakeLists.txt
@@ -36,6 +36,8 @@ if(APPLE)
     )
 endif()
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(../GetPybind11.cmake)
 find_package(Python3 3.10 REQUIRED)
 

--- a/pybind_interface/custatevecex/pybind_main_custatevecex.cpp
+++ b/pybind_interface/custatevecex/pybind_main_custatevecex.cpp
@@ -73,12 +73,13 @@ namespace qsim {
     }
 
     using Gate = Cirq::GateCirq<float>;
+    using Operation = qsim::Operation<float>;
     using Runner = CuStateVecExRunner<IO, Factory>;
     struct RunnerParameter : public Runner::Parameter {
       // max_fused_size is not used, but kept for consistency.
       unsigned max_fused_size = 2;
     };
-    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Gate, Runner>;
+    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Runner>;
     struct NoisyRunnerParameter : public NoisyRunner::Parameter {
       // max_fused_size is not used, but kept for consistency.
       unsigned max_fused_size = 2;

--- a/pybind_interface/decide/CMakeLists.txt
+++ b/pybind_interface/decide/CMakeLists.txt
@@ -39,6 +39,8 @@ if(APPLE)
     )
 endif()
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(../GetPybind11.cmake)
 
 # Configure based on the detected platform

--- a/pybind_interface/hip/CMakeLists.txt
+++ b/pybind_interface/hip/CMakeLists.txt
@@ -21,6 +21,8 @@ else()
     add_compile_options(-fno-lto)
 endif()
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(../GetPybind11.cmake)
 find_package(PythonLibs 3.10 REQUIRED)
 

--- a/pybind_interface/hip/pybind_main_hip.cpp
+++ b/pybind_interface/hip/pybind_main_hip.cpp
@@ -33,11 +33,10 @@ namespace qsim {
     using StateSpace = Simulator::StateSpace;
 
     using Gate = Cirq::GateCirq<float>;
-    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Gate>, Factory>;
-    using RunnerQT =
-        QSimRunner<IO, MultiQubitGateFuser<IO, const Gate*>, Factory>;
+    using Operation = qsim::Operation<float>;
+    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO>, Factory>;
     using RunnerParameter = Runner::Parameter;
-    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Gate, RunnerQT>;
+    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Runner>;
     using NoisyRunnerParameter = NoisyRunner::Parameter;
 
     StateSpace CreateStateSpace() const {

--- a/pybind_interface/pybind_main.cpp
+++ b/pybind_interface/pybind_main.cpp
@@ -14,10 +14,12 @@
 
 #include "pybind_main.h"
 
-#include <complex>
-#include <sstream>
-#include <cmath>
 #include <algorithm>
+#include <cmath>
+#include <complex>
+#include <map>
+#include <set>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -34,17 +36,9 @@ using namespace qsim;
 
 namespace {
 
-Circuit<Factory::Gate> getCircuit(const py::dict &options) {
+Circuit<Factory::Operation> getCircuit(const py::dict &options) {
   try {
-    return options["c\0"].cast<Circuit<Factory::Gate>>();
-  } catch (const std::invalid_argument &exp) {
-    throw;
-  }
-}
-
-NoisyCircuit<Factory::Gate> getNoisyCircuit(const py::dict &options) {
-  try {
-    return options["c\0"].cast<NoisyCircuit<Factory::Gate>>();
+    return options["c\0"].cast<Circuit<Factory::Operation>>();
   } catch (const std::invalid_argument &exp) {
     throw;
   }
@@ -70,9 +64,9 @@ std::vector<Bitstring> getBitstrings(const py::dict &options, int num_qubits) {
 }  // namespace
 
 Factory::Gate create_gate(const qsim::Cirq::GateKind gate_kind,
-                                  const unsigned time,
-                                  const std::vector<unsigned>& qubits,
-                                  const std::map<std::string, float>& params) {
+                          const unsigned time,
+                          const std::vector<unsigned>& qubits,
+                          const std::map<std::string, float>& params) {
   switch (gate_kind) {
     case Cirq::kI1:
       return Cirq::I1<float>::Create(time, qubits[0]);
@@ -189,11 +183,6 @@ Factory::Gate create_gate(const qsim::Cirq::GateKind gate_kind,
       return Cirq::CCZ<float>::Create(time, qubits[0], qubits[1], qubits[2]);
     case Cirq::kCCX:
       return Cirq::CCX<float>::Create(time, qubits[0], qubits[1], qubits[2]);
-    case Cirq::kMeasurement: {
-      std::vector<unsigned> qubits_ = qubits;
-      return gate::Measurement<Factory::Gate>::Create(
-        time, std::move(qubits_));
-      }
     // Matrix gates are handled in the add_matrix methods below.
     default:
       throw std::invalid_argument("GateKind not supported.");
@@ -201,8 +190,8 @@ Factory::Gate create_gate(const qsim::Cirq::GateKind gate_kind,
 }
 
 Factory::Gate create_diagonal_gate(const unsigned time,
-                                           const std::vector<unsigned>& qubits,
-                                           const std::vector<float>& angles) {
+                                   const std::vector<unsigned>& qubits,
+                                   const std::vector<float>& angles) {
   switch (qubits.size()) {
   case 2:
     return Cirq::TwoQubitDiagonalGate<float>::Create(
@@ -217,8 +206,8 @@ Factory::Gate create_diagonal_gate(const unsigned time,
 }
 
 Factory::Gate create_matrix_gate(const unsigned time,
-                                         const std::vector<unsigned>& qubits,
-                                         const std::vector<float>& matrix) {
+                                 const std::vector<unsigned>& qubits,
+                                 const std::vector<float>& matrix) {
   switch (qubits.size()) {
   case 0:
     // Global phase gate.
@@ -241,81 +230,44 @@ Factory::Gate create_matrix_gate(const unsigned time,
 void add_gate(const qsim::Cirq::GateKind gate_kind, const unsigned time,
               const std::vector<unsigned>& qubits,
               const std::map<std::string, float>& params,
-              Circuit<Factory::Gate>* circuit) {
-  circuit->gates.push_back(create_gate(gate_kind, time, qubits, params));
+              Circuit<Factory::Operation>* circuit) {
+  circuit->ops.push_back(create_gate(gate_kind, time, qubits, params));
 }
 
 void add_diagonal_gate(const unsigned time, const std::vector<unsigned>& qubits,
                        const std::vector<float>& angles,
-                       Circuit<Factory::Gate>* circuit) {
-  circuit->gates.push_back(create_diagonal_gate(time, qubits, angles));
+                       Circuit<Factory::Operation>* circuit) {
+  circuit->ops.push_back(create_diagonal_gate(time, qubits, angles));
 }
 
-void add_matrix_gate(const unsigned time,
-                     const std::vector<unsigned>& qubits,
+void add_matrix_gate(const unsigned time, const std::vector<unsigned>& qubits,
                      const std::vector<float>& matrix,
-                     Circuit<Factory::Gate>* circuit) {
-  circuit->gates.push_back(create_matrix_gate(time, qubits, matrix));
+                     Circuit<Factory::Operation>* circuit) {
+  circuit->ops.push_back(create_matrix_gate(time, qubits, matrix));
+}
+
+void add_measurement(const unsigned time, const std::vector<unsigned>& qubits,
+                     Circuit<Factory::Operation>* circuit) {
+  circuit->ops.push_back(CreateMeasurement(time, qubits));
 }
 
 void control_last_gate(const std::vector<unsigned>& qubits,
                        const std::vector<unsigned>& values,
-                       Circuit<Factory::Gate>* circuit) {
-  MakeControlledGate(qubits, values, circuit->gates.back());
-}
-
-template <typename Gate>
-Channel<Gate> create_single_gate_channel(Gate gate) {
-  auto gate_kind = KrausOperator<Gate>::kNormal;
-  if (gate.kind == gate::kMeasurement) {
-    gate_kind = KrausOperator<Gate>::kMeasurement;
-  }
-  return {{gate_kind, 1, 1.0, {gate}}};
-}
-
-void add_gate_channel(const qsim::Cirq::GateKind gate_kind, const unsigned time,
-                      const std::vector<unsigned>& qubits,
-                      const std::map<std::string, float>& params,
-                      NoisyCircuit<Factory::Gate>* ncircuit) {
-  ncircuit->channels.push_back(create_single_gate_channel(
-    create_gate(gate_kind, time, qubits, params)));
-}
-
-void add_diagonal_gate_channel(const unsigned time,
-                               const std::vector<unsigned>& qubits,
-                               const std::vector<float>& angles,
-                               NoisyCircuit<Factory::Gate>* ncircuit) {
-  ncircuit->channels.push_back(create_single_gate_channel(
-    create_diagonal_gate(time, qubits, angles)));
-}
-
-void add_matrix_gate_channel(const unsigned time,
-                             const std::vector<unsigned>& qubits,
-                             const std::vector<float>& matrix,
-                             NoisyCircuit<Factory::Gate>* ncircuit) {
-  ncircuit->channels.push_back(create_single_gate_channel(
-    create_matrix_gate(time, qubits, matrix)));
-}
-
-void control_last_gate_channel(const std::vector<unsigned>& qubits,
-                               const std::vector<unsigned>& values,
-                               NoisyCircuit<Factory::Gate>* ncircuit) {
-  if (ncircuit->channels.back().size() > 1) {
-    throw std::invalid_argument(
-        "Control cannot be added to noisy channels.");
-  }
-  for (Factory::Gate& op : ncircuit->channels.back()[0].ops) {
-    MakeControlledGate(qubits, values, op);
-  }
+                       Circuit<Factory::Operation>* circuit) {
+  auto& lop = circuit->ops.back();
+  lop = OpGetAlternative<Factory::Gate>(lop)->ControlledBy(qubits, values);
 }
 
 void add_channel(const unsigned time,
                  const std::vector<unsigned>& qubits,
                  const std::vector<std::tuple<float, std::vector<float>, bool>>&
                      prob_matrix_unitary_triples,
-                 NoisyCircuit<Factory::Gate>* ncircuit) {
+                 Circuit<Factory::Operation>* ncircuit) {
   // Adds a channel to the noisy circuit.
-  Channel<Factory::Gate> channel;
+
+  std::set<unsigned> qubits_set;
+  Channel<float> channel{{kChannel, time, {}}, {}};
+
   // prob_matrix_unitary_triples contains triples with these elements:
   //   0. The lower-bound probability of applying the matrix.
   //   1. The matrix to be applied.
@@ -325,33 +277,42 @@ void add_channel(const unsigned time,
     const std::vector<float>& mat = std::get<1>(triple);
     bool is_unitary = std::get<2>(triple);
     Factory::Gate gate = create_matrix_gate(time, qubits, mat);
-    channel.emplace_back(KrausOperator<Factory::Gate>{
-      KrausOperator<Factory::Gate>::kNormal, is_unitary, prob, {gate}
-    });
+
+    for (auto q : gate.qubits) {
+      qubits_set.insert(q);
+    }
+
+    channel.kops.push_back(KrausOperator<float>{is_unitary, prob, {gate}});
     if (!is_unitary) {
-      channel.back().CalculateKdKMatrix();
+      channel.kops.back().CalculateKdKMatrix();
     }
   }
-  ncircuit->channels.push_back(channel);
+
+  channel.qubits.reserve(qubits_set.size());
+  for (auto it = qubits_set.begin(); it != qubits_set.end(); ++it) {
+    channel.qubits.push_back(*it);
+  }
+
+  ncircuit->ops.push_back(channel);
 }
 
-void add_gate_to_opstring(const Cirq::GateKind gate_kind,
+void add_gate_to_opstring(const qsim::Cirq::GateKind gate_kind,
                           const std::vector<unsigned>& qubits,
-                          OpString<Factory::Gate>* opstring) {
+                          OpString<float>* opstring) {
   static std::map<std::string, float> params;
   opstring->ops.push_back(create_gate(gate_kind, 0, qubits, params));
 }
 
 void add_matrix_gate_to_opstring(const std::vector<unsigned>& qubits,
                                  const std::vector<float>& matrix,
-                                 OpString<Factory::Gate>* opstring) {
+                                 OpString<float>* opstring) {
   opstring->ops.push_back(create_matrix_gate(0, qubits, matrix));
 }
 
 // Methods for simulating amplitudes.
 
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options) {
-  Circuit<Factory::Gate> circuit;
+  Circuit<Factory::Operation> circuit;
   std::vector<Bitstring> bitstrings;
   try {
     circuit = getCircuit(options);
@@ -405,11 +366,11 @@ std::vector<std::complex<float>> qsim_simulate(const py::dict &options) {
 }
 
 std::vector<std::complex<float>> qtrajectory_simulate(const py::dict &options) {
-  NoisyCircuit<Factory::Gate> ncircuit;
+  Circuit<Factory::Operation> ncircuit;
   unsigned num_qubits;
   std::vector<Bitstring> bitstrings;
   try {
-    ncircuit = getNoisyCircuit(options);
+    ncircuit = getCircuit(options);
     num_qubits = ncircuit.num_qubits;
     bitstrings = getBitstrings(options, num_qubits);
   } catch (const std::invalid_argument &exp) {
@@ -532,7 +493,7 @@ class SimulatorHelper {
   static std::vector<std::complex<double>> simulate_expectation_values(
       const py::dict &options,
       const std::vector<std::tuple<
-                            std::vector<OpString<Factory::Gate>>,
+                            std::vector<OpString<float>>,
                             unsigned>>& opsums_and_qubit_counts,
       bool is_noisy, const StateType& input_state) {
     auto helper = SimulatorHelper(options, is_noisy);
@@ -570,7 +531,7 @@ class SimulatorHelper {
   simulate_moment_expectation_values(
       const py::dict &options,
       const std::vector<std::tuple<uint64_t, std::vector<
-          std::tuple<std::vector<OpString<Factory::Gate>>,
+          std::tuple<std::vector<OpString<float>>,
                      unsigned>>>>& opsums_and_qubit_counts,
       bool is_noisy, const StateType& input_state) {
     auto helper = SimulatorHelper(options, is_noisy);
@@ -640,7 +601,7 @@ class SimulatorHelper {
 
     try {
       if (is_noisy) {
-        ncircuit = getNoisyCircuit(options);
+        ncircuit = getCircuit(options);
         num_qubits = ncircuit.num_qubits;
         noisy_reps = ParseOptions<unsigned>(options, "r\0");
       } else {
@@ -730,18 +691,18 @@ class SimulatorHelper {
       Simulator simulator = factory.CreateSimulator();
       StateSpace state_space = factory.CreateStateSpace();
 
-      result = NoisyRunner::RunOnce(
+      result = NoisyRunner::RunOnce<Factory::Operation>(
         params, ncircuit.num_qubits,
-        ncircuit.channels.begin() + begin,
-        ncircuit.channels.begin() + end,
+        ncircuit.ops.begin() + begin,
+        ncircuit.ops.begin() + end,
         seed, state_space, simulator, state, stat
       );
     } else {
-      Circuit<Factory::Gate> subcircuit;
+      Circuit<Factory::Operation> subcircuit;
       subcircuit.num_qubits = circuit.num_qubits;
-      subcircuit.gates = std::vector<Factory::Gate>(
-        circuit.gates.begin() + begin,
-        circuit.gates.begin() + end
+      subcircuit.ops = std::vector<Factory::Operation>(
+        circuit.ops.begin() + begin,
+        circuit.ops.begin() + end
       );
       result = Runner::Run(get_params(), factory, subcircuit, state);
     }
@@ -764,11 +725,11 @@ class SimulatorHelper {
   }
 
   std::vector<std::complex<double>> get_expectation_value(
-      const std::vector<std::tuple<std::vector<OpString<Factory::Gate>>,
+      const std::vector<std::tuple<std::vector<OpString<float>>,
                                    unsigned>>& opsums_and_qubit_counts) {
     Simulator simulator = factory.CreateSimulator();
     StateSpace state_space = factory.CreateStateSpace();
-    using Fuser = MultiQubitGateFuser<IO, Factory::Gate>;
+    using Fuser = MultiQubitGateFuser<IO>;
 
     std::vector<std::complex<double>> results;
     results.reserve(opsums_and_qubit_counts.size());
@@ -797,8 +758,8 @@ class SimulatorHelper {
 
   bool is_noisy;
   // Only one of these will be populated, as specified by is_noisy.
-  Circuit<Factory::Gate> circuit;
-  NoisyCircuit<Factory::Gate> ncircuit;
+  Circuit<Factory::Operation> circuit;
+  Circuit<Factory::Operation> ncircuit;
 
   Factory factory;
   State state;
@@ -841,7 +802,7 @@ py::array_t<float> qtrajectory_simulate_fullstate(
 std::vector<std::complex<double>> qsim_simulate_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<
-                          std::vector<OpString<Factory::Gate>>,
+                          std::vector<OpString<float>>,
                           unsigned>>& opsums_and_qubit_counts,
     uint64_t input_state) {
   return SimulatorHelper::simulate_expectation_values(
@@ -851,7 +812,7 @@ std::vector<std::complex<double>> qsim_simulate_expectation_values(
 std::vector<std::complex<double>> qsim_simulate_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<
-                          std::vector<OpString<Factory::Gate>>,
+                          std::vector<OpString<float>>,
                           unsigned>>& opsums_and_qubit_counts,
     const py::array_t<float> &input_vector) {
   return SimulatorHelper::simulate_expectation_values(
@@ -862,7 +823,7 @@ std::vector<std::vector<std::complex<double>>>
 qsim_simulate_moment_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<uint64_t, std::vector<
-      std::tuple<std::vector<OpString<Factory::Gate>>, unsigned>
+      std::tuple<std::vector<OpString<float>>, unsigned>
     >>>& opsums_and_qubit_counts,
     uint64_t input_state) {
   return SimulatorHelper::simulate_moment_expectation_values(
@@ -873,7 +834,7 @@ std::vector<std::vector<std::complex<double>>>
 qsim_simulate_moment_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<uint64_t, std::vector<
-      std::tuple<std::vector<OpString<Factory::Gate>>, unsigned>
+      std::tuple<std::vector<OpString<float>>, unsigned>
     >>>& opsums_and_qubit_counts,
     const py::array_t<float> &input_vector) {
   return SimulatorHelper::simulate_moment_expectation_values(
@@ -883,7 +844,7 @@ qsim_simulate_moment_expectation_values(
 std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<
-                          std::vector<OpString<Factory::Gate>>,
+                          std::vector<OpString<float>>,
                           unsigned>>& opsums_and_qubit_counts,
     uint64_t input_state) {
   return SimulatorHelper::simulate_expectation_values(
@@ -893,7 +854,7 @@ std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
 std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<
-                          std::vector<OpString<Factory::Gate>>,
+                          std::vector<OpString<float>>,
                           unsigned>>& opsums_and_qubit_counts,
     const py::array_t<float> &input_vector) {
   return SimulatorHelper::simulate_expectation_values(
@@ -904,7 +865,7 @@ std::vector<std::vector<std::complex<double>>>
 qtrajectory_simulate_moment_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<uint64_t, std::vector<
-      std::tuple<std::vector<OpString<Factory::Gate>>, unsigned>
+      std::tuple<std::vector<OpString<float>>, unsigned>
     >>>& opsums_and_qubit_counts,
     uint64_t input_state) {
   return SimulatorHelper::simulate_moment_expectation_values(
@@ -915,7 +876,7 @@ std::vector<std::vector<std::complex<double>>>
 qtrajectory_simulate_moment_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<uint64_t, std::vector<
-      std::tuple<std::vector<OpString<Factory::Gate>>, unsigned>
+      std::tuple<std::vector<OpString<float>>, unsigned>
     >>>& opsums_and_qubit_counts,
     const py::array_t<float> &input_vector) {
   return SimulatorHelper::simulate_moment_expectation_values(
@@ -935,7 +896,7 @@ std::vector<uint64_t> qtrajectory_sample_final(
 }
 
 std::vector<unsigned> qsim_sample(const py::dict &options) {
-  Circuit<Factory::Gate> circuit;
+  Circuit<Factory::Operation> circuit;
   try {
     circuit = getCircuit(options);
   } catch (const std::invalid_argument &exp) {
@@ -991,9 +952,9 @@ std::vector<unsigned> qsim_sample(const py::dict &options) {
 }
 
 std::vector<unsigned> qtrajectory_sample(const py::dict &options) {
-  NoisyCircuit<Factory::Gate> ncircuit;
+  Circuit<Factory::Operation> ncircuit;
   try {
-    ncircuit = getNoisyCircuit(options);
+    ncircuit = getCircuit(options);
   } catch (const std::invalid_argument &exp) {
     IO::errorf("%s", exp.what());
     return {};
@@ -1029,13 +990,13 @@ std::vector<unsigned> qtrajectory_sample(const py::dict &options) {
       // Converts stat (which matches the MeasurementResult 'bits' field) into
       // bitstrings matching the MeasurementResult 'bitstring' field.
       unsigned idx = 0;
-      for (const auto& channel : ncircuit.channels) {
-        if (channel[0].kind != gate::kMeasurement)
-          continue;
-        for (const auto& op : channel[0].ops) {
+      for (const auto& op : ncircuit.ops) {
+        if (const auto* pg = OpGetAlternative<Measurement>(op)) {
           std::vector<unsigned> bitstring;
+          bitstring.reserve(pg->qubits.size());
+
           uint64_t val = stat.samples[idx];
-          for (const auto& q : op.qubits) {
+          for (const auto& q : pg->qubits) {
             bitstring.push_back((val >> q) & 1);
           }
           results.push_back(bitstring);
@@ -1073,11 +1034,10 @@ std::vector<unsigned> qtrajectory_sample(const py::dict &options) {
 // Method for running the hybrid simulator.
 
 std::vector<std::complex<float>> qsimh_simulate(const py::dict &options) {
-  using HybridSimulator = HybridSimulator<IO, Factory::Gate,
-                                          MultiQubitGateFuser, For>;
-  using Runner = QSimHRunner<IO, HybridSimulator>;
+  using HybridSimulator = HybridSimulator<IO, For>;
+  using Runner = QSimHRunner<IO, MultiQubitGateFuser<IO>, HybridSimulator>;
 
-  Circuit<Factory::Gate> circuit;
+  Circuit<Factory::Operation> circuit;
   std::vector<Bitstring> bitstrings;
   Runner::Parameter param;
   py::list dense_parts;

--- a/pybind_interface/pybind_main.h
+++ b/pybind_interface/pybind_main.h
@@ -29,64 +29,46 @@ namespace py = pybind11;
 #include "../lib/circuit.h"
 #include "../lib/expect.h"
 #include "../lib/gates_cirq.h"
+#include "../lib/operation.h"
 #include "../lib/qtrajectory.h"
 
 // Methods for mutating noiseless circuits.
 void add_gate(const qsim::Cirq::GateKind gate_kind, const unsigned time,
               const std::vector<unsigned>& qubits,
               const std::map<std::string, float>& params,
-              qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit);
+              qsim::Circuit<qsim::Operation<float>>* circuit);
 
 void add_diagonal_gate(const unsigned time, const std::vector<unsigned>& qubits,
                        const std::vector<float>& angles,
-                       qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit);
+                       qsim::Circuit<qsim::Operation<float>>* circuit);
 
 void add_matrix_gate(const unsigned time, const std::vector<unsigned>& qubits,
                      const std::vector<float>& matrix,
-                     qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit);
+                     qsim::Circuit<qsim::Operation<float>>* circuit);
+
+void add_measurement(const unsigned time, const std::vector<unsigned>& qubits,
+                     qsim::Circuit<qsim::Operation<float>>* circuit);
 
 void control_last_gate(const std::vector<unsigned>& qubits,
                        const std::vector<unsigned>& values,
-                       qsim::Circuit<qsim::Cirq::GateCirq<float>>* circuit);
-
-// Methods for mutating noisy circuits.
-void add_gate_channel(
-    const qsim::Cirq::GateKind gate_kind,
-    const unsigned time,
-    const std::vector<unsigned>& qubits,
-    const std::map<std::string, float>& params,
-    qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* ncircuit);
-
-void add_diagonal_gate_channel(
-    const unsigned time, const std::vector<unsigned>& qubits,
-    const std::vector<float>& angles,
-    qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* ncircuit);
-
-void add_matrix_gate_channel(
-    const unsigned time, const std::vector<unsigned>& qubits,
-    const std::vector<float>& matrix,
-    qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* ncircuit);
-
-void control_last_gate_channel(
-    const std::vector<unsigned>& qubits, const std::vector<unsigned>& values,
-    qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* ncircuit);
+                       qsim::Circuit<qsim::Operation<float>>* circuit);
 
 void add_channel(const unsigned time,
                  const std::vector<unsigned>& qubits,
                  const std::vector<std::tuple<float, std::vector<float>, bool>>&
                      prob_matrix_unitary_triples,
-                 qsim::NoisyCircuit<qsim::Cirq::GateCirq<float>>* ncircuit);
+                 qsim::Circuit<qsim::Operation<float>>* ncircuit);
 
 // Methods for populating opstrings.
 void add_gate_to_opstring(
     const qsim::Cirq::GateKind gate_kind,
     const std::vector<unsigned>& qubits,
-    qsim::OpString<qsim::Cirq::GateCirq<float>>* opstring);
+    qsim::OpString<float>* opstring);
 
 void add_matrix_gate_to_opstring(
     const std::vector<unsigned>& qubits,
     const std::vector<float>& matrix,
-    qsim::OpString<qsim::Cirq::GateCirq<float>>* opstring);
+    qsim::OpString<float>* opstring);
 
 // Methods for simulating noiseless circuits.
 std::vector<std::complex<float>> qsim_simulate(const py::dict &options);
@@ -116,15 +98,13 @@ std::vector<uint64_t> qtrajectory_sample_final(
 std::vector<std::complex<double>> qsim_simulate_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<
-                          std::vector<qsim::OpString<
-                              qsim::Cirq::GateCirq<float>>>,
+                          std::vector<qsim::OpString<float>>,
                           unsigned>>& opsums_and_qubit_counts,
     uint64_t input_state);
 std::vector<std::complex<double>> qsim_simulate_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<
-                          std::vector<qsim::OpString<
-                              qsim::Cirq::GateCirq<float>>>,
+                          std::vector<qsim::OpString<float>>,
                           unsigned>>& opsums_and_qubit_counts,
     const py::array_t<float> &input_vector);
 std::vector<std::vector<std::complex<double>>>
@@ -132,7 +112,7 @@ qsim_simulate_moment_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<uint64_t, std::vector<
       std::tuple<
-        std::vector<qsim::OpString<qsim::Cirq::GateCirq<float>>>,
+        std::vector<qsim::OpString<float>>,
         unsigned
     >>>>& opsums_and_qubit_counts,
     uint64_t input_state);
@@ -141,22 +121,20 @@ qsim_simulate_moment_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<uint64_t, std::vector<
       std::tuple<
-        std::vector<qsim::OpString<qsim::Cirq::GateCirq<float>>>,
+        std::vector<qsim::OpString<float>>,
         unsigned
     >>>>& opsums_and_qubit_counts,
     const py::array_t<float> &input_vector);
 std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<
-                          std::vector<qsim::OpString<
-                              qsim::Cirq::GateCirq<float>>>,
+                          std::vector<qsim::OpString<float>>,
                           unsigned>>& opsums_and_qubit_counts,
     uint64_t input_state);
 std::vector<std::complex<double>> qtrajectory_simulate_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<
-                          std::vector<qsim::OpString<
-                              qsim::Cirq::GateCirq<float>>>,
+                          std::vector<qsim::OpString<float>>,
                           unsigned>>& opsums_and_qubit_counts,
     const py::array_t<float> &input_vector);
 std::vector<std::vector<std::complex<double>>>
@@ -164,7 +142,7 @@ qtrajectory_simulate_moment_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<uint64_t, std::vector<
       std::tuple<
-        std::vector<qsim::OpString<qsim::Cirq::GateCirq<float>>>,
+        std::vector<qsim::OpString<float>>,
         unsigned
     >>>>& opsums_and_qubit_counts,
     uint64_t input_state);
@@ -173,7 +151,7 @@ qtrajectory_simulate_moment_expectation_values(
     const py::dict &options,
     const std::vector<std::tuple<uint64_t, std::vector<
       std::tuple<
-        std::vector<qsim::OpString<qsim::Cirq::GateCirq<float>>>,
+        std::vector<qsim::OpString<float>>,
         unsigned
     >>>>& opsums_and_qubit_counts,
     const py::array_t<float> &input_vector);
@@ -228,8 +206,7 @@ T ParseOptions(const py::dict& options, const char* key) {
       m.def("qtrajectory_sample_final", &qtrajectory_sample_final,                    \
             "Call the qtrajectory final-state sampler");                              \
                                                                                       \
-      using GateCirq = qsim::Cirq::GateCirq<float>;                                   \
-      using OpString = qsim::OpString<GateCirq>;                                      \
+      using OpString = qsim::OpString<float>;                                         \
                                                                                       \
       /* Methods for returning expectation values */                                  \
       m.def("qsim_simulate_expectation_values",                                       \
@@ -306,23 +283,22 @@ T ParseOptions(const py::dict& options, const char* key) {
       m.def("qsimh_simulate", &qsimh_simulate, "Call the qsimh simulator");           \
                                                                                       \
       using GateKind = qsim::Cirq::GateKind;                                          \
-      using Circuit = qsim::Circuit<GateCirq>;                                        \
-      using NoisyCircuit = qsim::NoisyCircuit<GateCirq>;                              \
+      using OtherGateKind = qsim::OtherGateKind;                                      \
+      using Circuit = qsim::Circuit<qsim::Operation<float>>;                          \
                                                                                       \
       py::class_<Circuit>(m, "Circuit")                                               \
         .def(py::init<>())                                                            \
         .def_readwrite("num_qubits", &Circuit::num_qubits)                            \
-        .def_readwrite("gates", &Circuit::gates);                                     \
-                                                                                      \
-      py::class_<NoisyCircuit>(m, "NoisyCircuit")                                     \
-        .def(py::init<>())                                                            \
-        .def_readwrite("num_qubits", &NoisyCircuit::num_qubits)                       \
-        .def_readwrite("channels", &NoisyCircuit::channels);                          \
+        .def_readwrite("ops", &Circuit::ops);                                         \
                                                                                       \
       py::class_<OpString>(m, "OpString")                                             \
         .def(py::init<>())                                                            \
         .def_readwrite("weight", &OpString::weight)                                   \
         .def_readwrite("ops", &OpString::ops);                                        \
+                                                                                      \
+      py::enum_<OtherGateKind>(m, "OtherGateKind")                                    \
+        .value("kMeasurement", OtherGateKind::kMeasurement)                           \
+        .export_values();                                                             \
                                                                                       \
       py::enum_<GateKind>(m, "GateKind")                                              \
         .value("kI1", GateKind::kI1)                                                  \
@@ -369,7 +345,6 @@ T ParseOptions(const py::dict& options, const char* key) {
         .value("kCCZ", GateKind::kCCZ)                                                \
         .value("kCCX", GateKind::kCCX)                                                \
         .value("kMatrixGate", GateKind::kMatrixGate)                                  \
-        .value("kMeasurement", GateKind::kMeasurement)                                \
         .export_values();                                                             \
                                                                                       \
       m.def("add_gate", &add_gate, "Adds a gate to the given circuit.");              \
@@ -377,17 +352,10 @@ T ParseOptions(const py::dict& options, const char* key) {
             "Adds a two- or three-qubit diagonal gate to the given circuit.");        \
       m.def("add_matrix_gate", &add_matrix_gate,                                      \
             "Adds a matrix-defined gate to the given circuit.");                      \
+      m.def("add_measurement", &add_measurement,                                      \
+            "Adds a measurement gate to the given circuit.");                         \
       m.def("control_last_gate", &control_last_gate,                                  \
             "Applies controls to the final gate of a circuit.");                      \
-                                                                                      \
-      m.def("add_gate_channel", &add_gate_channel,                                    \
-            "Adds a gate to the given noisy circuit.");                               \
-      m.def("add_diagonal_gate_channel", &add_diagonal_gate_channel,                  \
-            "Adds a two- or three-qubit diagonal gate to the given noisy circuit.");  \
-      m.def("add_matrix_gate_channel", &add_matrix_gate_channel,                      \
-            "Adds a matrix-defined gate to the given noisy circuit.");                \
-      m.def("control_last_gate_channel", &control_last_gate_channel,                  \
-            "Applies controls to the final channel of a noisy circuit.");             \
                                                                                       \
       m.def("add_channel", &add_channel,                                              \
             "Adds a channel to the given noisy circuit.");                            \
@@ -397,7 +365,7 @@ T ParseOptions(const py::dict& options, const char* key) {
       m.def("add_matrix_gate_to_opstring", &add_matrix_gate_to_opstring,              \
             "Adds a matrix gate to the given opstring.");
 
-#define GPU_MODULE_BINDINGS                                                                  \
+#define GPU_MODULE_BINDINGS                                                           \
       m.doc() = "pybind11 plugin";  /* optional module docstring */                   \
       /* Methods for returning amplitudes */                                          \
       m.def("qsim_simulate", &qsim_simulate, "Call the qsim simulator");              \
@@ -435,7 +403,7 @@ T ParseOptions(const py::dict& options, const char* key) {
             "Call the qtrajectory final-state sampler");                              \
                                                                                       \
       using GateCirq = qsim::Cirq::GateCirq<float>;                                   \
-      using OpString = qsim::OpString<GateCirq>;                                      \
+      using OpString = qsim::OpString<float>;                                         \
                                                                                       \
       /* Methods for returning expectation values */                                  \
       m.def("qsim_simulate_expectation_values",                                       \

--- a/pybind_interface/sse/CMakeLists.txt
+++ b/pybind_interface/sse/CMakeLists.txt
@@ -36,6 +36,8 @@ if(APPLE)
     )
 endif()
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(../GetPybind11.cmake)
 pybind11_add_module(qsim_sse pybind_main_sse.cpp)
 

--- a/pybind_interface/sse/pybind_main_sse.cpp
+++ b/pybind_interface/sse/pybind_main_sse.cpp
@@ -35,11 +35,10 @@ namespace qsim {
     using StateSpace = Simulator::StateSpace;
 
     using Gate = Cirq::GateCirq<float>;
-    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO, Gate>, Factory>;
-    using RunnerQT =
-        QSimRunner<IO, MultiQubitGateFuser<IO, const Gate*>, Factory>;
+    using Operation = qsim::Operation<float>;
+    using Runner = QSimRunner<IO, MultiQubitGateFuser<IO>, Factory>;
     using RunnerParameter = Runner::Parameter;
-    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Gate, RunnerQT>;
+    using NoisyRunner = qsim::QuantumTrajectorySimulator<IO, Runner>;
     using NoisyRunnerParameter = NoisyRunner::Parameter;
 
     StateSpace CreateStateSpace() const {

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -266,7 +266,7 @@ def add_op_to_circuit(
     qsim_op: cirq.GateOperation,
     time: int,
     qubit_to_index_dict: Dict[cirq.Qid, int],
-    circuit: Union[qsim.Circuit, qsim.NoisyCircuit],
+    circuit: qsim.Circuit,
 ):
     """Adds an operation to a noisy or noiseless circuit."""
     qsim_gate = qsim_op.gate
@@ -297,22 +297,16 @@ def add_op_to_circuit(
         gate_kind == qsim.kTwoQubitDiagonalGate
         or gate_kind == qsim.kThreeQubitDiagonalGate
     ):
-        if isinstance(circuit, qsim.Circuit):
-            qsim.add_diagonal_gate(
-                time, qsim_qubits, qsim_gate._diag_angles_radians, circuit
-            )
-        else:
-            qsim.add_diagonal_gate_channel(
-                time, qsim_qubits, qsim_gate._diag_angles_radians, circuit
-            )
+        qsim.add_diagonal_gate(
+            time, qsim_qubits, qsim_gate._diag_angles_radians, circuit
+        )
     elif gate_kind == qsim.kMatrixGate:
         m = [
             val for i in list(cirq.unitary(qsim_gate).flat) for val in [i.real, i.imag]
         ]
-        if isinstance(circuit, qsim.Circuit):
-            qsim.add_matrix_gate(time, qsim_qubits, m, circuit)
-        else:
-            qsim.add_matrix_gate_channel(time, qsim_qubits, m, circuit)
+        qsim.add_matrix_gate(time, qsim_qubits, m, circuit)
+    elif gate_kind == qsim.kMeasurement:
+        qsim.add_measurement(time, qsim_qubits, circuit)
     else:
         params = {}
         for p, val in vars(qsim_gate).items():
@@ -323,16 +317,10 @@ def add_op_to_circuit(
                 params[key] = val
             else:
                 raise ValueError("Parameters must be numeric.")
-        if isinstance(circuit, qsim.Circuit):
-            qsim.add_gate(gate_kind, time, qsim_qubits, params, circuit)
-        else:
-            qsim.add_gate_channel(gate_kind, time, qsim_qubits, params, circuit)
+        qsim.add_gate(gate_kind, time, qsim_qubits, params, circuit)
 
     if is_controlled:
-        if isinstance(circuit, qsim.Circuit):
-            qsim.control_last_gate(control_qubits, control_values, circuit)
-        else:
-            qsim.control_last_gate_channel(control_qubits, control_values, circuit)
+        qsim.control_last_gate(control_qubits, control_values, circuit)
 
 
 class QSimCircuit(cirq.Circuit):
@@ -435,13 +423,13 @@ class QSimCircuit(cirq.Circuit):
 
     def translate_cirq_to_qtrajectory(
         self, qubit_order: cirq.QubitOrderOrList = cirq.QubitOrder.DEFAULT
-    ) -> qsim.NoisyCircuit:
+    ) -> qsim.Circuit:
         """Translates this noisy Cirq circuit to the qsim representation.
         :qubit_order: Ordering of qubits
-        :return: a tuple of (C++ qsim NoisyCircuit object, moment boundary
+        :return: a tuple of (C++ qsim Circuit object, moment boundary
             gate indices)
         """
-        qsim_ncircuit = qsim.NoisyCircuit()
+        qsim_ncircuit = qsim.Circuit()
         ordered_qubits = cirq.QubitOrder.as_qubit_order(qubit_order).order_for(
             self.all_qubits()
         )

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Sequence, Tuple, Union
+from typing import Dict, List, Sequence, Tuple
 
 import cirq
 import numpy as np

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -214,7 +214,7 @@ def test_translate_cirq_to_qtrajectory():
     qsim_circuit = qsimcirq.QSimCircuit(circuit)
     qsim_ncircuit, moment_indices = qsim_circuit.translate_cirq_to_qtrajectory()
 
-    assert isinstance(qsim_ncircuit, qsimcirq.qsim.NoisyCircuit)
+    assert isinstance(qsim_ncircuit, qsimcirq.qsim.Circuit)
     assert qsim_ncircuit.num_qubits == 2
     # The circuit has 3 moments, and 4 gates are translated in total.
     assert moment_indices == [1, 2, 4]
@@ -226,7 +226,7 @@ def test_translate_cirq_to_qtrajectory():
         qsim_circuit_empty.translate_cirq_to_qtrajectory()
     )
 
-    assert isinstance(qsim_ncircuit_empty, qsimcirq.qsim.NoisyCircuit)
+    assert isinstance(qsim_ncircuit_empty, qsimcirq.qsim.Circuit)
     assert qsim_ncircuit_empty.num_qubits == 0
     assert moment_indices_empty == []
 
@@ -237,7 +237,7 @@ def test_translate_cirq_to_qtrajectory():
         qsim_circuit_unitary.translate_cirq_to_qtrajectory()
     )
 
-    assert isinstance(qsim_ncircuit_unitary, qsimcirq.qsim.NoisyCircuit)
+    assert isinstance(qsim_ncircuit_unitary, qsimcirq.qsim.Circuit)
     assert qsim_ncircuit_unitary.num_qubits == 2
     assert moment_indices_unitary == [2]
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -82,10 +82,12 @@ cc_test(
     deps = [
         "//lib:channels_cirq",
         "//lib:circuit",
+        "//lib:circuit_noisy",
         "//lib:formux",
         "//lib:fuser_mqubit",
         "//lib:gates_cirq",
         "//lib:io",
+        "//lib:operation",
         "//lib:qtrajectory",
         "//lib:run_qsim",
         "//lib:simulator",
@@ -103,7 +105,9 @@ cc_test(
     }),
     deps = [
         "//lib:circuit_qsim_parser",
-        "//lib:gates_qsim",
+        "//lib:gate",
+        "//lib:operation",
+        "//lib:operation_base",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -128,6 +132,18 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "fuser_testfixture",
+    testonly = 1,
+    hdrs = ["fuser_testfixture.h"],
+    deps = [
+        "//lib:gate",
+        "//lib:operation",
+        "//lib:operation_base",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_test(
     name = "fuser_basic_test",
     size = "small",
@@ -137,9 +153,12 @@ cc_test(
         "//conditions:default": [],
     }),
     deps = [
+        ":fuser_testfixture",
         "//lib:circuit_qsim_parser",
         "//lib:fuser_basic",
-        "//lib:gates_qsim",
+        "//lib:gate",
+        "//lib:operation",
+        "//lib:operation_base",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -153,11 +172,15 @@ cc_test(
         "//conditions:default": [],
     }),
     deps = [
+        ":fuser_testfixture",
         "//lib:formux",
+        "//lib:fuser",
         "//lib:fuser_mqubit",
         "//lib:gate",
         "//lib:gate_appl",
         "//lib:matrix",
+        "//lib:operation",
+        "//lib:operation_base",
         "//lib:simulator",
         "@com_google_googletest//:gtest_main",
     ],
@@ -170,6 +193,7 @@ cc_library(
     deps = [
         "//lib:circuit",
         "//lib:gates_cirq",
+        "//lib:operation",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -183,6 +207,7 @@ cc_test(
         "//conditions:default": [],
     }),
     deps = [
+        "//lib:gate",
         "//lib:gates_qsim",
         "@com_google_googletest//:gtest_main",
     ],
@@ -200,9 +225,9 @@ cc_library(
         "//lib:circuit_qsim_parser",
         "//lib:formux",
         "//lib:fuser_basic",
-        "//lib:gates_qsim",
         "//lib:hybrid",
         "//lib:io",
+        "//lib:operation",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -238,6 +263,22 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "operation_test",
+    size = "small",
+    srcs = ["operation_test.cc"],
+    copts = select({
+        ":windows": windows_copts,
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//lib:gate",
+        "//lib:operation",
+        "//lib:operation_base",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "qtrajectory_testfixture",
     testonly = 1,
@@ -249,12 +290,16 @@ cc_library(
     deps = [
         "//lib:channel",
         "//lib:channels_cirq",
+        "//lib:circuit",
         "//lib:circuit_noisy",
         "//lib:expect",
         "//lib:fuser_mqubit",
+        "//lib:gate",
         "//lib:gate_appl",
         "//lib:gates_cirq",
         "//lib:io",
+        "//lib:operation",
+        "//lib:operation_base",
         "//lib:qtrajectory",
         "@com_google_googletest//:gtest_main",
     ],
@@ -291,7 +336,13 @@ cc_test(
     }),
     deps = [
         ":gates_cirq_testfixture",
-        "//lib:run_qsim_lib",
+        "//lib:circuit_qsim_parser",
+        "//lib:formux",
+        "//lib:fuser_basic",
+        "//lib:io",
+        "//lib:operation",
+        "//lib:run_qsim",
+        "//lib:simulator",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -306,7 +357,13 @@ cc_test(
     }),
     deps = [
         ":gates_cirq_testfixture",
-        "//lib:run_qsimh_lib",
+        "//lib:circuit_qsim_parser",
+        "//lib:formux",
+        "//lib:fuser_basic",
+        "//lib:io",
+        "//lib:operation",
+        "//lib:run_qsimh",
+        "//lib:simulator_basic",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -321,10 +378,12 @@ cc_library(
     }),
     deps = [
         "//lib:expect",
+        "//lib:fuser",
         "//lib:fuser_mqubit",
         "//lib:gate_appl",
         "//lib:gates_qsim",
         "//lib:io",
+        "//lib:operation",
         "//lib:util_cpu",
         "@com_google_googletest//:gtest_main",
     ],
@@ -414,6 +473,7 @@ cc_library(
         "//lib:fuser_basic",
         "//lib:gates_qsim",
         "//lib:io",
+        "//lib:operation",
         "//lib:run_qsim",
         "@com_google_googletest//:gtest_main",
     ],
@@ -584,6 +644,7 @@ cc_library(
     }),
     deps = [
         "//lib:fuser",
+        "//lib:gate",
         "//lib:gate_appl",
         "//lib:gates_cirq",
         "@com_google_googletest//:gtest_main",
@@ -701,9 +762,10 @@ cc_test(
     }),
     deps = [
         "//lib:formux",
+        "//lib:fuser",
+        "//lib:gate",
         "//lib:gate_appl",
         "//lib:gates_cirq",
-        "//lib:gates_qsim",
         "//lib:mps_simulator",
         "@com_google_googletest//:gtest_main",
     ],

--- a/tests/channel_test.cc
+++ b/tests/channel_test.cc
@@ -82,142 +82,111 @@ void TestNonUnitaryKrausOparator(const KrausOperator& kop,
 
 TEST(ChannelTest, UnitaryKdKMatrix) {
   using fp_type = Simulator<For>::fp_type;
-  using Gate = Cirq::GateCirq<fp_type>;
 
-  auto normal = KrausOperator<Gate>::kNormal;
-
-  Channel<Gate> channel = {
+  Channel<fp_type> channel = {
+    {kChannel, 0, {0, 1, 2, 3, 4, 5, 6, 7}},
     {
-      normal, 1, 0.2, {
-                        Cirq::FSimGate<fp_type>::Create(0, 3, 4, 0.1, 1.4),
-                      }
-    },
-    {
-      normal, 1, 0.2, {
-                        Cirq::rx<fp_type>::Create(0, 0, 0.1),
-                        Cirq::ry<fp_type>::Create(0, 1, 0.2),
-                        Cirq::FSimGate<fp_type>::Create(1, 0, 1, 0.2, 1.3),
-                      }
-    },
-    {
-      normal, 1, 0.2, {
-                        Cirq::rz<fp_type>::Create(0, 3, 0.3),
-                        Cirq::rx<fp_type>::Create(0, 1, 0.4),
-                        Cirq::ry<fp_type>::Create(0, 4, 0.5),
-                        Cirq::rz<fp_type>::Create(0, 0, 0.6),
-                      }
-    },
-    {
-      normal, 1, 0.2, {
-                        Cirq::rx<fp_type>::Create(0, 4, 0.7),
-                        Cirq::ry<fp_type>::Create(0, 3, 0.8),
-                        Cirq::rz<fp_type>::Create(0, 1, 0.9),
-                        Cirq::rx<fp_type>::Create(0, 0, 1.0),
-                        Cirq::FSimGate<fp_type>::Create(1, 1, 3, 0.3, 1.2),
-                        Cirq::FSimGate<fp_type>::Create(1, 0, 4, 0.4, 1.1),
-                      }
-    },
-    {
-      normal, 1, 0.2, {
-                        Cirq::ry<fp_type>::Create(0, 7, 1.1),
-                        Cirq::rz<fp_type>::Create(0, 5, 1.2),
-                        Cirq::rx<fp_type>::Create(0, 1, 1.3),
-                        Cirq::ry<fp_type>::Create(0, 3, 1.4),
-                        Cirq::rz<fp_type>::Create(0, 2, 1.5),
-                        Cirq::rx<fp_type>::Create(0, 4, 1.6),
-                        Cirq::FSimGate<fp_type>::Create(1, 4, 5, 0.5, 1.0),
-                        Cirq::FSimGate<fp_type>::Create(1, 1, 3, 0.6, 0.9),
-                        Cirq::FSimGate<fp_type>::Create(1, 2, 7, 0.7, 0.8),
-                      }
-    },
+      {true, 0.2, {Cirq::FSimGate<fp_type>::Create(0, 3, 4, 0.1, 1.4)}},
+      {true, 0.2, {Cirq::rx<fp_type>::Create(0, 0, 0.1),
+                   Cirq::ry<fp_type>::Create(0, 1, 0.2),
+                   Cirq::FSimGate<fp_type>::Create(1, 0, 1, 0.2, 1.3)}},
+      {true, 0.2, {Cirq::rz<fp_type>::Create(0, 3, 0.3),
+                   Cirq::rx<fp_type>::Create(0, 1, 0.4),
+                   Cirq::ry<fp_type>::Create(0, 4, 0.5),
+                   Cirq::rz<fp_type>::Create(0, 0, 0.6)}},
+      {true, 0.2, {Cirq::rx<fp_type>::Create(0, 4, 0.7),
+                   Cirq::ry<fp_type>::Create(0, 3, 0.8),
+                   Cirq::rz<fp_type>::Create(0, 1, 0.9),
+                   Cirq::rx<fp_type>::Create(0, 0, 1.0),
+                   Cirq::FSimGate<fp_type>::Create(1, 1, 3, 0.3, 1.2),
+                   Cirq::FSimGate<fp_type>::Create(1, 0, 4, 0.4, 1.1)}},
+      {true, 0.2, {Cirq::ry<fp_type>::Create(0, 7, 1.1),
+                   Cirq::rz<fp_type>::Create(0, 5, 1.2),
+                   Cirq::rx<fp_type>::Create(0, 1, 1.3),
+                   Cirq::ry<fp_type>::Create(0, 3, 1.4),
+                   Cirq::rz<fp_type>::Create(0, 2, 1.5),
+                   Cirq::rx<fp_type>::Create(0, 4, 1.6),
+                   Cirq::FSimGate<fp_type>::Create(1, 4, 5, 0.5, 1.0),
+                   Cirq::FSimGate<fp_type>::Create(1, 1, 3, 0.6, 0.9),
+                   Cirq::FSimGate<fp_type>::Create(1, 2, 7, 0.7, 0.8)}},
+    }
   };
 
-  channel[0].CalculateKdKMatrix();
-  ASSERT_EQ(channel[0].kd_k.size(), 32);
-  ASSERT_EQ(channel[0].qubits.size(), 2);
-  EXPECT_EQ(channel[0].qubits[0], 3);
-  EXPECT_EQ(channel[0].qubits[1], 4);
-  TestUnitaryKrausOparator(channel[0]);
+  channel.kops[0].CalculateKdKMatrix();
+  ASSERT_EQ(channel.kops[0].kd_k.size(), 32);
+  ASSERT_EQ(channel.kops[0].qubits.size(), 2);
+  EXPECT_EQ(channel.kops[0].qubits[0], 3);
+  EXPECT_EQ(channel.kops[0].qubits[1], 4);
+  TestUnitaryKrausOparator(channel.kops[0]);
 
-  channel[1].CalculateKdKMatrix();
-  ASSERT_EQ(channel[1].kd_k.size(), 32);
-  ASSERT_EQ(channel[1].qubits.size(), 2);
-  EXPECT_EQ(channel[1].qubits[0], 0);
-  EXPECT_EQ(channel[1].qubits[1], 1);
-  TestUnitaryKrausOparator(channel[1]);
+  channel.kops[1].CalculateKdKMatrix();
+  ASSERT_EQ(channel.kops[1].kd_k.size(), 32);
+  ASSERT_EQ(channel.kops[1].qubits.size(), 2);
+  EXPECT_EQ(channel.kops[1].qubits[0], 0);
+  EXPECT_EQ(channel.kops[1].qubits[1], 1);
+  TestUnitaryKrausOparator(channel.kops[1]);
 
-  channel[2].CalculateKdKMatrix();
-  ASSERT_EQ(channel[2].kd_k.size(), 512);
-  ASSERT_EQ(channel[2].qubits.size(), 4);
-  EXPECT_EQ(channel[2].qubits[0], 0);
-  EXPECT_EQ(channel[2].qubits[1], 1);
-  EXPECT_EQ(channel[2].qubits[2], 3);
-  EXPECT_EQ(channel[2].qubits[3], 4);
-  TestUnitaryKrausOparator(channel[2]);
+  channel.kops[2].CalculateKdKMatrix();
+  ASSERT_EQ(channel.kops[2].kd_k.size(), 512);
+  ASSERT_EQ(channel.kops[2].qubits.size(), 4);
+  EXPECT_EQ(channel.kops[2].qubits[0], 0);
+  EXPECT_EQ(channel.kops[2].qubits[1], 1);
+  EXPECT_EQ(channel.kops[2].qubits[2], 3);
+  EXPECT_EQ(channel.kops[2].qubits[3], 4);
+  TestUnitaryKrausOparator(channel.kops[2]);
 
-  channel[3].CalculateKdKMatrix();
-  ASSERT_EQ(channel[3].kd_k.size(), 512);
-  ASSERT_EQ(channel[3].qubits.size(), 4);
-  EXPECT_EQ(channel[3].qubits[0], 0);
-  EXPECT_EQ(channel[3].qubits[1], 1);
-  EXPECT_EQ(channel[3].qubits[2], 3);
-  EXPECT_EQ(channel[3].qubits[3], 4);
-  TestUnitaryKrausOparator(channel[3]);
+  channel.kops[3].CalculateKdKMatrix();
+  ASSERT_EQ(channel.kops[3].kd_k.size(), 512);
+  ASSERT_EQ(channel.kops[3].qubits.size(), 4);
+  EXPECT_EQ(channel.kops[3].qubits[0], 0);
+  EXPECT_EQ(channel.kops[3].qubits[1], 1);
+  EXPECT_EQ(channel.kops[3].qubits[2], 3);
+  EXPECT_EQ(channel.kops[3].qubits[3], 4);
+  TestUnitaryKrausOparator(channel.kops[3]);
 
-  channel[4].CalculateKdKMatrix();
-  ASSERT_EQ(channel[4].kd_k.size(), 8192);
-  ASSERT_EQ(channel[4].qubits.size(), 6);
-  EXPECT_EQ(channel[4].qubits[0], 1);
-  EXPECT_EQ(channel[4].qubits[1], 2);
-  EXPECT_EQ(channel[4].qubits[2], 3);
-  EXPECT_EQ(channel[4].qubits[3], 4);
-  EXPECT_EQ(channel[4].qubits[4], 5);
-  EXPECT_EQ(channel[4].qubits[5], 7);
-  TestUnitaryKrausOparator(channel[4]);
+  channel.kops[4].CalculateKdKMatrix();
+  ASSERT_EQ(channel.kops[4].kd_k.size(), 8192);
+  ASSERT_EQ(channel.kops[4].qubits.size(), 6);
+  EXPECT_EQ(channel.kops[4].qubits[0], 1);
+  EXPECT_EQ(channel.kops[4].qubits[1], 2);
+  EXPECT_EQ(channel.kops[4].qubits[2], 3);
+  EXPECT_EQ(channel.kops[4].qubits[3], 4);
+  EXPECT_EQ(channel.kops[4].qubits[4], 5);
+  EXPECT_EQ(channel.kops[4].qubits[5], 7);
+  TestUnitaryKrausOparator(channel.kops[4]);
 }
 
 TEST(ChannelTest, NonUnitaryKdKMatrix) {
   using StateSpace = Simulator<For>::StateSpace;
   using State = StateSpace::State;
   using fp_type = StateSpace::fp_type;
-  using Gate = Cirq::GateCirq<fp_type>;
   using M1 = Cirq::MatrixGate1<fp_type>;
   using M2 = Cirq::MatrixGate2<fp_type>;
 
-  unsigned  num_qubits = 8;
-  auto normal = KrausOperator<Gate>::kNormal;
+  unsigned num_qubits = 8;
 
-  Channel<Gate> channel = {
+  Channel<fp_type> channel = {
+    {kChannel, 0, {0, 1, 3, 4}},
     {
-      normal, 0, 0, {
-                      M1::Create(0, 0,
-                                 {0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4}),
-                      M1::Create(0, 1,
-                                 {0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1}),
-                      M2::Create(0, 0, 1,
-                                 {0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4,
-                                  0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1,
-                                  0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2,
-                                  0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3}),
-                    }
-    },
-    {
-      normal, 0, 0, {
-                      M1::Create(0, 4,
-                                 {0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4}),
-                      M1::Create(0, 3,
-                                 {0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1}),
-                      M1::Create(0, 1,
-                                 {0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2}),
-                      M1::Create(0, 0,
-                                 {0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3}),
-                      M2::Create(0, 0, 4,
-                                 {0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4,
-                                  0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1,
-                                  0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2,
-                                  0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3}),
-                    }
-    },
+      {false, 0, {M1::Create(0, 0, {0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4}),
+                  M1::Create(0, 1, {0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1}),
+                  M2::Create(0, 0, 1, {0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4,
+                                       0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1,
+                                       0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2,
+                                       0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3})
+                 }
+      },
+      {false, 0, {M1::Create(0, 4, {0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4}),
+                  M1::Create(0, 3, {0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1}),
+                  M1::Create(0, 1, {0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2}),
+                  M1::Create(0, 0, {0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3}),
+                  M2::Create(0, 0, 4, {0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4,
+                                       0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1,
+                                       0.3, 0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2,
+                                       0.4, 0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3})
+                 }
+      },
+    }
   };
 
   StateSpace state_space(1);
@@ -229,23 +198,23 @@ TEST(ChannelTest, NonUnitaryKdKMatrix) {
   State state1 = state_space.Create(num_qubits);
   ASSERT_FALSE(state_space.IsNull(state1));
 
-  channel[0].CalculateKdKMatrix();
-  ASSERT_EQ(channel[0].kd_k.size(), 32);
-  ASSERT_EQ(channel[0].qubits.size(), 2);
-  EXPECT_EQ(channel[0].qubits[0], 0);
-  EXPECT_EQ(channel[0].qubits[1], 1);
+  channel.kops[0].CalculateKdKMatrix();
+  ASSERT_EQ(channel.kops[0].kd_k.size(), 32);
+  ASSERT_EQ(channel.kops[0].qubits.size(), 2);
+  EXPECT_EQ(channel.kops[0].qubits[0], 0);
+  EXPECT_EQ(channel.kops[0].qubits[1], 1);
   TestNonUnitaryKrausOparator(
-      channel[0], state_space, simulator, state0, state1);
+      channel.kops[0], state_space, simulator, state0, state1);
 
-  channel[1].CalculateKdKMatrix();
-  ASSERT_EQ(channel[1].kd_k.size(), 512);
-  ASSERT_EQ(channel[1].qubits.size(), 4);
-  EXPECT_EQ(channel[1].qubits[0], 0);
-  EXPECT_EQ(channel[1].qubits[1], 1);
-  EXPECT_EQ(channel[1].qubits[2], 3);
-  EXPECT_EQ(channel[1].qubits[3], 4);
+  channel.kops[1].CalculateKdKMatrix();
+  ASSERT_EQ(channel.kops[1].kd_k.size(), 512);
+  ASSERT_EQ(channel.kops[1].qubits.size(), 4);
+  EXPECT_EQ(channel.kops[1].qubits[0], 0);
+  EXPECT_EQ(channel.kops[1].qubits[1], 1);
+  EXPECT_EQ(channel.kops[1].qubits[2], 3);
+  EXPECT_EQ(channel.kops[1].qubits[3], 4);
   TestNonUnitaryKrausOparator(
-      channel[1], state_space, simulator, state0, state1);
+      channel.kops[1], state_space, simulator, state0, state1);
 }
 
 }  // namespace qsim

--- a/tests/channels_cirq_test.cc
+++ b/tests/channels_cirq_test.cc
@@ -20,10 +20,12 @@
 
 #include "../lib/channels_cirq.h"
 #include "../lib/circuit.h"
+#include "../lib/circuit_noisy.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_mqubit.h"
 #include "../lib/gates_cirq.h"
 #include "../lib/io.h"
+#include "../lib/operation.h"
 #include "../lib/qtrajectory.h"
 #include "../lib/run_qsim.h"
 #include "../lib/simmux.h"
@@ -52,11 +54,12 @@ using StateSpace = Simulator::StateSpace;
 using State = StateSpace::State;
 using fp_type = StateSpace::fp_type;
 using Gate = Cirq::GateCirq<fp_type>;
-using Fuser = MultiQubitGateFuser<IO, const Gate*>;
+using Operation = Operation<fp_type>;
+using Fuser = MultiQubitGateFuser<IO>;
 using Runner = QSimRunner<IO, Fuser, Factory<For>>;
-using QTSimulator = QuantumTrajectorySimulator<IO, Gate, Runner>;
+using QTSimulator = QuantumTrajectorySimulator<IO, Runner>;
 
-Circuit<Gate> CleanCircuit() {
+Circuit<Operation> CleanCircuit() {
   using Hd = Cirq::H<fp_type>;
   using IS = Cirq::ISWAP<fp_type>;
   using Rx = Cirq::rx<fp_type>;
@@ -74,12 +77,12 @@ Circuit<Gate> CleanCircuit() {
       Ry::Create(4, 0, 0.4),
       Rx::Create(4, 1, 0.7),
       IS::Create(5, 0, 1),
-      gate::Measurement<Gate>::Create(6, {0, 1}),
+      CreateMeasurement(6, {0, 1}),
     },
   };
 }
 
-void RunBatch(const NoisyCircuit<Gate>& ncircuit,
+void RunBatch(const Circuit<Operation>& ncircuit,
               const std::vector<double>& expected_results,
               unsigned num_reps = 25000) {
   unsigned num_qubits = 2;
@@ -109,23 +112,25 @@ void RunBatch(const NoisyCircuit<Gate>& ncircuit,
 }
 
 template <typename ChannelFactory>
-inline NoisyCircuit<Gate> MakeNoisy2(
-    const std::vector<Gate>& gates, const ChannelFactory& channel_factory) {
-  NoisyCircuit<Gate> ncircuit;
+inline Circuit<Operation> MakeNoisy2(
+    const std::vector<Operation>& ops, const ChannelFactory& channel_factory) {
+  Circuit<Operation> ncircuit;
 
   ncircuit.num_qubits = 2;
-  ncircuit.channels.reserve(2 * gates.size());
+  ncircuit.ops.reserve(2 * ops.size());
 
   unsigned prev_time = 0;
 
-  for (const auto& gate : gates) {
-    if (gate.time > prev_time) {
-      ncircuit.channels.push_back(
-          channel_factory.Create(2 * prev_time + 1, {0, 1}));
-      prev_time = gate.time;
+  for (const auto& op : ops) {
+    unsigned time = OpTime(op);
+
+    if (time > prev_time) {
+      ncircuit.ops.push_back(channel_factory.Create(2 * prev_time + 1, {0, 1}));
+      prev_time = time;
     }
 
-    ncircuit.channels.push_back(MakeChannelFromGate(2 * gate.time, gate));
+    ncircuit.ops.push_back(op);
+    OpBaseOperation(ncircuit.ops.back()).time *= 2;
   }
 
   return ncircuit;
@@ -188,7 +193,7 @@ for key, val in sorted(res.histogram(key='m').items()):
   auto ncircuit = MakeNoisy(circuit, channel);
   RunBatch(ncircuit, expected_results);
 
-  auto ncircuit2 = MakeNoisy2(circuit.gates, channel);
+  auto ncircuit2 = MakeNoisy2(circuit.ops, channel);
   RunBatch(ncircuit2, expected_results);
 }
 
@@ -234,7 +239,7 @@ for key, val in sorted(res.histogram(key='m').items()):
   auto ncircuit = MakeNoisy(circuit, channel);
   RunBatch(ncircuit, expected_results);
 
-  auto ncircuit2 = MakeNoisy2(circuit.gates, channel);
+  auto ncircuit2 = MakeNoisy2(circuit.ops, channel);
   RunBatch(ncircuit2, expected_results);
 }
 

--- a/tests/circuit_qsim_parser_test.cc
+++ b/tests/circuit_qsim_parser_test.cc
@@ -17,7 +17,9 @@
 #include "gtest/gtest.h"
 
 #include "../lib/circuit_qsim_parser.h"
-#include "../lib/gates_qsim.h"
+#include "../lib/gate.h"
+#include "../lib/operation.h"
+#include "../lib/operation_base.h"
 
 namespace qsim {
 
@@ -57,18 +59,18 @@ R"(2
 15 p 0.3
 )";
 
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
   std::stringstream ss1(valid_circuit);
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss1, circuit));
   EXPECT_EQ(circuit.num_qubits, 2);
-  EXPECT_EQ(circuit.gates.size(), 22);
+  EXPECT_EQ(circuit.ops.size(), 22);
 
   std::stringstream ss2(valid_circuit);
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(4, provider, ss2, circuit));
   EXPECT_EQ(circuit.num_qubits, 2);
-  EXPECT_EQ(circuit.gates.size(), 10);
+  EXPECT_EQ(circuit.ops.size(), 10);
 }
 
 TEST(CircuitQsimParserTest, ValidCircuitWithControlledGates) {
@@ -79,17 +81,25 @@ R"(5
 2 c 2 4 p 0.5
 )";
 
-  Circuit<GateQSim<float>> circuit;
+  using CG = ControlledGate<float>;
+
+  Circuit<Operation<float>> circuit;
   std::stringstream ss(valid_circuit);
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 5);
-  EXPECT_EQ(circuit.gates.size(), 3);
-  EXPECT_EQ(circuit.gates[0].qubits.size(), 1);
-  EXPECT_EQ(circuit.gates[0].controlled_by.size(), 2);
-  EXPECT_EQ(circuit.gates[1].qubits.size(), 2);
-  EXPECT_EQ(circuit.gates[1].controlled_by.size(), 3);
-  EXPECT_EQ(circuit.gates[2].qubits.size(), 0);
-  EXPECT_EQ(circuit.gates[2].controlled_by.size(), 2);
+  EXPECT_EQ(circuit.ops.size(), 3);
+  const auto* pg0 = OpGetAlternative<CG>(circuit.ops[0]);
+  const auto* pg1 = OpGetAlternative<CG>(circuit.ops[1]);
+  const auto* pg2 = OpGetAlternative<CG>(circuit.ops[2]);
+  ASSERT_NE(pg0, nullptr);
+  ASSERT_NE(pg1, nullptr);
+  ASSERT_NE(pg2, nullptr);
+  EXPECT_EQ(pg0->qubits.size(), 1);
+  EXPECT_EQ(pg0->controlled_by.size(), 2);
+  EXPECT_EQ(pg1->qubits.size(), 2);
+  EXPECT_EQ(pg1->controlled_by.size(), 3);
+  EXPECT_EQ(pg2->qubits.size(), 0);
+  EXPECT_EQ(pg2->controlled_by.size(), 2);
 }
 
 TEST(CircuitQsimParserTest, ValidTimeOrder) {
@@ -111,11 +121,11 @@ R"(4
 9 h 3
 )";
 
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
   std::stringstream ss(valid_circuit);
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 4);
-  EXPECT_EQ(circuit.gates.size(), 14);
+  EXPECT_EQ(circuit.ops.size(), 14);
 }
 
 TEST(CircuitQsimParserTest, InvalidGateName) {
@@ -126,7 +136,7 @@ R"(2
 1 badgate 0)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -139,7 +149,7 @@ R"(2
 1 cz 0 1 )";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -152,7 +162,7 @@ R"(2
 1 cz 0 1)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -165,7 +175,7 @@ R"(2
 1 cz 0 1)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -178,7 +188,7 @@ R"(2
 1 cz 0 1)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -191,7 +201,7 @@ R"(2
 1 cz 1 1)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -204,7 +214,7 @@ R"(2
 1 cz 0 1)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -217,7 +227,7 @@ R"(2
 1 cz 0)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -231,7 +241,7 @@ R"(2
 2 rx 0)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -245,7 +255,7 @@ R"(2
 2 ry 0)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -259,7 +269,7 @@ R"(2
 2 rz 0)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -273,7 +283,7 @@ R"(2
 2 rxy 0 0.7)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -286,7 +296,7 @@ R"(2
 1 fs 0 1 0.5)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -299,7 +309,7 @@ R"(2
 1 cp 0 1)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -315,7 +325,7 @@ R"(2
 1 cz 0 1)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -328,7 +338,7 @@ R"(2
 1 m 0 2)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -341,7 +351,7 @@ R"(2
 1 m 0 i)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -354,7 +364,7 @@ R"(2
 1 m 0 )";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -367,7 +377,7 @@ R"(2
 1 m 0 0)";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -379,7 +389,7 @@ R"(4
 )";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -391,7 +401,7 @@ R"(4
 )";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -403,7 +413,7 @@ R"(4
 )";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -415,7 +425,7 @@ R"(4
 )";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -427,7 +437,7 @@ R"(4
 )";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -441,7 +451,7 @@ R"(4
 )";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -455,7 +465,7 @@ R"(4
 )";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -469,7 +479,7 @@ R"(4
 )";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -484,7 +494,7 @@ R"(4
 )";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }
@@ -499,7 +509,7 @@ R"(4
 )";
 
   std::stringstream ss(invalid_circuit);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_FALSE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
 }

--- a/tests/expect_test.cc
+++ b/tests/expect_test.cc
@@ -31,7 +31,7 @@ TEST(ExpectTest, ExpectationValue) {
   using StateSpace = Simulator<For>::StateSpace;
   using State = StateSpace::State;
   using fp_type = StateSpace::fp_type;
-  using Fuser = MultiQubitGateFuser<IO, GateQSim<fp_type>>;
+  using Fuser = MultiQubitGateFuser<IO>;
 
   unsigned num_qubits = 16;
   unsigned depth = 16;
@@ -97,7 +97,7 @@ TEST(ExpectTest, ExpectationValue) {
   State tmp_state = state_space.Null();
 
   for (unsigned k = 1; k <= 6; ++k) {
-    std::vector<OpString<GateQSim<fp_type>>> strings;
+    std::vector<OpString<fp_type>> strings;
     strings.reserve(num_qubits);
 
     for (unsigned i = 0; i <= num_qubits - k; ++i) {
@@ -139,7 +139,7 @@ TEST(ExpectTest, ExpectationValue) {
   double w_re = 0.7;
   double w_im = 0.3;
 
-  std::vector<OpString<GateQSim<fp_type>>> strings = {{{w_re, w_im}, {}}};
+  std::vector<OpString<fp_type>> strings = {{{w_re, w_im}, {}}};
 
   auto evala = ExpectationValue<IO, Fuser>(param, strings, state_space,
                                            simulator, state, tmp_state);

--- a/tests/fuser_basic_test.cc
+++ b/tests/fuser_basic_test.cc
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <vector>
 #include <sstream>
+#include <vector>
+
+#include "fuser_testfixture.h"
 
 #include "gtest/gtest.h"
 
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/fuser_basic.h"
-#include "../lib/gates_qsim.h"
+#include "../lib/gate.h"
+#include "../lib/operation.h"
+#include "../lib/operation_base.h"
 
 namespace qsim {
 
@@ -62,513 +66,717 @@ R"(4
 )";
 
 TEST(FuserBasicTest, NoTimesToSplitAt) {
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using FusedGate = qsim::FusedGate<float>;
+
   std::stringstream ss(circuit_string1);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 4);
-  EXPECT_EQ(circuit.gates.size(), 27);
+  EXPECT_EQ(circuit.ops.size(), 27);
 
-  using Fuser = BasicGateFuser<IO, GateQSim<float>>;
+  using Fuser = BasicGateFuser<IO>;
   Fuser::Parameter param;
-  auto fused_gates = Fuser::FuseGates(param, circuit.num_qubits, circuit.gates);
+  auto fused_gates = Fuser::FuseGates(param, circuit.num_qubits, circuit.ops);
 
   EXPECT_EQ(fused_gates.size(), 5);
 
-  EXPECT_EQ(fused_gates[0].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].time, 1);
-  EXPECT_EQ(fused_gates[0].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].qubits[1], 1);
-  EXPECT_EQ(fused_gates[0].gates.size(), 6);
-  EXPECT_EQ(fused_gates[0].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[1]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].gates[2]->time, 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[1], 1);
-  EXPECT_EQ(fused_gates[0].gates[3]->kind, kGateT);
-  EXPECT_EQ(fused_gates[0].gates[3]->time, 2);
-  EXPECT_EQ(fused_gates[0].gates[3]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[3]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[4]->kind, kGateY);
-  EXPECT_EQ(fused_gates[0].gates[4]->time, 3);
-  EXPECT_EQ(fused_gates[0].gates[4]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[4]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[5]->kind, kGateX);
-  EXPECT_EQ(fused_gates[0].gates[5]->time, 2);
-  EXPECT_EQ(fused_gates[0].gates[5]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[5]->qubits[0], 1);
+  const auto* fgate0 = OpGetAlternative<FusedGate>(fused_gates[0]);
+  ASSERT_NE(fgate0, nullptr);
+  EXPECT_EQ(fgate0->kind, kGateCZ);
+  EXPECT_EQ(fgate0->time, 1);
+  EXPECT_EQ(fgate0->qubits.size(), 2);
+  EXPECT_EQ(fgate0->qubits[0], 0);
+  EXPECT_EQ(fgate0->qubits[1], 1);
+  EXPECT_EQ(fgate0->gates.size(), 6);
+  const auto* gate00 = OpGetAlternative<Gate>(fgate0->gates[0]);
+  ASSERT_NE(gate00, nullptr);
+  EXPECT_EQ(gate00->kind, kGateHd);
+  EXPECT_EQ(gate00->time, 0);
+  EXPECT_EQ(gate00->qubits.size(), 1);
+  EXPECT_EQ(gate00->qubits[0], 0);
+  const auto* gate01 = OpGetAlternative<Gate>(fgate0->gates[1]);
+  ASSERT_NE(gate01, nullptr);
+  EXPECT_EQ(gate01->kind, kGateHd);
+  EXPECT_EQ(gate01->time, 0);
+  EXPECT_EQ(gate01->qubits.size(), 1);
+  EXPECT_EQ(gate01->qubits[0], 1);
+  const auto* gate02 = OpGetAlternative<Gate>(fgate0->gates[2]);
+  ASSERT_NE(gate02, nullptr);
+  EXPECT_EQ(gate02->kind, kGateCZ);
+  EXPECT_EQ(gate02->time, 1);
+  EXPECT_EQ(gate02->qubits.size(), 2);
+  EXPECT_EQ(gate02->qubits[0], 0);
+  EXPECT_EQ(gate02->qubits[1], 1);
+  const auto* gate03 = OpGetAlternative<Gate>(fgate0->gates[3]);
+  ASSERT_NE(gate03, nullptr);
+  EXPECT_EQ(gate03->kind, kGateT);
+  EXPECT_EQ(gate03->time, 2);
+  EXPECT_EQ(gate03->qubits.size(), 1);
+  EXPECT_EQ(gate03->qubits[0], 0);
+  const auto* gate04 = OpGetAlternative<Gate>(fgate0->gates[4]);
+  ASSERT_NE(gate04, nullptr);
+  EXPECT_EQ(gate04->kind, kGateY);
+  EXPECT_EQ(gate04->time, 3);
+  EXPECT_EQ(gate04->qubits.size(), 1);
+  EXPECT_EQ(gate04->qubits[0], 0);
+  const auto* gate05 = OpGetAlternative<Gate>(fgate0->gates[5]);
+  ASSERT_NE(gate05, nullptr);
+  EXPECT_EQ(gate05->kind, kGateX);
+  EXPECT_EQ(gate05->time, 2);
+  EXPECT_EQ(gate05->qubits.size(), 1);
+  EXPECT_EQ(gate05->qubits[0], 1);
 
-  EXPECT_EQ(fused_gates[1].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[1].time, 1);
-  EXPECT_EQ(fused_gates[1].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[1].qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].qubits[1], 3);
-  EXPECT_EQ(fused_gates[1].gates.size(), 6);
-  EXPECT_EQ(fused_gates[1].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[1]->time, 0);
-  EXPECT_EQ(fused_gates[1].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[1]->qubits[0], 3);
-  EXPECT_EQ(fused_gates[1].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[1].gates[2]->time, 1);
-  EXPECT_EQ(fused_gates[1].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[1].gates[2]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[2]->qubits[1], 3);
-  EXPECT_EQ(fused_gates[1].gates[3]->kind, kGateY);
-  EXPECT_EQ(fused_gates[1].gates[3]->time, 2);
-  EXPECT_EQ(fused_gates[1].gates[3]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[3]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[4]->kind, kGateT);
-  EXPECT_EQ(fused_gates[1].gates[4]->time, 2);
-  EXPECT_EQ(fused_gates[1].gates[4]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[4]->qubits[0], 3);
-  EXPECT_EQ(fused_gates[1].gates[5]->kind, kGateX);
-  EXPECT_EQ(fused_gates[1].gates[5]->time, 3);
-  EXPECT_EQ(fused_gates[1].gates[5]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[5]->qubits[0], 3);
+  const auto* fgate1 = OpGetAlternative<FusedGate>(fused_gates[1]);
+  ASSERT_NE(fgate1, nullptr);
+  EXPECT_EQ(fgate1->kind, kGateCZ);
+  EXPECT_EQ(fgate1->time, 1);
+  EXPECT_EQ(fgate1->qubits.size(), 2);
+  EXPECT_EQ(fgate1->qubits[0], 2);
+  EXPECT_EQ(fgate1->qubits[1], 3);
+  EXPECT_EQ(fgate1->gates.size(), 6);
+  const auto* gate10 = OpGetAlternative<Gate>(fgate1->gates[0]);
+  ASSERT_NE(gate10, nullptr);
+  EXPECT_EQ(gate10->kind, kGateHd);
+  EXPECT_EQ(gate10->time, 0);
+  EXPECT_EQ(gate10->qubits.size(), 1);
+  EXPECT_EQ(gate10->qubits[0], 2);
+  const auto* gate11 = OpGetAlternative<Gate>(fgate1->gates[1]);
+  ASSERT_NE(gate11, nullptr);
+  EXPECT_EQ(gate11->kind, kGateHd);
+  EXPECT_EQ(gate11->time, 0);
+  EXPECT_EQ(gate11->qubits.size(), 1);
+  EXPECT_EQ(gate11->qubits[0], 3);
+  const auto* gate12 = OpGetAlternative<Gate>(fgate1->gates[2]);
+  ASSERT_NE(gate12, nullptr);
+  EXPECT_EQ(gate12->kind, kGateCZ);
+  EXPECT_EQ(gate12->time, 1);
+  EXPECT_EQ(gate12->qubits.size(), 2);
+  EXPECT_EQ(gate12->qubits[0], 2);
+  EXPECT_EQ(gate12->qubits[1], 3);
+  const auto* gate13 = OpGetAlternative<Gate>(fgate1->gates[3]);
+  ASSERT_NE(gate13, nullptr);
+  EXPECT_EQ(gate13->kind, kGateY);
+  EXPECT_EQ(gate13->time, 2);
+  EXPECT_EQ(gate13->qubits.size(), 1);
+  EXPECT_EQ(gate13->qubits[0], 2);
+  const auto* gate14 = OpGetAlternative<Gate>(fgate1->gates[4]);
+  ASSERT_NE(gate14, nullptr);
+  EXPECT_EQ(gate14->kind, kGateT);
+  EXPECT_EQ(gate14->time, 2);
+  EXPECT_EQ(gate14->qubits.size(), 1);
+  EXPECT_EQ(gate14->qubits[0], 3);
+  const auto* gate15 = OpGetAlternative<Gate>(fgate1->gates[5]);
+  ASSERT_NE(gate15, nullptr);
+  EXPECT_EQ(gate15->kind, kGateX);
+  EXPECT_EQ(gate15->time, 3);
+  EXPECT_EQ(gate15->qubits.size(), 1);
+  EXPECT_EQ(gate15->qubits[0], 3);
 
-  EXPECT_EQ(fused_gates[2].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].time, 3);
-  EXPECT_EQ(fused_gates[2].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].qubits[1], 2);
-  EXPECT_EQ(fused_gates[2].gates.size(), 9);
-  EXPECT_EQ(fused_gates[2].gates[0]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].gates[0]->time, 3);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits[1], 2);
-  EXPECT_EQ(fused_gates[2].gates[1]->kind, kGateT);
-  EXPECT_EQ(fused_gates[2].gates[1]->time, 4);
-  EXPECT_EQ(fused_gates[2].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[1]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[2]->kind, kGateT);
-  EXPECT_EQ(fused_gates[2].gates[2]->time, 4);
-  EXPECT_EQ(fused_gates[2].gates[2]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[2]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[2].gates[3]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].gates[3]->time, 5);
-  EXPECT_EQ(fused_gates[2].gates[3]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].gates[3]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[3]->qubits[1], 2);
-  EXPECT_EQ(fused_gates[2].gates[4]->kind, kGateX);
-  EXPECT_EQ(fused_gates[2].gates[4]->time, 6);
-  EXPECT_EQ(fused_gates[2].gates[4]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[4]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[5]->kind, kGateY);
-  EXPECT_EQ(fused_gates[2].gates[5]->time, 6);
-  EXPECT_EQ(fused_gates[2].gates[5]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[5]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[2].gates[6]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].gates[6]->time, 7);
-  EXPECT_EQ(fused_gates[2].gates[6]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].gates[6]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[6]->qubits[1], 2);
-  EXPECT_EQ(fused_gates[2].gates[7]->kind, kGateT);
-  EXPECT_EQ(fused_gates[2].gates[7]->time, 8);
-  EXPECT_EQ(fused_gates[2].gates[7]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[7]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[8]->kind, kGateT);
-  EXPECT_EQ(fused_gates[2].gates[8]->time, 8);
-  EXPECT_EQ(fused_gates[2].gates[8]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[8]->qubits[0], 2);
+  const auto* fgate2 = OpGetAlternative<FusedGate>(fused_gates[2]);
+  ASSERT_NE(fgate2, nullptr);
+  EXPECT_EQ(fgate2->kind, kGateCZ);
+  EXPECT_EQ(fgate2->time, 3);
+  EXPECT_EQ(fgate2->qubits.size(), 2);
+  EXPECT_EQ(fgate2->qubits[0], 1);
+  EXPECT_EQ(fgate2->qubits[1], 2);
+  EXPECT_EQ(fgate2->gates.size(), 9);
+  const auto* gate20 = OpGetAlternative<Gate>(fgate2->gates[0]);
+  ASSERT_NE(gate20, nullptr);
+  EXPECT_EQ(gate20->kind, kGateCZ);
+  EXPECT_EQ(gate20->time, 3);
+  EXPECT_EQ(gate20->qubits.size(), 2);
+  EXPECT_EQ(gate20->qubits[0], 1);
+  EXPECT_EQ(gate20->qubits[1], 2);
+  const auto* gate21 = OpGetAlternative<Gate>(fgate2->gates[1]);
+  ASSERT_NE(gate21, nullptr);
+  EXPECT_EQ(gate21->kind, kGateT);
+  EXPECT_EQ(gate21->time, 4);
+  EXPECT_EQ(gate21->qubits.size(), 1);
+  EXPECT_EQ(gate21->qubits[0], 1);
+  const auto* gate22 = OpGetAlternative<Gate>(fgate2->gates[2]);
+  ASSERT_NE(gate22, nullptr);
+  EXPECT_EQ(gate22->kind, kGateT);
+  EXPECT_EQ(gate22->time, 4);
+  EXPECT_EQ(gate22->qubits.size(), 1);
+  EXPECT_EQ(gate22->qubits[0], 2);
+  const auto* gate23 = OpGetAlternative<Gate>(fgate2->gates[3]);
+  ASSERT_NE(gate23, nullptr);
+  EXPECT_EQ(gate23->kind, kGateCZ);
+  EXPECT_EQ(gate23->time, 5);
+  EXPECT_EQ(gate23->qubits.size(), 2);
+  EXPECT_EQ(gate23->qubits[0], 1);
+  EXPECT_EQ(gate23->qubits[1], 2);
+  const auto* gate24 = OpGetAlternative<Gate>(fgate2->gates[4]);
+  ASSERT_NE(gate24, nullptr);
+  EXPECT_EQ(gate24->kind, kGateX);
+  EXPECT_EQ(gate24->time, 6);
+  EXPECT_EQ(gate24->qubits.size(), 1);
+  EXPECT_EQ(gate24->qubits[0], 1);
+  const auto* gate25 = OpGetAlternative<Gate>(fgate2->gates[5]);
+  ASSERT_NE(gate25, nullptr);
+  EXPECT_EQ(gate25->kind, kGateY);
+  EXPECT_EQ(gate25->time, 6);
+  EXPECT_EQ(gate25->qubits.size(), 1);
+  EXPECT_EQ(gate25->qubits[0], 2);
+  const auto* gate26 = OpGetAlternative<Gate>(fgate2->gates[6]);
+  ASSERT_NE(gate26, nullptr);
+  EXPECT_EQ(gate26->kind, kGateCZ);
+  EXPECT_EQ(gate26->time, 7);
+  EXPECT_EQ(gate26->qubits.size(), 2);
+  EXPECT_EQ(gate26->qubits[0], 1);
+  EXPECT_EQ(gate26->qubits[1], 2);
+  const auto* gate27 = OpGetAlternative<Gate>(fgate2->gates[7]);
+  ASSERT_NE(gate27, nullptr);
+  EXPECT_EQ(gate27->kind, kGateT);
+  EXPECT_EQ(gate27->time, 8);
+  EXPECT_EQ(gate27->qubits.size(), 1);
+  EXPECT_EQ(gate27->qubits[0], 1);
+  const auto* gate28 = OpGetAlternative<Gate>(fgate2->gates[8]);
+  ASSERT_NE(gate28, nullptr);
+  EXPECT_EQ(gate28->kind, kGateT);
+  EXPECT_EQ(gate28->time, 8);
+  EXPECT_EQ(gate28->qubits.size(), 1);
+  EXPECT_EQ(gate28->qubits[0], 2);
 
-  EXPECT_EQ(fused_gates[3].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[3].time, 9);
-  EXPECT_EQ(fused_gates[3].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[3].qubits[0], 0);
-  EXPECT_EQ(fused_gates[3].qubits[1], 1);
-  EXPECT_EQ(fused_gates[3].gates.size(), 3);
-  EXPECT_EQ(fused_gates[3].gates[0]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[3].gates[0]->time, 9);
-  EXPECT_EQ(fused_gates[3].gates[0]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[3].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[3].gates[0]->qubits[1], 1);
-  EXPECT_EQ(fused_gates[3].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[3].gates[1]->time, 10);
-  EXPECT_EQ(fused_gates[3].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[1]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[3].gates[2]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[3].gates[2]->time, 10);
-  EXPECT_EQ(fused_gates[3].gates[2]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[2]->qubits[0], 1);
+  const auto* fgate3 = OpGetAlternative<FusedGate>(fused_gates[3]);
+  ASSERT_NE(fgate3, nullptr);
+  EXPECT_EQ(fgate3->kind, kGateCZ);
+  EXPECT_EQ(fgate3->time, 9);
+  EXPECT_EQ(fgate3->qubits.size(), 2);
+  EXPECT_EQ(fgate3->qubits[0], 0);
+  EXPECT_EQ(fgate3->qubits[1], 1);
+  EXPECT_EQ(fgate3->gates.size(), 3);
+  const auto* gate30 = OpGetAlternative<Gate>(fgate3->gates[0]);
+  ASSERT_NE(gate30, nullptr);
+  EXPECT_EQ(gate30->kind, kGateCZ);
+  EXPECT_EQ(gate30->time, 9);
+  EXPECT_EQ(gate30->qubits.size(), 2);
+  EXPECT_EQ(gate30->qubits[0], 0);
+  EXPECT_EQ(gate30->qubits[1], 1);
+  const auto* gate31 = OpGetAlternative<Gate>(fgate3->gates[1]);
+  ASSERT_NE(gate31, nullptr);
+  EXPECT_EQ(gate31->kind, kGateHd);
+  EXPECT_EQ(gate31->time, 10);
+  EXPECT_EQ(gate31->qubits.size(), 1);
+  EXPECT_EQ(gate31->qubits[0], 0);
+  const auto* gate32 = OpGetAlternative<Gate>(fgate3->gates[2]);
+  ASSERT_NE(gate32, nullptr);
+  EXPECT_EQ(gate32->kind, kGateHd);
+  EXPECT_EQ(gate32->time, 10);
+  EXPECT_EQ(gate32->qubits.size(), 1);
+  EXPECT_EQ(gate32->qubits[0], 1);
 
-  EXPECT_EQ(fused_gates[4].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[4].time, 9);
-  EXPECT_EQ(fused_gates[4].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[4].qubits[0], 2);
-  EXPECT_EQ(fused_gates[4].qubits[1], 3);
-  EXPECT_EQ(fused_gates[4].gates.size(), 3);
-  EXPECT_EQ(fused_gates[4].gates[0]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[4].gates[0]->time, 9);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits[1], 3);
-  EXPECT_EQ(fused_gates[4].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[4].gates[1]->time, 10);
-  EXPECT_EQ(fused_gates[4].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[4].gates[1]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[4].gates[2]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[4].gates[2]->time, 10);
-  EXPECT_EQ(fused_gates[4].gates[2]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[4].gates[2]->qubits[0], 3);
+  const auto* fgate4 = OpGetAlternative<FusedGate>(fused_gates[4]);
+  ASSERT_NE(fgate4, nullptr);
+  EXPECT_EQ(fgate4->kind, kGateCZ);
+  EXPECT_EQ(fgate4->time, 9);
+  EXPECT_EQ(fgate4->qubits.size(), 2);
+  EXPECT_EQ(fgate4->qubits[0], 2);
+  EXPECT_EQ(fgate4->qubits[1], 3);
+  EXPECT_EQ(fgate4->gates.size(), 3);
+  const auto* gate40 = OpGetAlternative<Gate>(fgate4->gates[0]);
+  ASSERT_NE(gate40, nullptr);
+  EXPECT_EQ(gate40->kind, kGateCZ);
+  EXPECT_EQ(gate40->time, 9);
+  EXPECT_EQ(gate40->qubits.size(), 2);
+  EXPECT_EQ(gate40->qubits[0], 2);
+  EXPECT_EQ(gate40->qubits[1], 3);
+  const auto* gate41 = OpGetAlternative<Gate>(fgate4->gates[1]);
+  ASSERT_NE(gate41, nullptr);
+  EXPECT_EQ(gate41->kind, kGateHd);
+  EXPECT_EQ(gate41->time, 10);
+  EXPECT_EQ(gate41->qubits.size(), 1);
+  EXPECT_EQ(gate41->qubits[0], 2);
+  const auto* gate42 = OpGetAlternative<Gate>(fgate4->gates[2]);
+  ASSERT_NE(gate42, nullptr);
+  EXPECT_EQ(gate42->kind, kGateHd);
+  EXPECT_EQ(gate42->time, 10);
+  EXPECT_EQ(gate42->qubits.size(), 1);
+  EXPECT_EQ(gate42->qubits[0], 3);
 }
 
-
 TEST(FuserBasicTest, TimesToSplitAt1) {
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using FusedGate = qsim::FusedGate<float>;
+
   std::stringstream ss(circuit_string1);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 4);
-  EXPECT_EQ(circuit.gates.size(), 27);
+  EXPECT_EQ(circuit.ops.size(), 27);
 
   std::vector<unsigned> times_to_split_at{3, 8, 10};
 
-  using Fuser = BasicGateFuser<IO, GateQSim<float>>;
+  using Fuser = BasicGateFuser<IO>;
   Fuser::Parameter param;
   auto fused_gates = Fuser::FuseGates(
-      param, circuit.num_qubits, circuit.gates, times_to_split_at);
+      param, circuit.num_qubits, circuit.ops, times_to_split_at);
 
   EXPECT_EQ(fused_gates.size(), 6);
 
+  const auto* fgate0 = OpGetAlternative<FusedGate>(fused_gates[0]);
+  ASSERT_NE(fgate0, nullptr);
+  EXPECT_EQ(fgate0->kind, kGateCZ);
+  EXPECT_EQ(fgate0->time, 1);
+  EXPECT_EQ(fgate0->qubits.size(), 2);
+  EXPECT_EQ(fgate0->qubits[0], 0);
+  EXPECT_EQ(fgate0->qubits[1], 1);
+  EXPECT_EQ(fgate0->gates.size(), 6);
+  const auto* gate00 = OpGetAlternative<Gate>(fgate0->gates[0]);
+  ASSERT_NE(gate00, nullptr);
+  EXPECT_EQ(gate00->kind, kGateHd);
+  EXPECT_EQ(gate00->time, 0);
+  EXPECT_EQ(gate00->qubits.size(), 1);
+  EXPECT_EQ(gate00->qubits[0], 0);
+  const auto* gate01 = OpGetAlternative<Gate>(fgate0->gates[1]);
+  ASSERT_NE(gate01, nullptr);
+  EXPECT_EQ(gate01->kind, kGateHd);
+  EXPECT_EQ(gate01->time, 0);
+  EXPECT_EQ(gate01->qubits.size(), 1);
+  EXPECT_EQ(gate01->qubits[0], 1);
+  const auto* gate02 = OpGetAlternative<Gate>(fgate0->gates[2]);
+  ASSERT_NE(gate02, nullptr);
+  EXPECT_EQ(gate02->kind, kGateCZ);
+  EXPECT_EQ(gate02->time, 1);
+  EXPECT_EQ(gate02->qubits.size(), 2);
+  EXPECT_EQ(gate02->qubits[0], 0);
+  EXPECT_EQ(gate02->qubits[1], 1);
+  const auto* gate03 = OpGetAlternative<Gate>(fgate0->gates[3]);
+  ASSERT_NE(gate03, nullptr);
+  EXPECT_EQ(gate03->kind, kGateT);
+  EXPECT_EQ(gate03->time, 2);
+  EXPECT_EQ(gate03->qubits.size(), 1);
+  EXPECT_EQ(gate03->qubits[0], 0);
+  const auto* gate04 = OpGetAlternative<Gate>(fgate0->gates[4]);
+  ASSERT_NE(gate04, nullptr);
+  EXPECT_EQ(gate04->kind, kGateY);
+  EXPECT_EQ(gate04->time, 3);
+  EXPECT_EQ(gate04->qubits.size(), 1);
+  EXPECT_EQ(gate04->qubits[0], 0);
+  const auto* gate05 = OpGetAlternative<Gate>(fgate0->gates[5]);
+  ASSERT_NE(gate05, nullptr);
+  EXPECT_EQ(gate05->kind, kGateX);
+  EXPECT_EQ(gate05->time, 2);
+  EXPECT_EQ(gate05->qubits.size(), 1);
+  EXPECT_EQ(gate05->qubits[0], 1);
 
-  EXPECT_EQ(fused_gates[0].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].time, 1);
-  EXPECT_EQ(fused_gates[0].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].qubits[1], 1);
-  EXPECT_EQ(fused_gates[0].gates.size(), 6);
-  EXPECT_EQ(fused_gates[0].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[1]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].gates[2]->time, 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[1], 1);
-  EXPECT_EQ(fused_gates[0].gates[3]->kind, kGateT);
-  EXPECT_EQ(fused_gates[0].gates[3]->time, 2);
-  EXPECT_EQ(fused_gates[0].gates[3]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[3]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[4]->kind, kGateY);
-  EXPECT_EQ(fused_gates[0].gates[4]->time, 3);
-  EXPECT_EQ(fused_gates[0].gates[4]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[4]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[5]->kind, kGateX);
-  EXPECT_EQ(fused_gates[0].gates[5]->time, 2);
-  EXPECT_EQ(fused_gates[0].gates[5]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[5]->qubits[0], 1);
+  const auto* fgate1 = OpGetAlternative<FusedGate>(fused_gates[1]);
+  ASSERT_NE(fgate1, nullptr);
+  EXPECT_EQ(fgate1->kind, kGateCZ);
+  EXPECT_EQ(fgate1->time, 1);
+  EXPECT_EQ(fgate1->qubits.size(), 2);
+  EXPECT_EQ(fgate1->qubits[0], 2);
+  EXPECT_EQ(fgate1->qubits[1], 3);
+  EXPECT_EQ(fgate1->gates.size(), 6);
+  const auto* gate10 = OpGetAlternative<Gate>(fgate1->gates[0]);
+  ASSERT_NE(gate10, nullptr);
+  EXPECT_EQ(gate10->kind, kGateHd);
+  EXPECT_EQ(gate10->time, 0);
+  EXPECT_EQ(gate10->qubits.size(), 1);
+  EXPECT_EQ(gate10->qubits[0], 2);
+  const auto* gate11 = OpGetAlternative<Gate>(fgate1->gates[1]);
+  ASSERT_NE(gate11, nullptr);
+  EXPECT_EQ(gate11->kind, kGateHd);
+  EXPECT_EQ(gate11->time, 0);
+  EXPECT_EQ(gate11->qubits.size(), 1);
+  EXPECT_EQ(gate11->qubits[0], 3);
+  const auto* gate12 = OpGetAlternative<Gate>(fgate1->gates[2]);
+  ASSERT_NE(gate12, nullptr);
+  EXPECT_EQ(gate12->kind, kGateCZ);
+  EXPECT_EQ(gate12->time, 1);
+  EXPECT_EQ(gate12->qubits.size(), 2);
+  EXPECT_EQ(gate12->qubits[0], 2);
+  EXPECT_EQ(gate12->qubits[1], 3);
+  const auto* gate13 = OpGetAlternative<Gate>(fgate1->gates[3]);
+  ASSERT_NE(gate13, nullptr);
+  EXPECT_EQ(gate13->kind, kGateY);
+  EXPECT_EQ(gate13->time, 2);
+  EXPECT_EQ(gate13->qubits.size(), 1);
+  EXPECT_EQ(gate13->qubits[0], 2);
+  const auto* gate14 = OpGetAlternative<Gate>(fgate1->gates[4]);
+  ASSERT_NE(gate14, nullptr);
+  EXPECT_EQ(gate14->kind, kGateT);
+  EXPECT_EQ(gate14->time, 2);
+  EXPECT_EQ(gate14->qubits.size(), 1);
+  EXPECT_EQ(gate14->qubits[0], 3);
+  const auto* gate15 = OpGetAlternative<Gate>(fgate1->gates[5]);
+  ASSERT_NE(gate15, nullptr);
+  EXPECT_EQ(gate15->kind, kGateX);
+  EXPECT_EQ(gate15->time, 3);
+  EXPECT_EQ(gate15->qubits.size(), 1);
+  EXPECT_EQ(gate15->qubits[0], 3);
 
-  EXPECT_EQ(fused_gates[1].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[1].time, 1);
-  EXPECT_EQ(fused_gates[1].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[1].qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].qubits[1], 3);
-  EXPECT_EQ(fused_gates[1].gates.size(), 6);
-  EXPECT_EQ(fused_gates[1].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[1]->time, 0);
-  EXPECT_EQ(fused_gates[1].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[1]->qubits[0], 3);
-  EXPECT_EQ(fused_gates[1].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[1].gates[2]->time, 1);
-  EXPECT_EQ(fused_gates[1].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[1].gates[2]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[2]->qubits[1], 3);
-  EXPECT_EQ(fused_gates[1].gates[3]->kind, kGateY);
-  EXPECT_EQ(fused_gates[1].gates[3]->time, 2);
-  EXPECT_EQ(fused_gates[1].gates[3]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[3]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[4]->kind, kGateT);
-  EXPECT_EQ(fused_gates[1].gates[4]->time, 2);
-  EXPECT_EQ(fused_gates[1].gates[4]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[4]->qubits[0], 3);
-  EXPECT_EQ(fused_gates[1].gates[5]->kind, kGateX);
-  EXPECT_EQ(fused_gates[1].gates[5]->time, 3);
-  EXPECT_EQ(fused_gates[1].gates[5]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[5]->qubits[0], 3);
+  const auto* fgate2 = OpGetAlternative<FusedGate>(fused_gates[2]);
+  ASSERT_NE(fgate2, nullptr);
+  EXPECT_EQ(fgate2->kind, kGateCZ);
+  EXPECT_EQ(fgate2->time, 3);
+  EXPECT_EQ(fgate2->qubits.size(), 2);
+  EXPECT_EQ(fgate2->qubits[0], 1);
+  EXPECT_EQ(fgate2->qubits[1], 2);
+  EXPECT_EQ(fgate2->gates.size(), 1);
+  const auto* gate20 = OpGetAlternative<Gate>(fgate2->gates[0]);
+  ASSERT_NE(gate20, nullptr);
+  EXPECT_EQ(gate20->kind, kGateCZ);
+  EXPECT_EQ(gate20->time, 3);
+  EXPECT_EQ(gate20->qubits.size(), 2);
+  EXPECT_EQ(gate20->qubits[0], 1);
+  EXPECT_EQ(gate20->qubits[1], 2);
 
-  EXPECT_EQ(fused_gates[2].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].time, 3);
-  EXPECT_EQ(fused_gates[2].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].qubits[1], 2);
-  EXPECT_EQ(fused_gates[2].gates.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[0]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].gates[0]->time, 3);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits[1], 2);
+  const auto* fgate3 = OpGetAlternative<FusedGate>(fused_gates[3]);
+  ASSERT_NE(fgate3, nullptr);
+  EXPECT_EQ(fgate3->kind, kGateCZ);
+  EXPECT_EQ(fgate3->time, 5);
+  EXPECT_EQ(fgate3->qubits.size(), 2);
+  EXPECT_EQ(fgate3->qubits[0], 1);
+  EXPECT_EQ(fgate3->qubits[1], 2);
+  EXPECT_EQ(fgate3->gates.size(), 8);
+  const auto* gate30 = OpGetAlternative<Gate>(fgate3->gates[0]);
+  ASSERT_NE(gate30, nullptr);
+  EXPECT_EQ(gate30->kind, kGateT);
+  EXPECT_EQ(gate30->time, 4);
+  EXPECT_EQ(gate30->qubits.size(), 1);
+  EXPECT_EQ(gate30->qubits[0], 1);
+  const auto* gate31 = OpGetAlternative<Gate>(fgate3->gates[1]);
+  ASSERT_NE(gate31, nullptr);
+  EXPECT_EQ(gate31->kind, kGateT);
+  EXPECT_EQ(gate31->time, 4);
+  EXPECT_EQ(gate31->qubits.size(), 1);
+  EXPECT_EQ(gate31->qubits[0], 2);
+  const auto* gate32 = OpGetAlternative<Gate>(fgate3->gates[2]);
+  ASSERT_NE(gate32, nullptr);
+  EXPECT_EQ(gate32->kind, kGateCZ);
+  EXPECT_EQ(gate32->time, 5);
+  EXPECT_EQ(gate32->qubits.size(), 2);
+  EXPECT_EQ(gate32->qubits[0], 1);
+  EXPECT_EQ(gate32->qubits[1], 2);
+  const auto* gate33 = OpGetAlternative<Gate>(fgate3->gates[3]);
+  ASSERT_NE(gate33, nullptr);
+  EXPECT_EQ(gate33->kind, kGateX);
+  EXPECT_EQ(gate33->time, 6);
+  EXPECT_EQ(gate33->qubits.size(), 1);
+  EXPECT_EQ(gate33->qubits[0], 1);
+  const auto* gate34 = OpGetAlternative<Gate>(fgate3->gates[4]);
+  ASSERT_NE(gate34, nullptr);
+  EXPECT_EQ(gate34->kind, kGateY);
+  EXPECT_EQ(gate34->time, 6);
+  EXPECT_EQ(gate34->qubits.size(), 1);
+  EXPECT_EQ(gate34->qubits[0], 2);
+  const auto* gate35 = OpGetAlternative<Gate>(fgate3->gates[5]);
+  ASSERT_NE(gate35, nullptr);
+  EXPECT_EQ(gate35->kind, kGateCZ);
+  EXPECT_EQ(gate35->time, 7);
+  EXPECT_EQ(gate35->qubits.size(), 2);
+  EXPECT_EQ(gate35->qubits[0], 1);
+  EXPECT_EQ(gate35->qubits[1], 2);
+  const auto* gate36 = OpGetAlternative<Gate>(fgate3->gates[6]);
+  ASSERT_NE(gate36, nullptr);
+  EXPECT_EQ(gate36->kind, kGateT);
+  EXPECT_EQ(gate36->time, 8);
+  EXPECT_EQ(gate36->qubits.size(), 1);
+  EXPECT_EQ(gate36->qubits[0], 1);
+  const auto* gate37 = OpGetAlternative<Gate>(fgate3->gates[7]);
+  ASSERT_NE(gate37, nullptr);
+  EXPECT_EQ(gate37->kind, kGateT);
+  EXPECT_EQ(gate37->time, 8);
+  EXPECT_EQ(gate37->qubits.size(), 1);
+  EXPECT_EQ(gate37->qubits[0], 2);
 
-  EXPECT_EQ(fused_gates[3].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[3].time, 5);
-  EXPECT_EQ(fused_gates[3].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[3].qubits[0], 1);
-  EXPECT_EQ(fused_gates[3].qubits[1], 2);
-  EXPECT_EQ(fused_gates[3].gates.size(), 8);
-  EXPECT_EQ(fused_gates[3].gates[0]->kind, kGateT);
-  EXPECT_EQ(fused_gates[3].gates[0]->time, 4);
-  EXPECT_EQ(fused_gates[3].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[0]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[3].gates[1]->kind, kGateT);
-  EXPECT_EQ(fused_gates[3].gates[1]->time, 4);
-  EXPECT_EQ(fused_gates[3].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[1]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[3].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[3].gates[2]->time, 5);
-  EXPECT_EQ(fused_gates[3].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[3].gates[2]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[3].gates[2]->qubits[1], 2);
-  EXPECT_EQ(fused_gates[3].gates[3]->kind, kGateX);
-  EXPECT_EQ(fused_gates[3].gates[3]->time, 6);
-  EXPECT_EQ(fused_gates[3].gates[3]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[3]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[3].gates[4]->kind, kGateY);
-  EXPECT_EQ(fused_gates[3].gates[4]->time, 6);
-  EXPECT_EQ(fused_gates[3].gates[4]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[4]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[3].gates[5]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[3].gates[5]->time, 7);
-  EXPECT_EQ(fused_gates[3].gates[5]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[3].gates[5]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[3].gates[5]->qubits[1], 2);
-  EXPECT_EQ(fused_gates[3].gates[6]->kind, kGateT);
-  EXPECT_EQ(fused_gates[3].gates[6]->time, 8);
-  EXPECT_EQ(fused_gates[3].gates[6]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[6]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[3].gates[7]->kind, kGateT);
-  EXPECT_EQ(fused_gates[3].gates[7]->time, 8);
-  EXPECT_EQ(fused_gates[3].gates[7]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[7]->qubits[0], 2);
+  const auto* fgate4 = OpGetAlternative<FusedGate>(fused_gates[4]);
+  ASSERT_NE(fgate4, nullptr);
+  EXPECT_EQ(fgate4->kind, kGateCZ);
+  EXPECT_EQ(fgate4->time, 9);
+  EXPECT_EQ(fgate4->qubits.size(), 2);
+  EXPECT_EQ(fgate4->qubits[0], 0);
+  EXPECT_EQ(fgate4->qubits[1], 1);
+  EXPECT_EQ(fgate4->gates.size(), 3);
+  const auto* gate40 = OpGetAlternative<Gate>(fgate4->gates[0]);
+  ASSERT_NE(gate40, nullptr);
+  EXPECT_EQ(gate40->kind, kGateCZ);
+  EXPECT_EQ(gate40->time, 9);
+  EXPECT_EQ(gate40->qubits.size(), 2);
+  EXPECT_EQ(gate40->qubits[0], 0);
+  EXPECT_EQ(gate40->qubits[1], 1);
+  const auto* gate41 = OpGetAlternative<Gate>(fgate4->gates[1]);
+  ASSERT_NE(gate41, nullptr);
+  EXPECT_EQ(gate41->kind, kGateHd);
+  EXPECT_EQ(gate41->time, 10);
+  EXPECT_EQ(gate41->qubits.size(), 1);
+  EXPECT_EQ(gate41->qubits[0], 0);
+  const auto* gate42 = OpGetAlternative<Gate>(fgate4->gates[2]);
+  ASSERT_NE(gate42, nullptr);
+  EXPECT_EQ(gate42->kind, kGateHd);
+  EXPECT_EQ(gate42->time, 10);
+  EXPECT_EQ(gate42->qubits.size(), 1);
+  EXPECT_EQ(gate42->qubits[0], 1);
 
-  EXPECT_EQ(fused_gates[4].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[4].time, 9);
-  EXPECT_EQ(fused_gates[4].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[4].qubits[0], 0);
-  EXPECT_EQ(fused_gates[4].qubits[1], 1);
-  EXPECT_EQ(fused_gates[4].gates.size(), 3);
-  EXPECT_EQ(fused_gates[4].gates[0]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[4].gates[0]->time, 9);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits[1], 1);
-  EXPECT_EQ(fused_gates[4].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[4].gates[1]->time, 10);
-  EXPECT_EQ(fused_gates[4].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[4].gates[1]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[4].gates[2]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[4].gates[2]->time, 10);
-  EXPECT_EQ(fused_gates[4].gates[2]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[4].gates[2]->qubits[0], 1);
-
-  EXPECT_EQ(fused_gates[5].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[5].time, 9);
-  EXPECT_EQ(fused_gates[5].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[5].qubits[0], 2);
-  EXPECT_EQ(fused_gates[5].qubits[1], 3);
-  EXPECT_EQ(fused_gates[5].gates.size(), 3);
-  EXPECT_EQ(fused_gates[5].gates[0]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[5].gates[0]->time, 9);
-  EXPECT_EQ(fused_gates[5].gates[0]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[5].gates[0]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[5].gates[0]->qubits[1], 3);
-  EXPECT_EQ(fused_gates[5].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[5].gates[1]->time, 10);
-  EXPECT_EQ(fused_gates[5].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[5].gates[1]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[5].gates[2]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[5].gates[2]->time, 10);
-  EXPECT_EQ(fused_gates[5].gates[2]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[5].gates[2]->qubits[0], 3);
+  const auto* fgate5 = OpGetAlternative<FusedGate>(fused_gates[5]);
+  ASSERT_NE(fgate5, nullptr);
+  EXPECT_EQ(fgate5->kind, kGateCZ);
+  EXPECT_EQ(fgate5->time, 9);
+  EXPECT_EQ(fgate5->qubits.size(), 2);
+  EXPECT_EQ(fgate5->qubits[0], 2);
+  EXPECT_EQ(fgate5->qubits[1], 3);
+  EXPECT_EQ(fgate5->gates.size(), 3);
+  const auto* gate50 = OpGetAlternative<Gate>(fgate5->gates[0]);
+  ASSERT_NE(gate50, nullptr);
+  EXPECT_EQ(gate50->kind, kGateCZ);
+  EXPECT_EQ(gate50->time, 9);
+  EXPECT_EQ(gate50->qubits.size(), 2);
+  EXPECT_EQ(gate50->qubits[0], 2);
+  EXPECT_EQ(gate50->qubits[1], 3);
+  const auto* gate51 = OpGetAlternative<Gate>(fgate5->gates[1]);
+  ASSERT_NE(gate51, nullptr);
+  EXPECT_EQ(gate51->kind, kGateHd);
+  EXPECT_EQ(gate51->time, 10);
+  EXPECT_EQ(gate51->qubits.size(), 1);
+  EXPECT_EQ(gate51->qubits[0], 2);
+  const auto* gate52 = OpGetAlternative<Gate>(fgate5->gates[2]);
+  ASSERT_NE(gate52, nullptr);
+  EXPECT_EQ(gate52->kind, kGateHd);
+  EXPECT_EQ(gate52->time, 10);
+  EXPECT_EQ(gate52->qubits.size(), 1);
+  EXPECT_EQ(gate52->qubits[0], 3);
 }
 
 TEST(FuserBasicTest, TimesToSplitAt2) {
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using FusedGate = qsim::FusedGate<float>;
+
   std::stringstream ss(circuit_string1);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 4);
-  EXPECT_EQ(circuit.gates.size(), 27);
+  EXPECT_EQ(circuit.ops.size(), 27);
 
   std::vector<unsigned> times_to_split_at{2, 10};
 
-  using Fuser = BasicGateFuser<IO, GateQSim<float>>;
+  using Fuser = BasicGateFuser<IO>;
   Fuser::Parameter param;
   auto fused_gates = Fuser::FuseGates(
-      param, circuit.num_qubits, circuit.gates, times_to_split_at);
+      param, circuit.num_qubits, circuit.ops, times_to_split_at);
 
   EXPECT_EQ(fused_gates.size(), 5);
 
-  EXPECT_EQ(fused_gates[0].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].time, 1);
-  EXPECT_EQ(fused_gates[0].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].qubits[1], 1);
-  EXPECT_EQ(fused_gates[0].gates.size(), 5);
-  EXPECT_EQ(fused_gates[0].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[1]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].gates[2]->time, 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[1], 1);
-  EXPECT_EQ(fused_gates[0].gates[3]->kind, kGateT);
-  EXPECT_EQ(fused_gates[0].gates[3]->time, 2);
-  EXPECT_EQ(fused_gates[0].gates[3]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[3]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[4]->kind, kGateX);
-  EXPECT_EQ(fused_gates[0].gates[4]->time, 2);
-  EXPECT_EQ(fused_gates[0].gates[4]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[4]->qubits[0], 1);
+  const auto* fgate0 = OpGetAlternative<FusedGate>(fused_gates[0]);
+  ASSERT_NE(fgate0, nullptr);
+  EXPECT_EQ(fgate0->kind, kGateCZ);
+  EXPECT_EQ(fgate0->time, 1);
+  EXPECT_EQ(fgate0->qubits.size(), 2);
+  EXPECT_EQ(fgate0->qubits[0], 0);
+  EXPECT_EQ(fgate0->qubits[1], 1);
+  EXPECT_EQ(fgate0->gates.size(), 5);
+  const auto* gate00 = OpGetAlternative<Gate>(fgate0->gates[0]);
+  ASSERT_NE(gate00, nullptr);
+  EXPECT_EQ(gate00->kind, kGateHd);
+  EXPECT_EQ(gate00->time, 0);
+  EXPECT_EQ(gate00->qubits.size(), 1);
+  EXPECT_EQ(gate00->qubits[0], 0);
+  const auto* gate01 = OpGetAlternative<Gate>(fgate0->gates[1]);
+  ASSERT_NE(gate01, nullptr);
+  EXPECT_EQ(gate01->kind, kGateHd);
+  EXPECT_EQ(gate01->time, 0);
+  EXPECT_EQ(gate01->qubits.size(), 1);
+  EXPECT_EQ(gate01->qubits[0], 1);
+  const auto* gate02 = OpGetAlternative<Gate>(fgate0->gates[2]);
+  ASSERT_NE(gate02, nullptr);
+  EXPECT_EQ(gate02->kind, kGateCZ);
+  EXPECT_EQ(gate02->time, 1);
+  EXPECT_EQ(gate02->qubits.size(), 2);
+  EXPECT_EQ(gate02->qubits[0], 0);
+  EXPECT_EQ(gate02->qubits[1], 1);
+  const auto* gate03 = OpGetAlternative<Gate>(fgate0->gates[3]);
+  ASSERT_NE(gate03, nullptr);
+  EXPECT_EQ(gate03->kind, kGateT);
+  EXPECT_EQ(gate03->time, 2);
+  EXPECT_EQ(gate03->qubits.size(), 1);
+  EXPECT_EQ(gate03->qubits[0], 0);
+  const auto* gate04 = OpGetAlternative<Gate>(fgate0->gates[4]);
+  ASSERT_NE(gate04, nullptr);
+  EXPECT_EQ(gate04->kind, kGateX);
+  EXPECT_EQ(gate04->time, 2);
+  EXPECT_EQ(gate04->qubits.size(), 1);
+  EXPECT_EQ(gate04->qubits[0], 1);
 
-  EXPECT_EQ(fused_gates[1].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[1].time, 1);
-  EXPECT_EQ(fused_gates[1].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[1].qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].qubits[1], 3);
-  EXPECT_EQ(fused_gates[1].gates.size(), 5);
-  EXPECT_EQ(fused_gates[1].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[1]->time, 0);
-  EXPECT_EQ(fused_gates[1].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[1]->qubits[0], 3);
-  EXPECT_EQ(fused_gates[1].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[1].gates[2]->time, 1);
-  EXPECT_EQ(fused_gates[1].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[1].gates[2]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[2]->qubits[1], 3);
-  EXPECT_EQ(fused_gates[1].gates[3]->kind, kGateY);
-  EXPECT_EQ(fused_gates[1].gates[3]->time, 2);
-  EXPECT_EQ(fused_gates[1].gates[3]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[3]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[4]->kind, kGateT);
-  EXPECT_EQ(fused_gates[1].gates[4]->time, 2);
-  EXPECT_EQ(fused_gates[1].gates[4]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[4]->qubits[0], 3);
+  const auto* fgate1 = OpGetAlternative<FusedGate>(fused_gates[1]);
+  ASSERT_NE(fgate1, nullptr);
+  EXPECT_EQ(fgate1->kind, kGateCZ);
+  EXPECT_EQ(fgate1->time, 1);
+  EXPECT_EQ(fgate1->qubits.size(), 2);
+  EXPECT_EQ(fgate1->qubits[0], 2);
+  EXPECT_EQ(fgate1->qubits[1], 3);
+  EXPECT_EQ(fgate1->gates.size(), 5);
+  const auto* gate10 = OpGetAlternative<Gate>(fgate1->gates[0]);
+  ASSERT_NE(gate10, nullptr);
+  EXPECT_EQ(gate10->kind, kGateHd);
+  EXPECT_EQ(gate10->time, 0);
+  EXPECT_EQ(gate10->qubits.size(), 1);
+  EXPECT_EQ(gate10->qubits[0], 2);
+  const auto* gate11 = OpGetAlternative<Gate>(fgate1->gates[1]);
+  ASSERT_NE(gate11, nullptr);
+  EXPECT_EQ(gate11->kind, kGateHd);
+  EXPECT_EQ(gate11->time, 0);
+  EXPECT_EQ(gate11->qubits.size(), 1);
+  EXPECT_EQ(gate11->qubits[0], 3);
+  const auto* gate12 = OpGetAlternative<Gate>(fgate1->gates[2]);
+  ASSERT_NE(gate12, nullptr);
+  EXPECT_EQ(gate12->kind, kGateCZ);
+  EXPECT_EQ(gate12->time, 1);
+  EXPECT_EQ(gate12->qubits.size(), 2);
+  EXPECT_EQ(gate12->qubits[0], 2);
+  EXPECT_EQ(gate12->qubits[1], 3);
+  const auto* gate13 = OpGetAlternative<Gate>(fgate1->gates[3]);
+  ASSERT_NE(gate13, nullptr);
+  EXPECT_EQ(gate13->kind, kGateY);
+  EXPECT_EQ(gate13->time, 2);
+  EXPECT_EQ(gate13->qubits.size(), 1);
+  EXPECT_EQ(gate13->qubits[0], 2);
+  const auto* gate14 = OpGetAlternative<Gate>(fgate1->gates[4]);
+  ASSERT_NE(gate14, nullptr);
+  EXPECT_EQ(gate14->kind, kGateT);
+  EXPECT_EQ(gate14->time, 2);
+  EXPECT_EQ(gate14->qubits.size(), 1);
+  EXPECT_EQ(gate14->qubits[0], 3);
 
-  EXPECT_EQ(fused_gates[2].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].time, 3);
-  EXPECT_EQ(fused_gates[2].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].qubits[1], 2);
-  EXPECT_EQ(fused_gates[2].gates.size(), 9);
-  EXPECT_EQ(fused_gates[2].gates[0]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].gates[0]->time, 3);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits[1], 2);
-  EXPECT_EQ(fused_gates[2].gates[1]->kind, kGateT);
-  EXPECT_EQ(fused_gates[2].gates[1]->time, 4);
-  EXPECT_EQ(fused_gates[2].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[1]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[2]->kind, kGateT);
-  EXPECT_EQ(fused_gates[2].gates[2]->time, 4);
-  EXPECT_EQ(fused_gates[2].gates[2]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[2]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[2].gates[3]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].gates[3]->time, 5);
-  EXPECT_EQ(fused_gates[2].gates[3]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].gates[3]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[3]->qubits[1], 2);
-  EXPECT_EQ(fused_gates[2].gates[4]->kind, kGateX);
-  EXPECT_EQ(fused_gates[2].gates[4]->time, 6);
-  EXPECT_EQ(fused_gates[2].gates[4]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[4]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[5]->kind, kGateY);
-  EXPECT_EQ(fused_gates[2].gates[5]->time, 6);
-  EXPECT_EQ(fused_gates[2].gates[5]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[5]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[2].gates[6]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].gates[6]->time, 7);
-  EXPECT_EQ(fused_gates[2].gates[6]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].gates[6]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[6]->qubits[1], 2);
-  EXPECT_EQ(fused_gates[2].gates[7]->kind, kGateT);
-  EXPECT_EQ(fused_gates[2].gates[7]->time, 8);
-  EXPECT_EQ(fused_gates[2].gates[7]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[7]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[8]->kind, kGateT);
-  EXPECT_EQ(fused_gates[2].gates[8]->time, 8);
-  EXPECT_EQ(fused_gates[2].gates[8]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[8]->qubits[0], 2);
+  const auto* fgate2 = OpGetAlternative<FusedGate>(fused_gates[2]);
+  ASSERT_NE(fgate2, nullptr);
+  EXPECT_EQ(fgate2->kind, kGateCZ);
+  EXPECT_EQ(fgate2->time, 3);
+  EXPECT_EQ(fgate2->qubits.size(), 2);
+  EXPECT_EQ(fgate2->qubits[0], 1);
+  EXPECT_EQ(fgate2->qubits[1], 2);
+  EXPECT_EQ(fgate2->gates.size(), 9);
+  const auto* gate20 = OpGetAlternative<Gate>(fgate2->gates[0]);
+  ASSERT_NE(gate20, nullptr);
+  EXPECT_EQ(gate20->kind, kGateCZ);
+  EXPECT_EQ(gate20->time, 3);
+  EXPECT_EQ(gate20->qubits.size(), 2);
+  EXPECT_EQ(gate20->qubits[0], 1);
+  EXPECT_EQ(gate20->qubits[1], 2);
+  const auto* gate21 = OpGetAlternative<Gate>(fgate2->gates[1]);
+  ASSERT_NE(gate21, nullptr);
+  EXPECT_EQ(gate21->kind, kGateT);
+  EXPECT_EQ(gate21->time, 4);
+  EXPECT_EQ(gate21->qubits.size(), 1);
+  EXPECT_EQ(gate21->qubits[0], 1);
+  const auto* gate22 = OpGetAlternative<Gate>(fgate2->gates[2]);
+  ASSERT_NE(gate22, nullptr);
+  EXPECT_EQ(gate22->kind, kGateT);
+  EXPECT_EQ(gate22->time, 4);
+  EXPECT_EQ(gate22->qubits.size(), 1);
+  EXPECT_EQ(gate22->qubits[0], 2);
+  const auto* gate23 = OpGetAlternative<Gate>(fgate2->gates[3]);
+  ASSERT_NE(gate23, nullptr);
+  EXPECT_EQ(gate23->kind, kGateCZ);
+  EXPECT_EQ(gate23->time, 5);
+  EXPECT_EQ(gate23->qubits.size(), 2);
+  EXPECT_EQ(gate23->qubits[0], 1);
+  EXPECT_EQ(gate23->qubits[1], 2);
+  const auto* gate24 = OpGetAlternative<Gate>(fgate2->gates[4]);
+  ASSERT_NE(gate24, nullptr);
+  EXPECT_EQ(gate24->kind, kGateX);
+  EXPECT_EQ(gate24->time, 6);
+  EXPECT_EQ(gate24->qubits.size(), 1);
+  EXPECT_EQ(gate24->qubits[0], 1);
+  const auto* gate25 = OpGetAlternative<Gate>(fgate2->gates[5]);
+  ASSERT_NE(gate25, nullptr);
+  EXPECT_EQ(gate25->kind, kGateY);
+  EXPECT_EQ(gate25->time, 6);
+  EXPECT_EQ(gate25->qubits.size(), 1);
+  EXPECT_EQ(gate25->qubits[0], 2);
+  const auto* gate26 = OpGetAlternative<Gate>(fgate2->gates[6]);
+  ASSERT_NE(gate26, nullptr);
+  EXPECT_EQ(gate26->kind, kGateCZ);
+  EXPECT_EQ(gate26->time, 7);
+  EXPECT_EQ(gate26->qubits.size(), 2);
+  EXPECT_EQ(gate26->qubits[0], 1);
+  EXPECT_EQ(gate26->qubits[1], 2);
+  const auto* gate27 = OpGetAlternative<Gate>(fgate2->gates[7]);
+  ASSERT_NE(gate27, nullptr);
+  EXPECT_EQ(gate27->kind, kGateT);
+  EXPECT_EQ(gate27->time, 8);
+  EXPECT_EQ(gate27->qubits.size(), 1);
+  EXPECT_EQ(gate27->qubits[0], 1);
+  const auto* gate28 = OpGetAlternative<Gate>(fgate2->gates[8]);
+  ASSERT_NE(gate28, nullptr);
+  EXPECT_EQ(gate28->kind, kGateT);
+  EXPECT_EQ(gate28->time, 8);
+  EXPECT_EQ(gate28->qubits.size(), 1);
+  EXPECT_EQ(gate28->qubits[0], 2);
 
-  EXPECT_EQ(fused_gates[3].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[3].time, 9);
-  EXPECT_EQ(fused_gates[3].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[3].qubits[0], 0);
-  EXPECT_EQ(fused_gates[3].qubits[1], 1);
-  EXPECT_EQ(fused_gates[3].gates.size(), 4);
-  EXPECT_EQ(fused_gates[3].gates[0]->kind, kGateY);
-  EXPECT_EQ(fused_gates[3].gates[0]->time, 3);
-  EXPECT_EQ(fused_gates[3].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[3].gates[1]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[3].gates[1]->time, 9);
-  EXPECT_EQ(fused_gates[3].gates[1]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[3].gates[1]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[3].gates[1]->qubits[1], 1);
-  EXPECT_EQ(fused_gates[3].gates[2]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[3].gates[2]->time, 10);
-  EXPECT_EQ(fused_gates[3].gates[2]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[2]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[3].gates[3]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[3].gates[3]->time, 10);
-  EXPECT_EQ(fused_gates[3].gates[3]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[3]->qubits[0], 1);
+  const auto* fgate3 = OpGetAlternative<FusedGate>(fused_gates[3]);
+  ASSERT_NE(fgate3, nullptr);
+  EXPECT_EQ(fgate3->kind, kGateCZ);
+  EXPECT_EQ(fgate3->time, 9);
+  EXPECT_EQ(fgate3->qubits.size(), 2);
+  EXPECT_EQ(fgate3->qubits[0], 0);
+  EXPECT_EQ(fgate3->qubits[1], 1);
+  EXPECT_EQ(fgate3->gates.size(), 4);
+  const auto* gate30 = OpGetAlternative<Gate>(fgate3->gates[0]);
+  ASSERT_NE(gate30, nullptr);
+  EXPECT_EQ(gate30->kind, kGateY);
+  EXPECT_EQ(gate30->time, 3);
+  EXPECT_EQ(gate30->qubits.size(), 1);
+  EXPECT_EQ(gate30->qubits[0], 0);
+  const auto* gate31 = OpGetAlternative<Gate>(fgate3->gates[1]);
+  ASSERT_NE(gate31, nullptr);
+  EXPECT_EQ(gate31->kind, kGateCZ);
+  EXPECT_EQ(gate31->time, 9);
+  EXPECT_EQ(gate31->qubits.size(), 2);
+  EXPECT_EQ(gate31->qubits[0], 0);
+  EXPECT_EQ(gate31->qubits[1], 1);
+  const auto* gate32 = OpGetAlternative<Gate>(fgate3->gates[2]);
+  ASSERT_NE(gate32, nullptr);
+  EXPECT_EQ(gate32->kind, kGateHd);
+  EXPECT_EQ(gate32->time, 10);
+  EXPECT_EQ(gate32->qubits.size(), 1);
+  EXPECT_EQ(gate32->qubits[0], 0);
+  const auto* gate33 = OpGetAlternative<Gate>(fgate3->gates[3]);
+  ASSERT_NE(gate33, nullptr);
+  EXPECT_EQ(gate33->kind, kGateHd);
+  EXPECT_EQ(gate33->time, 10);
+  EXPECT_EQ(gate33->qubits.size(), 1);
+  EXPECT_EQ(gate33->qubits[0], 1);
 
-  EXPECT_EQ(fused_gates[4].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[4].time, 9);
-  EXPECT_EQ(fused_gates[4].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[4].qubits[0], 2);
-  EXPECT_EQ(fused_gates[4].qubits[1], 3);
-  EXPECT_EQ(fused_gates[4].gates.size(), 4);
-  EXPECT_EQ(fused_gates[4].gates[0]->kind, kGateX);
-  EXPECT_EQ(fused_gates[4].gates[0]->time, 3);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits[0], 3);
-  EXPECT_EQ(fused_gates[4].gates[1]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[4].gates[1]->time, 9);
-  EXPECT_EQ(fused_gates[4].gates[1]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[4].gates[1]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[4].gates[1]->qubits[1], 3);
-  EXPECT_EQ(fused_gates[4].gates[2]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[4].gates[2]->time, 10);
-  EXPECT_EQ(fused_gates[4].gates[2]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[4].gates[2]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[4].gates[3]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[4].gates[3]->time, 10);
-  EXPECT_EQ(fused_gates[4].gates[3]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[4].gates[3]->qubits[0], 3);
+  const auto* fgate4 = OpGetAlternative<FusedGate>(fused_gates[4]);
+  ASSERT_NE(fgate4, nullptr);
+  EXPECT_EQ(fgate4->kind, kGateCZ);
+  EXPECT_EQ(fgate4->time, 9);
+  EXPECT_EQ(fgate4->qubits.size(), 2);
+  EXPECT_EQ(fgate4->qubits[0], 2);
+  EXPECT_EQ(fgate4->qubits[1], 3);
+  EXPECT_EQ(fgate4->gates.size(), 4);
+  const auto* gate40 = OpGetAlternative<Gate>(fgate4->gates[0]);
+  ASSERT_NE(gate40, nullptr);
+  EXPECT_EQ(gate40->kind, kGateX);
+  EXPECT_EQ(gate40->time, 3);
+  EXPECT_EQ(gate40->qubits.size(), 1);
+  EXPECT_EQ(gate40->qubits[0], 3);
+  const auto* gate41 = OpGetAlternative<Gate>(fgate4->gates[1]);
+  ASSERT_NE(gate41, nullptr);
+  EXPECT_EQ(gate41->kind, kGateCZ);
+  EXPECT_EQ(gate41->time, 9);
+  EXPECT_EQ(gate41->qubits.size(), 2);
+  EXPECT_EQ(gate41->qubits[0], 2);
+  EXPECT_EQ(gate41->qubits[1], 3);
+  const auto* gate42 = OpGetAlternative<Gate>(fgate4->gates[2]);
+  ASSERT_NE(gate42, nullptr);
+  EXPECT_EQ(gate42->kind, kGateHd);
+  EXPECT_EQ(gate42->time, 10);
+  EXPECT_EQ(gate42->qubits.size(), 1);
+  EXPECT_EQ(gate42->qubits[0], 2);
+  const auto* gate43 = OpGetAlternative<Gate>(fgate4->gates[3]);
+  ASSERT_NE(gate43, nullptr);
+  EXPECT_EQ(gate43->kind, kGateHd);
+  EXPECT_EQ(gate43->time, 10);
+  EXPECT_EQ(gate43->qubits.size(), 1);
+  EXPECT_EQ(gate43->qubits[0], 3);
 }
 
 constexpr char circuit_string2[] =
@@ -585,207 +793,293 @@ R"(3
 )";
 
 TEST(FuserBasicTest, OrphanedQubits1) {
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using FusedGate = qsim::FusedGate<float>;
+
   std::stringstream ss(circuit_string2);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(2, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 3);
-  EXPECT_EQ(circuit.gates.size(), 7);
+  EXPECT_EQ(circuit.ops.size(), 7);
 
-  using Fuser = BasicGateFuser<IO, GateQSim<float>>;
+  using Fuser = BasicGateFuser<IO>;
   Fuser::Parameter param;
-  auto fused_gates = Fuser::FuseGates(param, circuit.num_qubits, circuit.gates);
+  auto fused_gates = Fuser::FuseGates(param, circuit.num_qubits, circuit.ops);
 
   EXPECT_EQ(fused_gates.size(), 2);
 
-  EXPECT_EQ(fused_gates[0].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].time, 1);
-  EXPECT_EQ(fused_gates[0].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].qubits[1], 1);
-  EXPECT_EQ(fused_gates[0].gates.size(), 5);
-  EXPECT_EQ(fused_gates[0].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[1]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].gates[2]->time, 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[1], 1);
-  EXPECT_EQ(fused_gates[0].gates[3]->kind, kGateT);
-  EXPECT_EQ(fused_gates[0].gates[3]->time, 2);
-  EXPECT_EQ(fused_gates[0].gates[3]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[3]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[4]->kind, kGateX);
-  EXPECT_EQ(fused_gates[0].gates[4]->time, 2);
-  EXPECT_EQ(fused_gates[0].gates[4]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[4]->qubits[0], 1);
+  const auto* fgate0 = OpGetAlternative<FusedGate>(fused_gates[0]);
+  ASSERT_NE(fgate0, nullptr);
+  EXPECT_EQ(fgate0->kind, kGateCZ);
+  EXPECT_EQ(fgate0->time, 1);
+  EXPECT_EQ(fgate0->qubits.size(), 2);
+  EXPECT_EQ(fgate0->qubits[0], 0);
+  EXPECT_EQ(fgate0->qubits[1], 1);
+  EXPECT_EQ(fgate0->gates.size(), 5);
+  const auto* gate00 = OpGetAlternative<Gate>(fgate0->gates[0]);
+  ASSERT_NE(gate00, nullptr);
+  EXPECT_EQ(gate00->kind, kGateHd);
+  EXPECT_EQ(gate00->time, 0);
+  EXPECT_EQ(gate00->qubits.size(), 1);
+  EXPECT_EQ(gate00->qubits[0], 0);
+  const auto* gate01 = OpGetAlternative<Gate>(fgate0->gates[1]);
+  ASSERT_NE(gate01, nullptr);
+  EXPECT_EQ(gate01->kind, kGateHd);
+  EXPECT_EQ(gate01->time, 0);
+  EXPECT_EQ(gate01->qubits.size(), 1);
+  EXPECT_EQ(gate01->qubits[0], 1);
+  const auto* gate02 = OpGetAlternative<Gate>(fgate0->gates[2]);
+  ASSERT_NE(gate02, nullptr);
+  EXPECT_EQ(gate02->kind, kGateCZ);
+  EXPECT_EQ(gate02->time, 1);
+  EXPECT_EQ(gate02->qubits.size(), 2);
+  EXPECT_EQ(gate02->qubits[0], 0);
+  EXPECT_EQ(gate02->qubits[1], 1);
+  const auto* gate03 = OpGetAlternative<Gate>(fgate0->gates[3]);
+  ASSERT_NE(gate03, nullptr);
+  EXPECT_EQ(gate03->kind, kGateT);
+  EXPECT_EQ(gate03->time, 2);
+  EXPECT_EQ(gate03->qubits.size(), 1);
+  EXPECT_EQ(gate03->qubits[0], 0);
+  const auto* gate04 = OpGetAlternative<Gate>(fgate0->gates[4]);
+  ASSERT_NE(gate04, nullptr);
+  EXPECT_EQ(gate04->kind, kGateX);
+  EXPECT_EQ(gate04->time, 2);
+  EXPECT_EQ(gate04->qubits.size(), 1);
+  EXPECT_EQ(gate04->qubits[0], 1);
 
-  EXPECT_EQ(fused_gates[1].kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].time, 0);
-  EXPECT_EQ(fused_gates[1].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates.size(), 2);
-  EXPECT_EQ(fused_gates[1].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[1]->kind, kGateY);
-  EXPECT_EQ(fused_gates[1].gates[1]->time, 2);
-  EXPECT_EQ(fused_gates[1].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[1]->qubits[0], 2);
+  const auto* fgate1 = OpGetAlternative<FusedGate>(fused_gates[1]);
+  ASSERT_NE(fgate1, nullptr);
+  EXPECT_EQ(fgate1->kind, kGateHd);
+  EXPECT_EQ(fgate1->time, 0);
+  EXPECT_EQ(fgate1->qubits.size(), 1);
+  EXPECT_EQ(fgate1->qubits[0], 2);
+  EXPECT_EQ(fgate1->gates.size(), 2);
+  const auto* gate10 = OpGetAlternative<Gate>(fgate1->gates[0]);
+  ASSERT_NE(gate10, nullptr);
+  EXPECT_EQ(gate10->kind, kGateHd);
+  EXPECT_EQ(gate10->time, 0);
+  EXPECT_EQ(gate10->qubits.size(), 1);
+  EXPECT_EQ(gate10->qubits[0], 2);
+  const auto* gate11 = OpGetAlternative<Gate>(fgate1->gates[1]);
+  ASSERT_NE(gate11, nullptr);
+  EXPECT_EQ(gate11->kind, kGateY);
+  EXPECT_EQ(gate11->time, 2);
+  EXPECT_EQ(gate11->qubits.size(), 1);
+  EXPECT_EQ(gate11->qubits[0], 2);
 }
 
 TEST(FuserBasicTest, OrphanedQubits2) {
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using FusedGate = qsim::FusedGate<float>;
+
   std::stringstream ss(circuit_string2);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 3);
-  EXPECT_EQ(circuit.gates.size(), 9);
+  EXPECT_EQ(circuit.ops.size(), 9);
 
   std::vector<unsigned> times_to_split_at{1, 4};
 
-  using Fuser = BasicGateFuser<IO, GateQSim<float>>;
+  using Fuser = BasicGateFuser<IO>;
   Fuser::Parameter param;
   auto fused_gates = Fuser::FuseGates(
-      param, circuit.num_qubits, circuit.gates, times_to_split_at);
+      param, circuit.num_qubits, circuit.ops, times_to_split_at);
 
   EXPECT_EQ(fused_gates.size(), 4);
 
-  EXPECT_EQ(fused_gates[0].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].time, 1);
-  EXPECT_EQ(fused_gates[0].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].qubits[1], 1);
-  EXPECT_EQ(fused_gates[0].gates.size(), 3);
-  EXPECT_EQ(fused_gates[0].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[1]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].gates[2]->time, 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[1], 1);
+  const auto* fgate0 = OpGetAlternative<FusedGate>(fused_gates[0]);
+  ASSERT_NE(fgate0, nullptr);
+  EXPECT_EQ(fgate0->kind, kGateCZ);
+  EXPECT_EQ(fgate0->time, 1);
+  EXPECT_EQ(fgate0->qubits.size(), 2);
+  EXPECT_EQ(fgate0->qubits[0], 0);
+  EXPECT_EQ(fgate0->qubits[1], 1);
+  EXPECT_EQ(fgate0->gates.size(), 3);
+  const auto* gate00 = OpGetAlternative<Gate>(fgate0->gates[0]);
+  ASSERT_NE(gate00, nullptr);
+  EXPECT_EQ(gate00->kind, kGateHd);
+  EXPECT_EQ(gate00->time, 0);
+  EXPECT_EQ(gate00->qubits.size(), 1);
+  EXPECT_EQ(gate00->qubits[0], 0);
+  const auto* gate01 = OpGetAlternative<Gate>(fgate0->gates[1]);
+  ASSERT_NE(gate01, nullptr);
+  EXPECT_EQ(gate01->kind, kGateHd);
+  EXPECT_EQ(gate01->time, 0);
+  EXPECT_EQ(gate01->qubits.size(), 1);
+  EXPECT_EQ(gate01->qubits[0], 1);
+  const auto* gate02 = OpGetAlternative<Gate>(fgate0->gates[2]);
+  ASSERT_NE(gate02, nullptr);
+  EXPECT_EQ(gate02->kind, kGateCZ);
+  EXPECT_EQ(gate02->time, 1);
+  EXPECT_EQ(gate02->qubits.size(), 2);
+  EXPECT_EQ(gate02->qubits[0], 0);
+  EXPECT_EQ(gate02->qubits[1], 1);
 
-  EXPECT_EQ(fused_gates[1].kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].time, 0);
-  EXPECT_EQ(fused_gates[1].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits[0], 2);
+  const auto* fgate1 = OpGetAlternative<FusedGate>(fused_gates[1]);
+  ASSERT_NE(fgate1, nullptr);
+  EXPECT_EQ(fgate1->kind, kGateHd);
+  EXPECT_EQ(fgate1->time, 0);
+  EXPECT_EQ(fgate1->qubits.size(), 1);
+  EXPECT_EQ(fgate1->qubits[0], 2);
+  EXPECT_EQ(fgate1->gates.size(), 1);
+  const auto* gate10 = OpGetAlternative<Gate>(fgate1->gates[0]);
+  ASSERT_NE(gate10, nullptr);
+  EXPECT_EQ(gate10->kind, kGateHd);
+  EXPECT_EQ(gate10->time, 0);
+  EXPECT_EQ(gate10->qubits.size(), 1);
+  EXPECT_EQ(gate10->qubits[0], 2);
 
-  EXPECT_EQ(fused_gates[2].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].time, 3);
-  EXPECT_EQ(fused_gates[2].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].qubits[1], 2);
-  EXPECT_EQ(fused_gates[2].gates.size(), 3);
-  EXPECT_EQ(fused_gates[2].gates[0]->kind, kGateX);
-  EXPECT_EQ(fused_gates[2].gates[0]->time, 2);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[1]->kind, kGateY);
-  EXPECT_EQ(fused_gates[2].gates[1]->time, 2);
-  EXPECT_EQ(fused_gates[2].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[1]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[2].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].gates[2]->time, 3);
-  EXPECT_EQ(fused_gates[2].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].gates[2]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[2].gates[2]->qubits[1], 2);
+  const auto* fgate2 = OpGetAlternative<FusedGate>(fused_gates[2]);
+  ASSERT_NE(fgate2, nullptr);
+  EXPECT_EQ(fgate2->kind, kGateCZ);
+  EXPECT_EQ(fgate2->time, 3);
+  EXPECT_EQ(fgate2->qubits.size(), 2);
+  EXPECT_EQ(fgate2->qubits[0], 1);
+  EXPECT_EQ(fgate2->qubits[1], 2);
+  EXPECT_EQ(fgate2->gates.size(), 3);
+  const auto* gate20 = OpGetAlternative<Gate>(fgate2->gates[0]);
+  ASSERT_NE(gate20, nullptr);
+  EXPECT_EQ(gate20->kind, kGateX);
+  EXPECT_EQ(gate20->time, 2);
+  EXPECT_EQ(gate20->qubits.size(), 1);
+  EXPECT_EQ(gate20->qubits[0], 1);
+  const auto* gate21 = OpGetAlternative<Gate>(fgate2->gates[1]);
+  ASSERT_NE(gate21, nullptr);
+  EXPECT_EQ(gate21->kind, kGateY);
+  EXPECT_EQ(gate21->time, 2);
+  EXPECT_EQ(gate21->qubits.size(), 1);
+  EXPECT_EQ(gate21->qubits[0], 2);
+  const auto* gate22 = OpGetAlternative<Gate>(fgate2->gates[2]);
+  ASSERT_NE(gate22, nullptr);
+  EXPECT_EQ(gate22->kind, kGateCZ);
+  EXPECT_EQ(gate22->time, 3);
+  EXPECT_EQ(gate22->qubits.size(), 2);
+  EXPECT_EQ(gate22->qubits[0], 1);
+  EXPECT_EQ(gate22->qubits[1], 2);
 
-  EXPECT_EQ(fused_gates[3].kind, kGateT);
-  EXPECT_EQ(fused_gates[3].time, 2);
-  EXPECT_EQ(fused_gates[3].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].qubits[0], 0);
-  EXPECT_EQ(fused_gates[3].gates.size(), 2);
-  EXPECT_EQ(fused_gates[3].gates[0]->kind, kGateT);
-  EXPECT_EQ(fused_gates[3].gates[0]->time, 2);
-  EXPECT_EQ(fused_gates[3].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[3].gates[1]->kind, kGateX);
-  EXPECT_EQ(fused_gates[3].gates[1]->time, 4);
-  EXPECT_EQ(fused_gates[3].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[1]->qubits[0], 0);
+  const auto* fgate3 = OpGetAlternative<FusedGate>(fused_gates[3]);
+  ASSERT_NE(fgate3, nullptr);
+  EXPECT_EQ(fgate3->kind, kGateT);
+  EXPECT_EQ(fgate3->time, 2);
+  EXPECT_EQ(fgate3->qubits.size(), 1);
+  EXPECT_EQ(fgate3->qubits[0], 0);
+  EXPECT_EQ(fgate3->gates.size(), 2);
+  const auto* gate30 = OpGetAlternative<Gate>(fgate3->gates[0]);
+  ASSERT_NE(gate30, nullptr);
+  EXPECT_EQ(gate30->kind, kGateT);
+  EXPECT_EQ(gate30->time, 2);
+  EXPECT_EQ(gate30->qubits.size(), 1);
+  EXPECT_EQ(gate30->qubits[0], 0);
+  const auto* gate31 = OpGetAlternative<Gate>(fgate3->gates[1]);
+  ASSERT_NE(gate31, nullptr);
+  EXPECT_EQ(gate31->kind, kGateX);
+  EXPECT_EQ(gate31->time, 4);
+  EXPECT_EQ(gate31->qubits.size(), 1);
+  EXPECT_EQ(gate31->qubits[0], 0);
 }
 
-TEST(FuserBasicTest, UnfusibleSingleQubitGate) {
+TEST(FuserBasicTest, DecomposedQubitGate) {
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using FusedGate = qsim::FusedGate<float>;
+  using DecomposedGate = qsim::DecomposedGate<float>;
+
+  using OperationD = detail::append_to_variant_t<Operation, DecomposedGate>;
+
   std::stringstream ss(circuit_string2);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(2, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 3);
-  EXPECT_EQ(circuit.gates.size(), 7);
+  EXPECT_EQ(circuit.ops.size(), 7);
 
-  circuit.gates[1].unfusible = true;
-  circuit.gates[2].unfusible = true;
+  Circuit<OperationD> circuitd;
+  circuitd.num_qubits = circuit.num_qubits;
+  circuitd.ops.resize(circuit.ops.size());
 
-  using Fuser = BasicGateFuser<IO, GateQSim<float>>;
+  circuitd.ops[0] = *OpGetAlternative<Gate>(circuit.ops[0]);
+  circuitd.ops[1] = DecomposedGate{*OpGetAlternative<Gate>(circuit.ops[1])};
+  circuitd.ops[2] = DecomposedGate{*OpGetAlternative<Gate>(circuit.ops[2])};
+  circuitd.ops[3] = *OpGetAlternative<Gate>(circuit.ops[3]);
+  circuitd.ops[4] = *OpGetAlternative<Gate>(circuit.ops[4]);
+  circuitd.ops[5] = *OpGetAlternative<Gate>(circuit.ops[5]);
+  circuitd.ops[6] = *OpGetAlternative<Gate>(circuit.ops[6]);
+
+  using Fuser = BasicGateFuser<IO>;
   Fuser::Parameter param;
-  auto fused_gates = Fuser::FuseGates(param, circuit.num_qubits, circuit.gates);
+  auto fused_gates = Fuser::FuseGates(param, circuitd.num_qubits, circuitd.ops);
 
   EXPECT_EQ(fused_gates.size(), 3);
 
-  EXPECT_EQ(fused_gates[0].kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].time, 0);
-  EXPECT_EQ(fused_gates[0].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].qubits[0], 1);
-  EXPECT_EQ(fused_gates[0].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits[0], 1);
+  const auto* fgate0 = OpGetAlternative<FusedGate>(fused_gates[0]);
+  ASSERT_NE(fgate0, nullptr);
+  EXPECT_EQ(fgate0->kind, kGateHd);
+  EXPECT_EQ(fgate0->time, 0);
+  EXPECT_EQ(fgate0->qubits.size(), 1);
+  EXPECT_EQ(fgate0->qubits[0], 1);
+  const auto* gate00 = OpGetAlternative<DecomposedGate>(fgate0->gates[0]);
+  EXPECT_EQ(gate00->kind, kGateHd);
+  EXPECT_EQ(gate00->time, 0);
+  EXPECT_EQ(gate00->qubits.size(), 1);
+  EXPECT_EQ(gate00->qubits[0], 1);
 
-  EXPECT_EQ(fused_gates[1].kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].time, 0);
-  EXPECT_EQ(fused_gates[1].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates.size(), 2);
-  EXPECT_EQ(fused_gates[1].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[1]->kind, kGateY);
-  EXPECT_EQ(fused_gates[1].gates[1]->time, 2);
-  EXPECT_EQ(fused_gates[1].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[1]->qubits[0], 2);
+  const auto* fgate1 = OpGetAlternative<FusedGate>(fused_gates[1]);
+  ASSERT_NE(fgate1, nullptr);
+  EXPECT_EQ(fgate1->kind, kGateHd);
+  EXPECT_EQ(fgate1->time, 0);
+  EXPECT_EQ(fgate1->qubits.size(), 1);
+  EXPECT_EQ(fgate1->qubits[0], 2);
+  EXPECT_EQ(fgate1->gates.size(), 2);
+  const auto* gate10 = OpGetAlternative<DecomposedGate>(fgate1->gates[0]);
+  EXPECT_EQ(gate10->kind, kGateHd);
+  EXPECT_EQ(gate10->time, 0);
+  EXPECT_EQ(gate10->qubits.size(), 1);
+  EXPECT_EQ(gate10->qubits[0], 2);
+  const auto* gate11 = OpGetAlternative<Gate>(fgate1->gates[1]);
+  ASSERT_NE(gate11, nullptr);
+  EXPECT_EQ(gate11->kind, kGateY);
+  EXPECT_EQ(gate11->time, 2);
+  EXPECT_EQ(gate11->qubits.size(), 1);
+  EXPECT_EQ(gate11->qubits[0], 2);
 
-  EXPECT_EQ(fused_gates[2].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].time, 1);
-  EXPECT_EQ(fused_gates[2].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].qubits[0], 0);
-  EXPECT_EQ(fused_gates[2].qubits[1], 1);
-  EXPECT_EQ(fused_gates[2].gates.size(), 4);
-  EXPECT_EQ(fused_gates[2].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[2].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[2].gates[1]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[2].gates[1]->time, 1);
-  EXPECT_EQ(fused_gates[2].gates[1]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[2].gates[1]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[2].gates[1]->qubits[1], 1);
-  EXPECT_EQ(fused_gates[2].gates[2]->kind, kGateT);
-  EXPECT_EQ(fused_gates[2].gates[2]->time, 2);
-  EXPECT_EQ(fused_gates[2].gates[2]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[2]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[2].gates[3]->kind, kGateX);
-  EXPECT_EQ(fused_gates[2].gates[3]->time, 2);
-  EXPECT_EQ(fused_gates[2].gates[3]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[3]->qubits[0], 1);
+  const auto* fgate2 = OpGetAlternative<FusedGate>(fused_gates[2]);
+  ASSERT_NE(fgate2, nullptr);
+  EXPECT_EQ(fgate2->kind, kGateCZ);
+  EXPECT_EQ(fgate2->time, 1);
+  EXPECT_EQ(fgate2->qubits.size(), 2);
+  EXPECT_EQ(fgate2->qubits[0], 0);
+  EXPECT_EQ(fgate2->qubits[1], 1);
+  EXPECT_EQ(fgate2->gates.size(), 4);
+  const auto* gate20 = OpGetAlternative<Gate>(fgate2->gates[0]);
+  ASSERT_NE(gate20, nullptr);
+  EXPECT_EQ(gate20->kind, kGateHd);
+  EXPECT_EQ(gate20->time, 0);
+  EXPECT_EQ(gate20->qubits.size(), 1);
+  EXPECT_EQ(gate20->qubits[0], 0);
+  const auto* gate21 = OpGetAlternative<Gate>(fgate2->gates[1]);
+  ASSERT_NE(gate21, nullptr);
+  EXPECT_EQ(gate21->kind, kGateCZ);
+  EXPECT_EQ(gate21->time, 1);
+  EXPECT_EQ(gate21->qubits.size(), 2);
+  EXPECT_EQ(gate21->qubits[0], 0);
+  EXPECT_EQ(gate21->qubits[1], 1);
+  const auto* gate22 = OpGetAlternative<Gate>(fgate2->gates[2]);
+  ASSERT_NE(gate22, nullptr);
+  EXPECT_EQ(gate22->kind, kGateT);
+  EXPECT_EQ(gate22->time, 2);
+  EXPECT_EQ(gate22->qubits.size(), 1);
+  EXPECT_EQ(gate22->qubits[0], 0);
+  const auto* gate23 = OpGetAlternative<Gate>(fgate2->gates[3]);
+  ASSERT_NE(gate23, nullptr);
+  EXPECT_EQ(gate23->kind, kGateX);
+  EXPECT_EQ(gate23->time, 2);
+  EXPECT_EQ(gate23->qubits.size(), 1);
+  EXPECT_EQ(gate23->qubits[0], 1);
 }
 
 constexpr char circuit_string3[] =
@@ -810,153 +1104,197 @@ R"(4
 )";
 
 TEST(FuserBasicTest, MeasurementGate) {
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using FusedGate = qsim::FusedGate<float>;
+
   std::stringstream ss(circuit_string3);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 4);
-  EXPECT_EQ(circuit.gates.size(), 17);
+  EXPECT_EQ(circuit.ops.size(), 17);
 
   // Vector of pointers to gates.
-  std::vector<const GateQSim<float>*> pgates;
-  pgates.reserve(circuit.gates.size());
+  std::vector<const Operation*> pgates;
+  pgates.reserve(circuit.ops.size());
 
-  for (const auto& gate : circuit.gates) {
+  for (const auto& gate : circuit.ops) {
     pgates.push_back(&gate);
   }
 
-  using Fuser = BasicGateFuser<IO, const GateQSim<float>*>;
+  using Fuser = BasicGateFuser<IO>;
   Fuser::Parameter param;
-  auto fused_gates = Fuser::FuseGates(param, circuit.num_qubits, pgates);
+  const auto fused_gates = Fuser::FuseGates(param, circuit.num_qubits, pgates);
 
   EXPECT_EQ(fused_gates.size(), 11);
 
-  EXPECT_EQ(fused_gates[0].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].time, 1);
-  EXPECT_EQ(fused_gates[0].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].qubits[1], 1);
-  EXPECT_EQ(fused_gates[0].gates.size(), 3);
-  EXPECT_EQ(fused_gates[0].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[1]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].gates[2]->time, 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[1], 1);
+  const auto* fgate0 = OpGetAlternative<FusedGate>(fused_gates[0]);
+  ASSERT_NE(fgate0, nullptr);
+  EXPECT_EQ(fgate0->kind, kGateCZ);
+  EXPECT_EQ(fgate0->time, 1);
+  EXPECT_EQ(fgate0->qubits.size(), 2);
+  EXPECT_EQ(fgate0->qubits[0], 0);
+  EXPECT_EQ(fgate0->qubits[1], 1);
+  EXPECT_EQ(fgate0->gates.size(), 3);
+  const auto* gate00 = OpGetAlternative<Gate>(fgate0->gates[0]);
+  ASSERT_NE(gate00, nullptr);
+  EXPECT_EQ(gate00->kind, kGateHd);
+  EXPECT_EQ(gate00->time, 0);
+  EXPECT_EQ(gate00->qubits.size(), 1);
+  EXPECT_EQ(gate00->qubits[0], 0);
+  const auto* gate01 = OpGetAlternative<Gate>(fgate0->gates[1]);
+  ASSERT_NE(gate01, nullptr);
+  EXPECT_EQ(gate01->kind, kGateHd);
+  EXPECT_EQ(gate01->time, 0);
+  EXPECT_EQ(gate01->qubits.size(), 1);
+  EXPECT_EQ(gate01->qubits[0], 1);
+  const auto* gate02 = OpGetAlternative<Gate>(fgate0->gates[2]);
+  ASSERT_NE(gate02, nullptr);
+  EXPECT_EQ(gate02->kind, kGateCZ);
+  EXPECT_EQ(gate02->time, 1);
+  EXPECT_EQ(gate02->qubits.size(), 2);
+  EXPECT_EQ(gate02->qubits[0], 0);
+  EXPECT_EQ(gate02->qubits[1], 1);
 
-  EXPECT_EQ(fused_gates[1].kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].time, 0);
-  EXPECT_EQ(fused_gates[1].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits[0], 2);
+  const auto* fgate1 = OpGetAlternative<FusedGate>(fused_gates[1]);
+  ASSERT_NE(fgate1, nullptr);
+  EXPECT_EQ(fgate1->kind, kGateHd);
+  EXPECT_EQ(fgate1->time, 0);
+  EXPECT_EQ(fgate1->qubits.size(), 1);
+  EXPECT_EQ(fgate1->qubits[0], 2);
+  EXPECT_EQ(fgate1->gates.size(), 1);
+  const auto* gate10 = OpGetAlternative<Gate>(fgate1->gates[0]);
+  ASSERT_NE(gate10, nullptr);
+  EXPECT_EQ(gate10->kind, kGateHd);
+  EXPECT_EQ(gate10->time, 0);
+  EXPECT_EQ(gate10->qubits.size(), 1);
+  EXPECT_EQ(gate10->qubits[0], 2);
 
-  EXPECT_EQ(fused_gates[2].kind, kGateHd);
-  EXPECT_EQ(fused_gates[2].time, 0);
-  EXPECT_EQ(fused_gates[2].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].qubits[0], 3);
-  EXPECT_EQ(fused_gates[2].gates.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[2].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits[0], 3);
+  const auto* fgate2 = OpGetAlternative<FusedGate>(fused_gates[2]);
+  ASSERT_NE(fgate2, nullptr);
+  EXPECT_EQ(fgate2->kind, kGateHd);
+  EXPECT_EQ(fgate2->time, 0);
+  EXPECT_EQ(fgate2->qubits.size(), 1);
+  EXPECT_EQ(fgate2->qubits[0], 3);
+  EXPECT_EQ(fgate2->gates.size(), 1);
+  const auto* gate20 = OpGetAlternative<Gate>(fgate2->gates[0]);
+  ASSERT_NE(gate20, nullptr);
+  EXPECT_EQ(gate20->kind, kGateHd);
+  EXPECT_EQ(gate20->time, 0);
+  EXPECT_EQ(gate20->qubits.size(), 1);
+  EXPECT_EQ(gate20->qubits[0], 3);
 
-  EXPECT_EQ(fused_gates[3].kind, kMeasurement);
-  EXPECT_EQ(fused_gates[3].time, 1);
-  EXPECT_EQ(fused_gates[3].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[3].qubits[0], 2);
-  EXPECT_EQ(fused_gates[3].qubits[1], 3);
-  EXPECT_EQ(fused_gates[3].gates.size(), 2);
+  const auto* fgate3 = OpGetAlternative<Measurement>(fused_gates[3]);
+  EXPECT_EQ(fgate3->kind, kMeasurement);
+  EXPECT_EQ(fgate3->time, 1);
+  EXPECT_EQ(fgate3->qubits.size(), 2);
+  EXPECT_EQ(fgate3->qubits[0], 2);
+  EXPECT_EQ(fgate3->qubits[1], 3);
 
-  EXPECT_EQ(fused_gates[4].kind, kGateIS);
-  EXPECT_EQ(fused_gates[4].time, 2);
-  EXPECT_EQ(fused_gates[4].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[4].qubits[0], 2);
-  EXPECT_EQ(fused_gates[4].qubits[1], 3);
-  EXPECT_EQ(fused_gates[4].gates.size(), 1);
-  EXPECT_EQ(fused_gates[4].gates[0]->kind, kGateIS);
-  EXPECT_EQ(fused_gates[4].gates[0]->time, 2);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits[1], 3);
+  const auto* fgate4 = OpGetAlternative<FusedGate>(fused_gates[4]);
+  ASSERT_NE(fgate4, nullptr);
+  EXPECT_EQ(fgate4->kind, kGateIS);
+  EXPECT_EQ(fgate4->time, 2);
+  EXPECT_EQ(fgate4->qubits.size(), 2);
+  EXPECT_EQ(fgate4->qubits[0], 2);
+  EXPECT_EQ(fgate4->qubits[1], 3);
+  EXPECT_EQ(fgate4->gates.size(), 1);
+  const auto* gate40 = OpGetAlternative<Gate>(fgate4->gates[0]);
+  ASSERT_NE(gate40, nullptr);
+  EXPECT_EQ(gate40->kind, kGateIS);
+  EXPECT_EQ(gate40->time, 2);
+  EXPECT_EQ(gate40->qubits.size(), 2);
+  EXPECT_EQ(gate40->qubits[0], 2);
+  EXPECT_EQ(gate40->qubits[1], 3);
 
-  EXPECT_EQ(fused_gates[5].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[5].time, 3);
-  EXPECT_EQ(fused_gates[5].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[5].qubits[0], 0);
-  EXPECT_EQ(fused_gates[5].qubits[1], 1);
-  EXPECT_EQ(fused_gates[5].gates.size(), 3);
-  EXPECT_EQ(fused_gates[5].gates[0]->kind, kGateX);
-  EXPECT_EQ(fused_gates[5].gates[0]->time, 2);
-  EXPECT_EQ(fused_gates[5].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[5].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[5].gates[1]->kind, kGateY);
-  EXPECT_EQ(fused_gates[5].gates[1]->time, 2);
-  EXPECT_EQ(fused_gates[5].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[5].gates[1]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[5].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[5].gates[2]->time, 3);
-  EXPECT_EQ(fused_gates[5].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[5].gates[2]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[5].gates[2]->qubits[1], 1);
+  const auto* fgate5 = OpGetAlternative<FusedGate>(fused_gates[5]);
+  ASSERT_NE(fgate5, nullptr);
+  EXPECT_EQ(fgate5->kind, kGateCZ);
+  EXPECT_EQ(fgate5->time, 3);
+  EXPECT_EQ(fgate5->qubits.size(), 2);
+  EXPECT_EQ(fgate5->qubits[0], 0);
+  EXPECT_EQ(fgate5->qubits[1], 1);
+  EXPECT_EQ(fgate5->gates.size(), 3);
+  const auto* gate50 = OpGetAlternative<Gate>(fgate5->gates[0]);
+  ASSERT_NE(gate50, nullptr);
+  EXPECT_EQ(gate50->kind, kGateX);
+  EXPECT_EQ(gate50->time, 2);
+  EXPECT_EQ(gate50->qubits.size(), 1);
+  EXPECT_EQ(gate50->qubits[0], 0);
+  const auto* gate51 = OpGetAlternative<Gate>(fgate5->gates[1]);
+  ASSERT_NE(gate51, nullptr);
+  EXPECT_EQ(gate51->kind, kGateY);
+  EXPECT_EQ(gate51->time, 2);
+  EXPECT_EQ(gate51->qubits.size(), 1);
+  EXPECT_EQ(gate51->qubits[0], 1);
+  const auto* gate52 = OpGetAlternative<Gate>(fgate5->gates[2]);
+  ASSERT_NE(gate52, nullptr);
+  EXPECT_EQ(gate52->kind, kGateCZ);
+  EXPECT_EQ(gate52->time, 3);
+  EXPECT_EQ(gate52->qubits.size(), 2);
+  EXPECT_EQ(gate52->qubits[0], 0);
+  EXPECT_EQ(gate52->qubits[1], 1);
 
-  EXPECT_EQ(fused_gates[6].kind, kMeasurement);
-  EXPECT_EQ(fused_gates[6].time, 3);
-  EXPECT_EQ(fused_gates[6].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[6].qubits[0], 2);
-  EXPECT_EQ(fused_gates[6].qubits[1], 3);
-  EXPECT_EQ(fused_gates[6].gates.size(), 1);
+  const auto* fgate6 = OpGetAlternative<Measurement>(fused_gates[6]);
+  EXPECT_EQ(fgate6->kind, kMeasurement);
+  EXPECT_EQ(fgate6->time, 3);
+  EXPECT_EQ(fgate6->qubits.size(), 2);
+  EXPECT_EQ(fgate6->qubits[0], 2);
+  EXPECT_EQ(fgate6->qubits[1], 3);
 
-  EXPECT_EQ(fused_gates[7].kind, kGateIS);
-  EXPECT_EQ(fused_gates[7].time, 4);
-  EXPECT_EQ(fused_gates[7].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[7].qubits[0], 2);
-  EXPECT_EQ(fused_gates[7].qubits[1], 3);
-  EXPECT_EQ(fused_gates[7].gates.size(), 1);
-  EXPECT_EQ(fused_gates[7].gates[0]->kind, kGateIS);
-  EXPECT_EQ(fused_gates[7].gates[0]->time, 4);
-  EXPECT_EQ(fused_gates[7].gates[0]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[7].gates[0]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[7].gates[0]->qubits[1], 3);
+  const auto* fgate7 = OpGetAlternative<FusedGate>(fused_gates[7]);
+  ASSERT_NE(fgate7, nullptr);
+  EXPECT_EQ(fgate7->kind, kGateIS);
+  EXPECT_EQ(fgate7->time, 4);
+  EXPECT_EQ(fgate7->qubits.size(), 2);
+  EXPECT_EQ(fgate7->qubits[0], 2);
+  EXPECT_EQ(fgate7->qubits[1], 3);
+  EXPECT_EQ(fgate7->gates.size(), 1);
+  const auto* gate70 = OpGetAlternative<Gate>(fgate7->gates[0]);
+  ASSERT_NE(gate70, nullptr);
+  EXPECT_EQ(gate70->kind, kGateIS);
+  EXPECT_EQ(gate70->time, 4);
+  EXPECT_EQ(gate70->qubits.size(), 2);
+  EXPECT_EQ(gate70->qubits[0], 2);
+  EXPECT_EQ(gate70->qubits[1], 3);
 
-  EXPECT_EQ(fused_gates[8].kind, kGateX);
-  EXPECT_EQ(fused_gates[8].time, 4);
-  EXPECT_EQ(fused_gates[8].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[8].qubits[0], 0);
-  EXPECT_EQ(fused_gates[8].gates.size(), 1);
-  EXPECT_EQ(fused_gates[8].gates[0]->kind, kGateX);
-  EXPECT_EQ(fused_gates[8].gates[0]->time, 4);
-  EXPECT_EQ(fused_gates[8].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[8].gates[0]->qubits[0], 0);
+  const auto* fgate8 = OpGetAlternative<FusedGate>(fused_gates[8]);
+  ASSERT_NE(fgate8, nullptr);
+  EXPECT_EQ(fgate8->kind, kGateX);
+  EXPECT_EQ(fgate8->time, 4);
+  EXPECT_EQ(fgate8->qubits.size(), 1);
+  EXPECT_EQ(fgate8->qubits[0], 0);
+  EXPECT_EQ(fgate8->gates.size(), 1);
+  const auto* gate80 = OpGetAlternative<Gate>(fgate8->gates[0]);
+  ASSERT_NE(gate80, nullptr);
+  EXPECT_EQ(gate80->kind, kGateX);
+  EXPECT_EQ(gate80->time, 4);
+  EXPECT_EQ(gate80->qubits.size(), 1);
+  EXPECT_EQ(gate80->qubits[0], 0);
 
-  EXPECT_EQ(fused_gates[9].kind, kGateY);
-  EXPECT_EQ(fused_gates[9].time, 4);
-  EXPECT_EQ(fused_gates[9].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[9].qubits[0], 1);
-  EXPECT_EQ(fused_gates[9].gates.size(), 1);
-  EXPECT_EQ(fused_gates[9].gates[0]->kind, kGateY);
-  EXPECT_EQ(fused_gates[9].gates[0]->time, 4);
-  EXPECT_EQ(fused_gates[9].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[9].gates[0]->qubits[0], 1);
+  const auto* fgate9 = OpGetAlternative<FusedGate>(fused_gates[9]);
+  ASSERT_NE(fgate9, nullptr);
+  EXPECT_EQ(fgate9->kind, kGateY);
+  EXPECT_EQ(fgate9->time, 4);
+  EXPECT_EQ(fgate9->qubits.size(), 1);
+  EXPECT_EQ(fgate9->qubits[0], 1);
+  EXPECT_EQ(fgate9->gates.size(), 1);
+  const auto* gate90 = OpGetAlternative<Gate>(fgate9->gates[0]);
+  ASSERT_NE(gate90, nullptr);
+  EXPECT_EQ(gate90->kind, kGateY);
+  EXPECT_EQ(gate90->time, 4);
+  EXPECT_EQ(gate90->qubits.size(), 1);
+  EXPECT_EQ(gate90->qubits[0], 1);
 
-  EXPECT_EQ(fused_gates[10].kind, kMeasurement);
-  EXPECT_EQ(fused_gates[10].time, 5);
-  EXPECT_EQ(fused_gates[10].qubits.size(), 4);
-  EXPECT_EQ(fused_gates[10].qubits[0], 2);
-  EXPECT_EQ(fused_gates[10].qubits[1], 3);
-  EXPECT_EQ(fused_gates[10].qubits[2], 0);
-  EXPECT_EQ(fused_gates[10].qubits[3], 1);
-  EXPECT_EQ(fused_gates[10].gates.size(), 2);
+  const auto* fgate10 = OpGetAlternative<Measurement>(fused_gates[10]);
+  EXPECT_EQ(fgate10->kind, kMeasurement);
+  EXPECT_EQ(fgate10->time, 5);
+  EXPECT_EQ(fgate10->qubits.size(), 4);
+  EXPECT_EQ(fgate10->qubits[0], 2);
+  EXPECT_EQ(fgate10->qubits[1], 3);
+  EXPECT_EQ(fgate10->qubits[2], 0);
+  EXPECT_EQ(fgate10->qubits[3], 1);
 }
 
 constexpr char circuit_string4[] =
@@ -977,198 +1315,180 @@ R"(5
 )";
 
 TEST(FuserBasicTest, ControlledGate) {
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using ControlledGate = qsim::ControlledGate<float>;
+  using FusedGate = qsim::FusedGate<float>;
+
   std::stringstream ss(circuit_string4);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 5);
-  EXPECT_EQ(circuit.gates.size(), 13);
+  EXPECT_EQ(circuit.ops.size(), 13);
 
   // Vector of pointers to gates.
-  std::vector<const GateQSim<float>*> pgates;
-  pgates.reserve(circuit.gates.size());
+  std::vector<const Operation*> pgates;
+  pgates.reserve(circuit.ops.size());
 
-  for (const auto& gate : circuit.gates) {
+  for (const auto& gate : circuit.ops) {
     pgates.push_back(&gate);
   }
 
-  using Fuser = BasicGateFuser<IO, const GateQSim<float>*>;
+  using Fuser = BasicGateFuser<IO>;
   Fuser::Parameter param;
-  auto fused_gates = Fuser::FuseGates(param, circuit.num_qubits, pgates);
+  const auto fused_gates = Fuser::FuseGates(param, circuit.num_qubits, pgates);
 
   EXPECT_EQ(fused_gates.size(), 8);
 
-  EXPECT_EQ(fused_gates[0].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].time, 1);
-  EXPECT_EQ(fused_gates[0].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].qubits[1], 1);
-  EXPECT_EQ(fused_gates[0].gates.size(), 3);
-  EXPECT_EQ(fused_gates[0].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[0]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[0].gates[1]->time, 0);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[0].gates[1]->qubits[0], 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[0].gates[2]->time, 1);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[0], 0);
-  EXPECT_EQ(fused_gates[0].gates[2]->qubits[1], 1);
+  const auto* fgate0 = OpGetAlternative<FusedGate>(fused_gates[0]);
+  ASSERT_NE(fgate0, nullptr);
+  EXPECT_EQ(fgate0->kind, kGateCZ);
+  EXPECT_EQ(fgate0->time, 1);
+  EXPECT_EQ(fgate0->qubits.size(), 2);
+  EXPECT_EQ(fgate0->qubits[0], 0);
+  EXPECT_EQ(fgate0->qubits[1], 1);
+  EXPECT_EQ(fgate0->gates.size(), 3);
+  const auto* gate00 = OpGetAlternative<Gate>(fgate0->gates[0]);
+  ASSERT_NE(gate00, nullptr);
+  EXPECT_EQ(gate00->kind, kGateHd);
+  EXPECT_EQ(gate00->time, 0);
+  EXPECT_EQ(gate00->qubits.size(), 1);
+  EXPECT_EQ(gate00->qubits[0], 0);
+  const auto* gate01 = OpGetAlternative<Gate>(fgate0->gates[1]);
+  ASSERT_NE(gate01, nullptr);
+  EXPECT_EQ(gate01->kind, kGateHd);
+  EXPECT_EQ(gate01->time, 0);
+  EXPECT_EQ(gate01->qubits.size(), 1);
+  EXPECT_EQ(gate01->qubits[0], 1);
+  const auto* gate02 = OpGetAlternative<Gate>(fgate0->gates[2]);
+  ASSERT_NE(gate02, nullptr);
+  EXPECT_EQ(gate02->kind, kGateCZ);
+  EXPECT_EQ(gate02->time, 1);
+  EXPECT_EQ(gate02->qubits.size(), 2);
+  EXPECT_EQ(gate02->qubits[0], 0);
+  EXPECT_EQ(gate02->qubits[1], 1);
 
-  EXPECT_EQ(fused_gates[1].kind, kGateCZ);
-  EXPECT_EQ(fused_gates[1].time, 1);
-  EXPECT_EQ(fused_gates[1].qubits.size(), 2);
-  EXPECT_EQ(fused_gates[1].qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].qubits[1], 3);
-  EXPECT_EQ(fused_gates[1].gates.size(), 4);
-  EXPECT_EQ(fused_gates[1].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[0]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[1]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[1]->time, 0);
-  EXPECT_EQ(fused_gates[1].gates[1]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[1]->qubits[0], 3);
-  EXPECT_EQ(fused_gates[1].gates[2]->kind, kGateCZ);
-  EXPECT_EQ(fused_gates[1].gates[2]->time, 1);
-  EXPECT_EQ(fused_gates[1].gates[2]->qubits.size(), 2);
-  EXPECT_EQ(fused_gates[1].gates[2]->qubits[0], 2);
-  EXPECT_EQ(fused_gates[1].gates[2]->qubits[1], 3);
-  EXPECT_EQ(fused_gates[1].gates[3]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[1].gates[3]->time, 3);
-  EXPECT_EQ(fused_gates[1].gates[3]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[1].gates[3]->qubits[0], 3);
+  const auto* fgate1 = OpGetAlternative<FusedGate>(fused_gates[1]);
+  ASSERT_NE(fgate1, nullptr);
+  EXPECT_EQ(fgate1->kind, kGateCZ);
+  EXPECT_EQ(fgate1->time, 1);
+  EXPECT_EQ(fgate1->qubits.size(), 2);
+  EXPECT_EQ(fgate1->qubits[0], 2);
+  EXPECT_EQ(fgate1->qubits[1], 3);
+  EXPECT_EQ(fgate1->gates.size(), 4);
+  const auto* gate10 = OpGetAlternative<Gate>(fgate1->gates[0]);
+  ASSERT_NE(gate10, nullptr);
+  EXPECT_EQ(gate10->kind, kGateHd);
+  EXPECT_EQ(gate10->time, 0);
+  EXPECT_EQ(gate10->qubits.size(), 1);
+  EXPECT_EQ(gate10->qubits[0], 2);
+  const auto* gate11 = OpGetAlternative<Gate>(fgate1->gates[1]);
+  ASSERT_NE(gate11, nullptr);
+  EXPECT_EQ(gate11->kind, kGateHd);
+  EXPECT_EQ(gate11->time, 0);
+  EXPECT_EQ(gate11->qubits.size(), 1);
+  EXPECT_EQ(gate11->qubits[0], 3);
+  const auto* gate12 = OpGetAlternative<Gate>(fgate1->gates[2]);
+  ASSERT_NE(gate12, nullptr);
+  EXPECT_EQ(gate12->kind, kGateCZ);
+  EXPECT_EQ(gate12->time, 1);
+  EXPECT_EQ(gate12->qubits.size(), 2);
+  EXPECT_EQ(gate12->qubits[0], 2);
+  EXPECT_EQ(gate12->qubits[1], 3);
+  const auto* gate13 = OpGetAlternative<Gate>(fgate1->gates[3]);
+  ASSERT_NE(gate13, nullptr);
+  EXPECT_EQ(gate13->kind, kGateHd);
+  EXPECT_EQ(gate13->time, 3);
+  EXPECT_EQ(gate13->qubits.size(), 1);
+  EXPECT_EQ(gate13->qubits[0], 3);
 
-  EXPECT_EQ(fused_gates[2].kind, kGateHd);
-  EXPECT_EQ(fused_gates[2].time, 0);
-  EXPECT_EQ(fused_gates[2].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].qubits[0], 4);
-  EXPECT_EQ(fused_gates[2].gates.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[2].gates[0]->time, 0);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[2].gates[0]->qubits[0], 4);
+  const auto* fgate2 = OpGetAlternative<FusedGate>(fused_gates[2]);
+  ASSERT_NE(fgate2, nullptr);
+  EXPECT_EQ(fgate2->kind, kGateHd);
+  EXPECT_EQ(fgate2->time, 0);
+  EXPECT_EQ(fgate2->qubits.size(), 1);
+  EXPECT_EQ(fgate2->qubits[0], 4);
+  EXPECT_EQ(fgate2->gates.size(), 1);
+  const auto* gate20 = OpGetAlternative<Gate>(fgate2->gates[0]);
+  ASSERT_NE(gate20, nullptr);
+  EXPECT_EQ(gate20->kind, kGateHd);
+  EXPECT_EQ(gate20->time, 0);
+  EXPECT_EQ(gate20->qubits.size(), 1);
+  EXPECT_EQ(gate20->qubits[0], 4);
 
-  EXPECT_EQ(fused_gates[3].kind, kGateHd);
-  EXPECT_EQ(fused_gates[3].time, 2);
-  EXPECT_EQ(fused_gates[3].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].qubits[0], 2);
-  EXPECT_EQ(fused_gates[3].parent->controlled_by.size(), 3);
-  EXPECT_EQ(fused_gates[3].parent->controlled_by[0], 0);
-  EXPECT_EQ(fused_gates[3].parent->controlled_by[1], 1);
-  EXPECT_EQ(fused_gates[3].parent->controlled_by[2], 4);
-  EXPECT_EQ(fused_gates[3].parent->cmask, 7);
-  EXPECT_EQ(fused_gates[3].gates.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[3].gates[0]->time, 2);
-  EXPECT_EQ(fused_gates[3].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[3].gates[0]->qubits[0], 2);
+  const auto* fgate3 = OpGetAlternative<ControlledGate>(fused_gates[3]);
+  EXPECT_EQ(fgate3->kind, kGateHd);
+  EXPECT_EQ(fgate3->time, 2);
+  EXPECT_EQ(fgate3->qubits.size(), 1);
+  EXPECT_EQ(fgate3->qubits[0], 2);
+  EXPECT_EQ(fgate3->controlled_by.size(), 3);
+  EXPECT_EQ(fgate3->controlled_by[0], 0);
+  EXPECT_EQ(fgate3->controlled_by[1], 1);
+  EXPECT_EQ(fgate3->controlled_by[2], 4);
+  EXPECT_EQ(fgate3->cmask, 7);
 
-  EXPECT_EQ(fused_gates[4].kind, kGateHd);
-  EXPECT_EQ(fused_gates[4].time, 3);
-  EXPECT_EQ(fused_gates[4].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[4].qubits[0], 0);
-  EXPECT_EQ(fused_gates[4].gates.size(), 1);
-  EXPECT_EQ(fused_gates[4].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[4].gates[0]->time, 3);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[4].gates[0]->qubits[0], 0);
+  const auto* fgate4 = OpGetAlternative<FusedGate>(fused_gates[4]);
+  ASSERT_NE(fgate4, nullptr);
+  EXPECT_EQ(fgate4->kind, kGateHd);
+  EXPECT_EQ(fgate4->time, 3);
+  EXPECT_EQ(fgate4->qubits.size(), 1);
+  EXPECT_EQ(fgate4->qubits[0], 0);
+  EXPECT_EQ(fgate4->gates.size(), 1);
+  const auto* gate40 = OpGetAlternative<Gate>(fgate4->gates[0]);
+  ASSERT_NE(gate40, nullptr);
+  EXPECT_EQ(gate40->kind, kGateHd);
+  EXPECT_EQ(gate40->time, 3);
+  EXPECT_EQ(gate40->qubits.size(), 1);
+  EXPECT_EQ(gate40->qubits[0], 0);
 
-  EXPECT_EQ(fused_gates[5].kind, kGateHd);
-  EXPECT_EQ(fused_gates[5].time, 3);
-  EXPECT_EQ(fused_gates[5].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[5].qubits[0], 1);
-  EXPECT_EQ(fused_gates[5].gates.size(), 1);
-  EXPECT_EQ(fused_gates[5].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[5].gates[0]->time, 3);
-  EXPECT_EQ(fused_gates[5].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[5].gates[0]->qubits[0], 1);
+  const auto* fgate5 = OpGetAlternative<FusedGate>(fused_gates[5]);
+  ASSERT_NE(fgate5, nullptr);
+  EXPECT_EQ(fgate5->kind, kGateHd);
+  EXPECT_EQ(fgate5->time, 3);
+  EXPECT_EQ(fgate5->qubits.size(), 1);
+  EXPECT_EQ(fgate5->qubits[0], 1);
+  EXPECT_EQ(fgate5->gates.size(), 1);
+  const auto* gate50 = OpGetAlternative<Gate>(fgate5->gates[0]);
+  ASSERT_NE(gate50, nullptr);
+  EXPECT_EQ(gate50->kind, kGateHd);
+  EXPECT_EQ(gate50->time, 3);
+  EXPECT_EQ(gate50->qubits.size(), 1);
+  EXPECT_EQ(gate50->qubits[0], 1);
 
-  EXPECT_EQ(fused_gates[6].kind, kGateHd);
-  EXPECT_EQ(fused_gates[6].time, 3);
-  EXPECT_EQ(fused_gates[6].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[6].qubits[0], 2);
-  EXPECT_EQ(fused_gates[6].gates.size(), 1);
-  EXPECT_EQ(fused_gates[6].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[6].gates[0]->time, 3);
-  EXPECT_EQ(fused_gates[6].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[6].gates[0]->qubits[0], 2);
+  const auto* fgate6 = OpGetAlternative<FusedGate>(fused_gates[6]);
+  ASSERT_NE(fgate6, nullptr);
+  EXPECT_EQ(fgate6->kind, kGateHd);
+  EXPECT_EQ(fgate6->time, 3);
+  EXPECT_EQ(fgate6->qubits.size(), 1);
+  EXPECT_EQ(fgate6->qubits[0], 2);
+  EXPECT_EQ(fgate6->gates.size(), 1);
+  const auto* gate60 = OpGetAlternative<Gate>(fgate6->gates[0]);
+  ASSERT_NE(gate60, nullptr);
+  EXPECT_EQ(gate60->kind, kGateHd);
+  EXPECT_EQ(gate60->time, 3);
+  EXPECT_EQ(gate60->qubits.size(), 1);
+  EXPECT_EQ(gate60->qubits[0], 2);
 
-  EXPECT_EQ(fused_gates[7].kind, kGateHd);
-  EXPECT_EQ(fused_gates[7].time, 3);
-  EXPECT_EQ(fused_gates[7].qubits.size(), 1);
-  EXPECT_EQ(fused_gates[7].qubits[0], 4);
-  EXPECT_EQ(fused_gates[7].gates.size(), 1);
-  EXPECT_EQ(fused_gates[7].gates[0]->kind, kGateHd);
-  EXPECT_EQ(fused_gates[7].gates[0]->time, 3);
-  EXPECT_EQ(fused_gates[7].gates[0]->qubits.size(), 1);
-  EXPECT_EQ(fused_gates[7].gates[0]->qubits[0], 4);
+  const auto* fgate7 = OpGetAlternative<FusedGate>(fused_gates[7]);
+  ASSERT_NE(fgate7, nullptr);
+  EXPECT_EQ(fgate7->kind, kGateHd);
+  EXPECT_EQ(fgate7->time, 3);
+  EXPECT_EQ(fgate7->qubits.size(), 1);
+  EXPECT_EQ(fgate7->qubits[0], 4);
+  EXPECT_EQ(fgate7->gates.size(), 1);
+  const auto* gate70 = OpGetAlternative<Gate>(fgate7->gates[0]);
+  ASSERT_NE(gate70, nullptr);
+  EXPECT_EQ(gate70->kind, kGateHd);
+  EXPECT_EQ(gate70->time, 3);
+  EXPECT_EQ(gate70->qubits.size(), 1);
+  EXPECT_EQ(gate70->qubits[0], 4);
 }
-
-namespace {
-
-template <typename Gate, typename FusedGate>
-bool TestFusedGates(unsigned num_qubits,
-                    const std::vector<Gate>& gates,
-                    const std::vector<FusedGate>& fused_gates) {
-  std::vector<unsigned> times(num_qubits, 0);
-  std::vector<unsigned> gate_map(gates.size(), 0);
-
-  // Test if gate times are ordered correctly.
-  for (auto g : fused_gates) {
-    if (g.parent->controlled_by.size() > 0 && g.gates.size() > 1) {
-      return false;
-    }
-
-    for (auto p : g.gates) {
-      auto k = (std::size_t(p) - std::size_t(gates.data())) / sizeof(*p);
-
-      if (k >= gate_map.size()) {
-        return false;
-      }
-
-      ++gate_map[k];
-
-      if (p->kind == gate::kMeasurement) {
-        if (g.parent->kind != gate::kMeasurement || g.parent->time != p->time) {
-          return false;
-        }
-      }
-
-      for (auto q : p->qubits) {
-        if (p->time < times[q]) {
-          return false;
-        }
-        times[q] = p->time;
-      }
-
-      for (auto q : p->controlled_by) {
-        if (p->time < times[q]) {
-          return false;
-        }
-        times[q] = p->time;
-      }
-    }
-  }
-
-  // Test if all gates are present only once.
-  for (auto m : gate_map) {
-    if (m != 1) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-}  // namespace
 
 TEST(FuserBasicTest, SmallCircuits) {
-  using Gate = GateQSim<float>;
-  using Fuser = BasicGateFuser<IO, Gate>;
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using Fuser = BasicGateFuser<IO>;
 
   Fuser::Parameter param;
   param.verbosity = 0;
@@ -1179,7 +1499,7 @@ TEST(FuserBasicTest, SmallCircuits) {
       GateGPh<float>::Create(0, -1, 0),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -1193,7 +1513,7 @@ TEST(FuserBasicTest, SmallCircuits) {
       GateGPh<float>::Create(0, -1, 0),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -1207,7 +1527,7 @@ TEST(FuserBasicTest, SmallCircuits) {
       GateGPh<float>::Create(0, -1, 0),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -1216,24 +1536,29 @@ TEST(FuserBasicTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 2;
-    std::vector<Gate> circuit = {
+    std::vector<Operation> circuit = {
       GateZ<float>::Create(0, 0).ControlledBy({1}, {1}),
       GateCZ<float>::Create(1, 0, 1),
       GateGPh<float>::Create(1, -1, 0),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
     EXPECT_EQ(fused_gates.size(), 2);
-    EXPECT_EQ(fused_gates[1].gates[1], &circuit[2]);
+
+    const auto* fgate1 = OpGetAlternative<FusedGate<float>>(fused_gates[1]);
+    const auto* gate11 = OpGetAlternative<Gate>(fgate1->gates[1]);
+    ASSERT_NE(gate11, nullptr);
+    EXPECT_EQ(gate11, OpGetAlternative<Gate>(circuit[2]));
   }
 }
 
 TEST(FuserBasicTest, ValidTimeOrder) {
-  using Gate = GateQSim<float>;
-  using Fuser = BasicGateFuser<IO, Gate>;
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using Fuser = BasicGateFuser<IO>;
 
   Fuser::Parameter param;
   param.verbosity = 0;
@@ -1243,16 +1568,16 @@ TEST(FuserBasicTest, ValidTimeOrder) {
     auto gate1 = GateZ<float>::Create(1, 2);
     auto gate2 = GateZ<float>::Create(2, 5);
 
-    std::vector<Gate> circuit = {
+    std::vector<Operation> circuit = {
       GateCZ<float>::Create(0, 0, 1),
       GateCZ<float>::Create(0, 2, 3),
-      MakeControlledGate({1}, gate1),
+      MakeControlledGate(gate1, {1}),
       GateCZ<float>::Create(0, 4, 5),
       GateCZ<float>::Create(2, 0, 1),
       GateCZ<float>::Create(1, 3, 4),
       GateCZ<float>::Create(2, 2, 3),
       GateCZ<float>::Create(3, 1, 2),
-      MakeControlledGate({4}, gate2),
+      MakeControlledGate(gate2, {4}),
       GateCZ<float>::Create(3, 3, 4),
       GateCZ<float>::Create(5, 0, 1),
       GateCZ<float>::Create(4, 2, 3),
@@ -1260,7 +1585,7 @@ TEST(FuserBasicTest, ValidTimeOrder) {
       GateCZ<float>::Create(4, 6, 7),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    const auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end());
 
     EXPECT_EQ(fused_gates.size(), 14);
@@ -1269,14 +1594,14 @@ TEST(FuserBasicTest, ValidTimeOrder) {
 
   {
     unsigned num_qubits = 6;
-    std::vector<Gate> circuit = {
+    std::vector<Operation> circuit = {
       GateCZ<float>::Create(0, 0, 1),
       GateCZ<float>::Create(0, 2, 3),
       GateCZ<float>::Create(1, 1, 2),
       GateCZ<float>::Create(0, 4, 5),
       GateCZ<float>::Create(1, 3, 4),
-      gate::Measurement<Gate>::Create(2, {0, 1, 2}),
-      gate::Measurement<Gate>::Create(2, {4, 5}),
+      CreateMeasurement(2, {0, 1, 2}),
+      CreateMeasurement(2, {4, 5}),
       GateCZ<float>::Create(3, 0, 1),
       GateCZ<float>::Create(3, 2, 3),
       GateCZ<float>::Create(4, 1, 2),
@@ -1284,7 +1609,7 @@ TEST(FuserBasicTest, ValidTimeOrder) {
       GateCZ<float>::Create(4, 3, 4),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    const auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end());
 
     EXPECT_EQ(fused_gates.size(), 11);
@@ -1302,7 +1627,7 @@ TEST(FuserBasicTest, ValidTimeOrder) {
       GateCZ<float>::Create(1, 5, 0),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    const auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end());
 
     EXPECT_EQ(fused_gates.size(), 6);
@@ -1322,7 +1647,7 @@ TEST(FuserBasicTest, ValidTimeOrder) {
       GateCZ<float>::Create(1, 7, 0),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    const auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end());
 
     EXPECT_EQ(fused_gates.size(), 8);
@@ -1343,7 +1668,7 @@ TEST(FuserBasicTest, ValidTimeOrder) {
     };
 
     std::vector<unsigned> time_boundary = {3};
-    auto fused_gates = Fuser::FuseGates(
+    const auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), time_boundary);
 
     EXPECT_EQ(fused_gates.size(), 6);
@@ -1352,18 +1677,18 @@ TEST(FuserBasicTest, ValidTimeOrder) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<Gate> circuit = {
+    std::vector<Operation> circuit = {
       GateCZ<float>::Create(0, 0, 1),
       GateCZ<float>::Create(0, 2, 3),
       GateCZ<float>::Create(2, 1, 2),
       GateCZ<float>::Create(1, 0, 3),
-      gate::Measurement<Gate>::Create(3, {1, 2}),
+      CreateMeasurement(3, {1, 2}),
       GateCZ<float>::Create(3, 0, 3),
       GateCZ<float>::Create(5, 1, 2),
       GateCZ<float>::Create(4, 0, 3),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    const auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end());
 
     EXPECT_EQ(fused_gates.size(), 7);
@@ -1378,8 +1703,9 @@ TEST(FuserBasicTest, ValidTimeOrder) {
     };
 
     std::vector<unsigned> time_boundary = {1};
-    auto fused_gates = Fuser::FuseGates(param, num_qubits, circuit.begin(),
-                                        circuit.end(), time_boundary, false);
+    const auto fused_gates = Fuser::FuseGates<Gate>(
+        param, num_qubits, circuit.begin(), circuit.end(),
+        time_boundary, false);
 
     EXPECT_EQ(fused_gates.size(), 2);
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -1392,7 +1718,7 @@ TEST(FuserBasicTest, ValidTimeOrder) {
       GateGPh<float>::Create(0, -1, 0),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    const auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -1401,8 +1727,9 @@ TEST(FuserBasicTest, ValidTimeOrder) {
 }
 
 TEST(FuserBasicTest, InvalidTimeOrder) {
-  using Gate = GateQSim<float>;
-  using Fuser = BasicGateFuser<IO, Gate>;
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using Fuser = BasicGateFuser<IO>;
 
   Fuser::Parameter param;
   param.verbosity = 0;
@@ -1414,7 +1741,7 @@ TEST(FuserBasicTest, InvalidTimeOrder) {
       GateCZ<float>::Create(0, 1, 2),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end());
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1429,7 +1756,7 @@ TEST(FuserBasicTest, InvalidTimeOrder) {
       GateCZ<float>::Create(1, 0, 2),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end());
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1445,7 +1772,7 @@ TEST(FuserBasicTest, InvalidTimeOrder) {
     };
 
     std::vector<unsigned> time_boundary = {1};
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), time_boundary);
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1461,7 +1788,7 @@ TEST(FuserBasicTest, InvalidTimeOrder) {
     };
 
     std::vector<unsigned> time_boundary = {2};
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), time_boundary);
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1469,14 +1796,14 @@ TEST(FuserBasicTest, InvalidTimeOrder) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<Gate> circuit = {
+    std::vector<Operation> circuit = {
       GateCZ<float>::Create(0, 0, 1),
       GateCZ<float>::Create(0, 2, 3),
-      gate::Measurement<Gate>::Create(2, {0, 3}),
+      CreateMeasurement(2, {0, 3}),
       GateCZ<float>::Create(1, 1, 2),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end());
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1484,14 +1811,14 @@ TEST(FuserBasicTest, InvalidTimeOrder) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<Gate> circuit = {
+    std::vector<Operation> circuit = {
       GateCZ<float>::Create(0, 0, 1),
       GateCZ<float>::Create(0, 2, 3),
       GateCZ<float>::Create(2, 0, 3),
-      gate::Measurement<Gate>::Create(1, {1, 2}),
+      CreateMeasurement(1, {1, 2}),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end());
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1501,14 +1828,14 @@ TEST(FuserBasicTest, InvalidTimeOrder) {
     unsigned num_qubits = 4;
     auto gate = GateZ<float>::Create(1, 1);
 
-    std::vector<Gate> circuit = {
+    std::vector<Operation> circuit = {
       GateCZ<float>::Create(0, 0, 1),
       GateCZ<float>::Create(0, 2, 3),
       GateCZ<float>::Create(2, 0, 3),
-      MakeControlledGate({3}, gate),
+      MakeControlledGate(gate, {3}),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end());
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1518,14 +1845,14 @@ TEST(FuserBasicTest, InvalidTimeOrder) {
     unsigned num_qubits = 4;
     auto gate = GateZ<float>::Create(2, 1);
 
-    std::vector<Gate> circuit = {
+    std::vector<Operation> circuit = {
       GateCZ<float>::Create(0, 0, 1),
       GateCZ<float>::Create(0, 2, 3),
-      MakeControlledGate({3}, gate),
+      MakeControlledGate(gate, {3}),
       GateCZ<float>::Create(1, 0, 3),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end());
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1539,16 +1866,18 @@ TEST(FuserBasicTest, InvalidTimeOrder) {
     };
 
     std::vector<unsigned> time_boundary = {1};
-    auto fused_gates = Fuser::FuseGates(param, num_qubits, circuit.begin(),
-                                        circuit.end(), time_boundary, false);
+    auto fused_gates = Fuser::FuseGates<Gate>(
+        param, num_qubits, circuit.begin(), circuit.end(),
+        time_boundary, false);
 
     EXPECT_EQ(fused_gates.size(), 0);
   }
 }
 
 TEST(FuserBasicTest, QubitsOutOfRange) {
-  using Gate = GateQSim<float>;
-  using Fuser = BasicGateFuser<IO, Gate>;
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using Fuser = BasicGateFuser<IO>;
 
   Fuser::Parameter param;
   param.verbosity = 0;
@@ -1560,7 +1889,7 @@ TEST(FuserBasicTest, QubitsOutOfRange) {
       GateCZ<float>::Create(0, 1, 2),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1569,12 +1898,13 @@ TEST(FuserBasicTest, QubitsOutOfRange) {
   {
     unsigned num_qubits = 3;
     auto gate = GateZ<float>::Create(0, 2);
-    std::vector<Gate> circuit = {
+
+    std::vector<Operation> circuit = {
       GateCZ<float>::Create(0, 0, 1),
-      MakeControlledGate({3}, gate),
+      MakeControlledGate(gate, {3}),
     };
 
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 0);

--- a/tests/fuser_mqubit_test.cc
+++ b/tests/fuser_mqubit_test.cc
@@ -19,13 +19,17 @@
 #include <utility>
 #include <vector>
 
+#include "fuser_testfixture.h"
+
 #include "gtest/gtest.h"
 
 #include "../lib/formux.h"
+#include "../lib/fuser.h"
 #include "../lib/fuser_mqubit.h"
 #include "../lib/gate.h"
 #include "../lib/gate_appl.h"
 #include "../lib/matrix.h"
+#include "../lib/operation.h"
 #include "../lib/simmux.h"
 
 namespace qsim {
@@ -37,38 +41,15 @@ struct IO {
 
 namespace {
 
-enum DummyGateKind {
-  kGateOther = 0,
-  kMeasurement = gate::kMeasurement,
-};
-
-struct DummyGate {
-  using GateKind = DummyGateKind;
-  using fp_type = float;
-
-  GateKind kind;
-  unsigned time;
-  uint64_t cmask;
-  std::vector<unsigned> qubits;
-  std::vector<unsigned> controlled_by;
-  Matrix<float> matrix;
-  bool unfusible;
-};
-
-DummyGate CreateDummyGate(unsigned time, std::vector<unsigned>&& qubits) {
-  return {kGateOther, time, 0, std::move(qubits), {}, {}, false};
+Gate<float> CreateGate(unsigned time, std::vector<unsigned>&& qubits) {
+  return {0, time, std::move(qubits), {}, {}, false};
 }
 
-DummyGate CreateDummyMeasurementGate(unsigned time,
-                                     std::vector<unsigned>&& qubits) {
-  return {kMeasurement, time, 0, std::move(qubits), {}, {}, false};
-}
-
-DummyGate CreateDummyControlledGate(unsigned time,
-                                    std::vector<unsigned>&& qubits,
-                                    std::vector<unsigned>&& controlled_by) {
-  return {kGateOther, time, 0, std::move(qubits), std::move(controlled_by), {},
-          false};
+ControlledGate<float> CreateControlledGate(
+    unsigned time, std::vector<unsigned>&& qubits,
+    std::vector<unsigned>&& controlled_by) {
+  return Gate<float>{0, time, std::move(qubits), {}, {}, false}.ControlledBy(
+      std::move(controlled_by));
 }
 
 std::vector<unsigned> GenQubits(unsigned num_qubits, std::mt19937& rgen,
@@ -95,34 +76,41 @@ constexpr double p6 = 0.02 + p5;
 constexpr double pc = 0.0075 + p6;
 constexpr double pm = 0.0075 + pc;
 
-constexpr double pu = 0.002;
+constexpr double pd = 0.002;
 
+template <typename OperationD>
 void AddToCircuit(unsigned time,
                   std::uniform_real_distribution<double>& distr,
                   std::mt19937& rgen, unsigned& n,
                   std::vector<unsigned>& available,
-                  std::vector<DummyGate>& circuit) {
+                  std::vector<OperationD>& circuit) {
   double r = distr(rgen);
 
   if (r < p0) {
-    circuit.push_back(CreateDummyGate(time, {}));
+    circuit.push_back(CreateGate(time, {}));
   } else if (r < p1) {
-    circuit.push_back(CreateDummyGate(time, GenQubits(1, rgen, n, available)));
+    circuit.push_back(CreateGate(time, GenQubits(1, rgen, n, available)));
+
+    if (distr(rgen) < pd) {
+      using Gate = qsim::Gate<float>;
+      using DecomposedGate = qsim::DecomposedGate<float>;
+      circuit.back() = DecomposedGate{*OpGetAlternative<Gate>(circuit.back())};
+    }
   } else if (r < p2) {
-    circuit.push_back(CreateDummyGate(time, GenQubits(2, rgen, n, available)));
+    circuit.push_back(CreateGate(time, GenQubits(2, rgen, n, available)));
   } else if (r < p3) {
-    circuit.push_back(CreateDummyGate(time, GenQubits(3, rgen, n, available)));
+    circuit.push_back(CreateGate(time, GenQubits(3, rgen, n, available)));
   } else if (r < p4) {
-    circuit.push_back(CreateDummyGate(time, GenQubits(4, rgen, n, available)));
+    circuit.push_back(CreateGate(time, GenQubits(4, rgen, n, available)));
   } else if (r < p5) {
-    circuit.push_back(CreateDummyGate(time, GenQubits(5, rgen, n, available)));
+    circuit.push_back(CreateGate(time, GenQubits(5, rgen, n, available)));
   } else if (r < p6) {
-    circuit.push_back(CreateDummyGate(time, GenQubits(6, rgen, n, available)));
+    circuit.push_back(CreateGate(time, GenQubits(6, rgen, n, available)));
   } else if (r < pc) {
     auto qs = GenQubits(1 + rgen() % 3, rgen, n, available);
     auto cqs = GenQubits(1 + rgen() % 3, rgen, n, available);
     circuit.push_back(
-        CreateDummyControlledGate(time, std::move(qs), std::move(cqs)));
+        CreateControlledGate(time, std::move(qs), std::move(cqs)));
   } else if (r < pm) {
     unsigned num_mea_gates = 0;
     unsigned max_num_mea_gates = 1 + rgen() % 5;
@@ -131,25 +119,25 @@ void AddToCircuit(unsigned time,
       unsigned k = 1 + rgen() % 12;
       if (k > n) k = n;
       circuit.push_back(
-          CreateDummyMeasurementGate(time, GenQubits(k, rgen, n, available)));
+          CreateMeasurement(time, GenQubits(k, rgen, n, available)));
       ++num_mea_gates;
     }
   }
 
-  if (r < p6 && distr(rgen) < pu) {
-    circuit.back().unfusible = true;
-  }
+  auto& op = circuit.back();
 
-  auto& gate = circuit.back();
-
-  if (gate.kind != gate::kMeasurement) {
-    std::sort(gate.qubits.begin(), gate.qubits.end());
+  if (!OpGetAlternative<Measurement>(op)) {
+    auto& base_op = OpBaseOperation(op);
+    std::sort(base_op.qubits.begin(), base_op.qubits.end());
   }
 }
 
-std::vector<DummyGate> GenerateRandomCircuit1(unsigned num_qubits,
-                                              unsigned depth) {
-  std::vector<DummyGate> circuit;
+auto GenerateRandomCircuit1(unsigned num_qubits, unsigned depth) {
+  using DecomposedGate = qsim::DecomposedGate<float>;
+  using Operation = qsim::Operation<float>;
+  using OperationD = detail::append_to_variant_t<Operation, DecomposedGate>;
+
+  std::vector<OperationD> circuit;
   circuit.reserve(depth);
 
   std::mt19937 rgen(1);
@@ -170,10 +158,13 @@ std::vector<DummyGate> GenerateRandomCircuit1(unsigned num_qubits,
   return circuit;
 }
 
-std::vector<DummyGate> GenerateRandomCircuit2(unsigned num_qubits,
-                                              unsigned depth,
-                                              unsigned max_fused_gate_size) {
-  std::vector<DummyGate> circuit;
+auto GenerateRandomCircuit2(unsigned num_qubits, unsigned depth,
+                            unsigned max_fused_gate_size) {
+  using DecomposedGate = qsim::DecomposedGate<float>;
+  using Operation = qsim::Operation<float>;
+  using OperationD = detail::append_to_variant_t<Operation, DecomposedGate>;
+
+  std::vector<OperationD> circuit;
   circuit.reserve(num_qubits * depth);
 
   std::mt19937 rgen(2);
@@ -196,64 +187,10 @@ std::vector<DummyGate> GenerateRandomCircuit2(unsigned num_qubits,
   return circuit;
 }
 
-template <typename FusedGate>
-bool TestFusedGates(unsigned num_qubits,
-                    const std::vector<DummyGate>& gates,
-                    const std::vector<FusedGate>& fused_gates) {
-  std::vector<unsigned> times(num_qubits, 0);
-  std::vector<unsigned> gate_map(gates.size(), 0);
-
-  // Test if gate times are ordered correctly.
-  for (auto g : fused_gates) {
-    if (g.parent->controlled_by.size() > 0 && g.gates.size() > 1) {
-      return false;
-    }
-
-    for (auto p : g.gates) {
-      auto k = (std::size_t(p) - std::size_t(gates.data())) / sizeof(*p);
-
-      if (k >= gate_map.size()) {
-        return false;
-      }
-
-      ++gate_map[k];
-
-      if (p->kind == gate::kMeasurement) {
-        if (g.parent->kind != gate::kMeasurement || g.parent->time != p->time) {
-          return false;
-        }
-      }
-
-      for (auto q : p->qubits) {
-        if (p->time < times[q]) {
-          return false;
-        }
-        times[q] = p->time;
-      }
-
-      for (auto q : p->controlled_by) {
-        if (p->time < times[q]) {
-          return false;
-        }
-        times[q] = p->time;
-      }
-    }
-  }
-
-  // Test if all gates are present only once.
-  for (auto m : gate_map) {
-    if (m != 1) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 }  // namespace
 
 TEST(FuserMultiQubitTest, RandomCircuit1) {
-  using Fuser = MultiQubitGateFuser<IO, DummyGate>;
+  using Fuser = MultiQubitGateFuser<IO>;
 
   unsigned num_qubits = 30;
   unsigned depth = 100000;
@@ -264,9 +201,11 @@ TEST(FuserMultiQubitTest, RandomCircuit1) {
   Fuser::Parameter param;
   param.verbosity = 0;
 
+  using Operation = decltype(circuit)::value_type;
+
   for (unsigned q = 2; q <= 6; ++q) {
     param.max_fused_size = q;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -274,7 +213,7 @@ TEST(FuserMultiQubitTest, RandomCircuit1) {
 
   for (unsigned q = 2; q <= 6; ++q) {
     param.max_fused_size = q;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(),
         {5000, 7000, 25000, 37000}, false);
 
@@ -283,7 +222,7 @@ TEST(FuserMultiQubitTest, RandomCircuit1) {
 }
 
 TEST(FuserMultiQubitTest, RandomCircuit2) {
-  using Fuser = MultiQubitGateFuser<IO, const DummyGate*>;
+  using Fuser = MultiQubitGateFuser<IO>;
 
   unsigned num_qubits = 40;
   unsigned depth = 6400;
@@ -291,8 +230,10 @@ TEST(FuserMultiQubitTest, RandomCircuit2) {
   // Random circuit of approximately 100000 gates.
   auto circuit = GenerateRandomCircuit2(num_qubits, depth, 6);
 
+  using Operation = decltype(circuit)::value_type;
+
   // Vector of pointers to gates.
-  std::vector<const DummyGate*> pcircuit;
+  std::vector<const Operation*> pcircuit;
   pcircuit.reserve(circuit.size());
 
   for (const auto& gate : circuit) {
@@ -304,7 +245,7 @@ TEST(FuserMultiQubitTest, RandomCircuit2) {
 
   for (unsigned q = 2; q <= 6; ++q) {
     param.max_fused_size = q;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<const Operation*>(
         param, num_qubits, pcircuit.begin(), pcircuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -312,7 +253,7 @@ TEST(FuserMultiQubitTest, RandomCircuit2) {
 
   for (unsigned q = 2; q <= 6; ++q) {
     param.max_fused_size = q;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<const Operation*>(
         param, num_qubits, pcircuit.begin(), pcircuit.end(),
         {300, 700, 2400}, false);
 
@@ -321,7 +262,11 @@ TEST(FuserMultiQubitTest, RandomCircuit2) {
 }
 
 TEST(FuserMultiQubitTest, Simulation) {
-  using Fuser = MultiQubitGateFuser<IO, DummyGate>;
+  using Gate = qsim::Gate<float>;
+  using FusedGate = qsim::FusedGate<float>;
+  using ControlledGate = ControlledGate<float>;
+  using DecomposedGate = qsim::DecomposedGate<float>;
+  using Fuser = MultiQubitGateFuser<IO>;
 
   unsigned num_qubits = 12;
   unsigned depth = 200;
@@ -331,19 +276,35 @@ TEST(FuserMultiQubitTest, Simulation) {
   std::mt19937 rgen(1);
   std::uniform_real_distribution<double> distr(0, 1);
 
-  for (auto& gate : circuit) {
-    if (gate.kind == kMeasurement) continue;
+  for (auto& op : circuit) {
+    if (OpGetAlternative<Measurement>(op)) continue;
 
-    if (gate.controlled_by.size() > 0) {
-      gate.cmask = (uint64_t{1} << gate.controlled_by.size()) - 1;
-    }
+    if (auto* pg = OpGetAlternative<Gate>(op)) {
+      unsigned size = unsigned{1} << (2 * pg->qubits.size() + 1);
+      pg->matrix.reserve(size);
 
-    unsigned size = unsigned{1} << (2 * gate.qubits.size() + 1);
-    gate.matrix.reserve(size);
+      // Random gate matrices.
+      for (unsigned i = 0; i < size; ++i) {
+        pg->matrix.push_back(2 * distr(rgen) - 1);
+      }
+    } else if (auto* pg = OpGetAlternative<DecomposedGate>(op)) {
+      unsigned size = unsigned{1} << (2 * pg->qubits.size() + 1);
+      pg->matrix.reserve(size);
 
-    // Random gate matrices.
-    for (unsigned i = 0; i < size; ++i) {
-      gate.matrix.push_back(2 * distr(rgen) - 1);
+      // Random gate matrices.
+      for (unsigned i = 0; i < size; ++i) {
+        pg->matrix.push_back(2 * distr(rgen) - 1);
+      }
+    } else if (auto* pg = OpGetAlternative<ControlledGate>(op)) {
+      unsigned size = unsigned{1} << (2 * pg->qubits.size() + 1);
+      pg->matrix.reserve(size);
+
+      // Random gate matrices.
+      for (unsigned i = 0; i < size; ++i) {
+        pg->matrix.push_back(2 * distr(rgen) - 1);
+      }
+
+      pg->cmask = (uint64_t{1} << pg->controlled_by.size()) - 1;
     }
   }
 
@@ -370,15 +331,28 @@ TEST(FuserMultiQubitTest, Simulation) {
   for (unsigned q = 2; q <= 6; ++q) {
     state_space.SetStateZero(state1);
 
+    using Operation = decltype(circuit)::value_type;
+
     param.max_fused_size = q;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_ops = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end());
 
-    EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
+    EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_ops));
 
     // Simulate fused gates.
-    for (const auto& gate : fused_gates) {
-      ApplyFusedGate(simulator, gate, state1);
+    for (const auto& op : fused_ops) {
+      if (const auto* pg = OpGetAlternative<FusedGate>(op)) {
+        if (!pg->ParentIsDecomposed()) {
+          ApplyGate(simulator, op, state1);
+        } else {
+          auto fgate = *pg;
+          CalculateFusedMatrix(fgate);
+          ApplyGate(simulator, fgate, state1);
+        }
+      } else {
+        ApplyGate(simulator, op, state1);
+      }
+
       // Renormalize the state to prevent floating point overflow.
       state_space.Multiply(1.0 / std::sqrt(state_space.Norm(state1)), state1);
     }
@@ -391,24 +365,27 @@ TEST(FuserMultiQubitTest, Simulation) {
 }
 
 TEST(FuserMultiQubitTest, SmallCircuits) {
-  using Fuser = MultiQubitGateFuser<IO, DummyGate>;
+  using Gate = qsim::Gate<float>;
+  using FusedGate = qsim::FusedGate<float>;
+  using Operation = qsim::Operation<float>;
+  using Fuser = MultiQubitGateFuser<IO>;
 
   Fuser::Parameter param;
   param.verbosity = 0;
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(1, {1, 2}),
-      CreateDummyGate(2, {0, 1}),
-      CreateDummyGate(2, {2, 3}),
-      CreateDummyGate(3, {1, 2}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(1, {1, 2}),
+      CreateGate(2, {0, 1}),
+      CreateGate(2, {2, 3}),
+      CreateGate(3, {1, 2}),
     };
 
     param.max_fused_size = 4;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -417,18 +394,18 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(1, {1, 2}),
-      CreateDummyControlledGate(1, {0}, {3}),
-      CreateDummyGate(3, {0, 1}),
-      CreateDummyGate(3, {2, 3}),
-      CreateDummyGate(4, {1, 2}),
+    std::vector<Operation> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(1, {1, 2}),
+      CreateControlledGate(1, {0}, {3}),
+      CreateGate(3, {0, 1}),
+      CreateGate(3, {2, 3}),
+      CreateGate(4, {1, 2}),
     };
 
     param.max_fused_size = 4;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -437,21 +414,21 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 6;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(0, {4, 5}),
-      CreateDummyGate(1, {1, 2}),
-      CreateDummyGate(1, {3, 4}),
-      CreateDummyGate(2, {0, 1}),
-      CreateDummyGate(2, {2, 3}),
-      CreateDummyGate(2, {4, 5}),
-      CreateDummyGate(3, {1, 2}),
-      CreateDummyGate(3, {3, 4}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(0, {4, 5}),
+      CreateGate(1, {1, 2}),
+      CreateGate(1, {3, 4}),
+      CreateGate(2, {0, 1}),
+      CreateGate(2, {2, 3}),
+      CreateGate(2, {4, 5}),
+      CreateGate(3, {1, 2}),
+      CreateGate(3, {3, 4}),
     };
 
     param.max_fused_size = 6;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -460,23 +437,23 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 6;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(0, {4, 5}),
-      CreateDummyGate(1, {1, 2}),
-      CreateDummyGate(1, {3, 4}),
-      CreateDummyMeasurementGate(2, {0, 1, 2}),
-      CreateDummyMeasurementGate(2, {4, 5}),
-      CreateDummyGate(3, {0, 1}),
-      CreateDummyGate(3, {2, 3}),
-      CreateDummyGate(3, {4, 5}),
-      CreateDummyGate(4, {1, 2}),
-      CreateDummyGate(4, {3, 4}),
+    std::vector<Operation> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(0, {4, 5}),
+      CreateGate(1, {1, 2}),
+      CreateGate(1, {3, 4}),
+      CreateMeasurement(2, {0, 1, 2}),
+      CreateMeasurement(2, {4, 5}),
+      CreateGate(3, {0, 1}),
+      CreateGate(3, {2, 3}),
+      CreateGate(3, {4, 5}),
+      CreateGate(4, {1, 2}),
+      CreateGate(4, {3, 4}),
     };
 
     param.max_fused_size = 6;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -485,14 +462,14 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1, 2}),
-      CreateDummyGate(1, {2, 3}),
-      CreateDummyGate(2, {1, 2}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1, 2}),
+      CreateGate(1, {2, 3}),
+      CreateGate(2, {1, 2}),
     };
 
     param.max_fused_size = 3;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -501,15 +478,15 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(1, {1, 2}),
-      CreateDummyGate(2, {2, 3}),
-      CreateDummyGate(3, {0, 1, 2}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(1, {1, 2}),
+      CreateGate(2, {2, 3}),
+      CreateGate(3, {0, 1, 2}),
     };
 
     param.max_fused_size = 3;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -518,16 +495,16 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 5;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(1, {1, 2}),
-      CreateDummyGate(2, {2, 3}),
-      CreateDummyGate(3, {3, 4}),
-      CreateDummyGate(4, {0, 1, 2, 3}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(1, {1, 2}),
+      CreateGate(2, {2, 3}),
+      CreateGate(3, {3, 4}),
+      CreateGate(4, {0, 1, 2, 3}),
     };
 
     param.max_fused_size = 3;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -536,17 +513,17 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 6;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(0, {4, 5}),
-      CreateDummyGate(1, {1, 2}),
-      CreateDummyGate(1, {3, 4}),
-      CreateDummyGate(1, {5, 0}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(0, {4, 5}),
+      CreateGate(1, {1, 2}),
+      CreateGate(1, {3, 4}),
+      CreateGate(1, {5, 0}),
     };
 
     param.max_fused_size = 3;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -555,19 +532,19 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 8;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(0, {4, 5}),
-      CreateDummyGate(0, {6, 7}),
-      CreateDummyGate(1, {1, 2}),
-      CreateDummyGate(1, {3, 4}),
-      CreateDummyGate(1, {5, 6}),
-      CreateDummyGate(1, {7, 0}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(0, {4, 5}),
+      CreateGate(0, {6, 7}),
+      CreateGate(1, {1, 2}),
+      CreateGate(1, {3, 4}),
+      CreateGate(1, {5, 6}),
+      CreateGate(1, {7, 0}),
     };
 
     param.max_fused_size = 5;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -576,14 +553,14 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 3;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {1, 2}),
-      CreateDummyGate(1, {0, 1}),
-      CreateDummyGate(2, {1, 2}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {1, 2}),
+      CreateGate(1, {0, 1}),
+      CreateGate(2, {1, 2}),
     };
 
     param.max_fused_size = 3;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -592,14 +569,14 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 3;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(1, {0, 2}),
-      CreateDummyGate(2, {1, 2}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(1, {0, 2}),
+      CreateGate(2, {1, 2}),
     };
 
     param.max_fused_size = 3;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -608,16 +585,16 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 6;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(1, {2, 3}),
-      CreateDummyGate(2, {4, 5}),
-      CreateDummyGate(3, {1, 2}),
-      CreateDummyGate(4, {2, 3, 4}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(1, {2, 3}),
+      CreateGate(2, {4, 5}),
+      CreateGate(3, {1, 2}),
+      CreateGate(4, {2, 3, 4}),
     };
 
     param.max_fused_size = 3;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -626,18 +603,18 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 7;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {1, 6}),
-      CreateDummyGate(1, {0, 1}),
-      CreateDummyGate(1, {4, 5}),
-      CreateDummyGate(2, {1, 2, 3}),
-      CreateDummyGate(2, {5, 6}),
-      CreateDummyGate(3, {3, 4}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {1, 6}),
+      CreateGate(1, {0, 1}),
+      CreateGate(1, {4, 5}),
+      CreateGate(2, {1, 2, 3}),
+      CreateGate(2, {5, 6}),
+      CreateGate(3, {3, 4}),
     };
 
     {
       param.max_fused_size = 3;
-      auto fused_gates = Fuser::FuseGates(
+      auto fused_gates = Fuser::FuseGates<Gate>(
           param, num_qubits, circuit.begin(), circuit.end(), false);
 
       EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -646,7 +623,7 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
     {
       param.max_fused_size = 5;
-      auto fused_gates = Fuser::FuseGates(
+      auto fused_gates = Fuser::FuseGates<Gate>(
           param, num_qubits, circuit.begin(), circuit.end(), false);
 
       EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -659,12 +636,12 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 2;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -673,13 +650,13 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 2;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {}),
-      CreateDummyGate(0, {}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {}),
+      CreateGate(0, {}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -688,13 +665,13 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 2;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -703,49 +680,56 @@ TEST(FuserMultiQubitTest, SmallCircuits) {
 
   {
     unsigned num_qubits = 2;
-    std::vector<DummyGate> circuit = {
-      CreateDummyControlledGate(0, {0}, {1}),
-      CreateDummyGate(1, {0, 1}),
-      CreateDummyGate(1, {}),
+    std::vector<Operation> circuit = {
+      CreateControlledGate(0, {0}, {1}),
+      CreateGate(1, {0, 1}),
+      CreateGate(1, {}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
     EXPECT_EQ(fused_gates.size(), 2);
-    EXPECT_EQ(fused_gates[1].gates[1], &circuit[2]);
+
+    const auto* fgate1 = OpGetAlternative<FusedGate>(fused_gates[1]);
+    ASSERT_NE(fgate1, nullptr);
+    const auto* gate11 = OpGetAlternative<Gate>(fgate1->gates[1]);
+    ASSERT_NE(gate11, nullptr);
+    EXPECT_EQ(gate11, OpGetAlternative<Gate>(circuit[2]));
   }
 }
 
 TEST(FuserMultiQubitTest, ValidTimeOrder) {
-  using Fuser = MultiQubitGateFuser<IO, DummyGate>;
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using Fuser = MultiQubitGateFuser<IO>;
 
   Fuser::Parameter param;
   param.verbosity = 0;
 
   {
     unsigned num_qubits = 8;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyControlledGate(1, {1}, {2}),
-      CreateDummyGate(0, {4, 5}),
-      CreateDummyGate(2, {0, 1}),
-      CreateDummyGate(1, {3, 4}),
-      CreateDummyGate(2, {2, 3}),
-      CreateDummyGate(3, {1, 2}),
-      CreateDummyControlledGate(2, {4}, {5}),
-      CreateDummyGate(3, {3, 4}),
-      CreateDummyGate(5, {0, 1}),
-      CreateDummyGate(4, {2, 3}),
-      CreateDummyGate(5, {4, 5}),
-      CreateDummyGate(4, {6, 7}),
+    std::vector<Operation> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateControlledGate(1, {1}, {2}),
+      CreateGate(0, {4, 5}),
+      CreateGate(2, {0, 1}),
+      CreateGate(1, {3, 4}),
+      CreateGate(2, {2, 3}),
+      CreateGate(3, {1, 2}),
+      CreateControlledGate(2, {4}, {5}),
+      CreateGate(3, {3, 4}),
+      CreateGate(5, {0, 1}),
+      CreateGate(4, {2, 3}),
+      CreateGate(5, {4, 5}),
+      CreateGate(4, {6, 7}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 14);
@@ -754,23 +738,23 @@ TEST(FuserMultiQubitTest, ValidTimeOrder) {
 
   {
     unsigned num_qubits = 6;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(1, {1, 2}),
-      CreateDummyGate(0, {4, 5}),
-      CreateDummyGate(1, {3, 4}),
-      CreateDummyMeasurementGate(2, {0, 1, 2}),
-      CreateDummyMeasurementGate(2, {4, 5}),
-      CreateDummyGate(3, {0, 1}),
-      CreateDummyGate(3, {2, 3}),
-      CreateDummyGate(4, {1, 2}),
-      CreateDummyGate(3, {4, 5}),
-      CreateDummyGate(4, {3, 4}),
+    std::vector<Operation> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(1, {1, 2}),
+      CreateGate(0, {4, 5}),
+      CreateGate(1, {3, 4}),
+      CreateMeasurement(2, {0, 1, 2}),
+      CreateMeasurement(2, {4, 5}),
+      CreateGate(3, {0, 1}),
+      CreateGate(3, {2, 3}),
+      CreateGate(4, {1, 2}),
+      CreateGate(3, {4, 5}),
+      CreateGate(4, {3, 4}),
     };
 
     param.max_fused_size = 6;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 3);
@@ -779,17 +763,17 @@ TEST(FuserMultiQubitTest, ValidTimeOrder) {
 
   {
     unsigned num_qubits = 6;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(1, {1, 2}),
-      CreateDummyGate(0, {4, 5}),
-      CreateDummyGate(1, {3, 4}),
-      CreateDummyGate(1, {5, 0}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(1, {1, 2}),
+      CreateGate(0, {4, 5}),
+      CreateGate(1, {3, 4}),
+      CreateGate(1, {5, 0}),
     };
 
     param.max_fused_size = 3;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 4);
@@ -798,19 +782,19 @@ TEST(FuserMultiQubitTest, ValidTimeOrder) {
 
   {
     unsigned num_qubits = 8;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(0, {4, 5}),
-      CreateDummyGate(1, {1, 2}),
-      CreateDummyGate(1, {3, 4}),
-      CreateDummyGate(0, {6, 7}),
-      CreateDummyGate(1, {5, 6}),
-      CreateDummyGate(1, {7, 0}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(0, {4, 5}),
+      CreateGate(1, {1, 2}),
+      CreateGate(1, {3, 4}),
+      CreateGate(0, {6, 7}),
+      CreateGate(1, {5, 6}),
+      CreateGate(1, {7, 0}),
     };
 
     param.max_fused_size = 5;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 3);
@@ -819,16 +803,16 @@ TEST(FuserMultiQubitTest, ValidTimeOrder) {
 
   {
     unsigned num_qubits = 6;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(1, {2, 3}),
-      CreateDummyGate(3, {1, 2}),
-      CreateDummyGate(2, {4, 5}),
-      CreateDummyGate(4, {2, 3, 4}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(1, {2, 3}),
+      CreateGate(3, {1, 2}),
+      CreateGate(2, {4, 5}),
+      CreateGate(4, {2, 3, 4}),
     };
 
     param.max_fused_size = 3;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 4);
@@ -837,18 +821,18 @@ TEST(FuserMultiQubitTest, ValidTimeOrder) {
 
   {
     unsigned num_qubits = 7;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {1, 6}),
-      CreateDummyGate(1, {0, 1}),
-      CreateDummyGate(2, {1, 2, 3}),
-      CreateDummyGate(1, {4, 5}),
-      CreateDummyGate(3, {3, 4}),
-      CreateDummyGate(2, {5, 6}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {1, 6}),
+      CreateGate(1, {0, 1}),
+      CreateGate(2, {1, 2, 3}),
+      CreateGate(1, {4, 5}),
+      CreateGate(3, {3, 4}),
+      CreateGate(2, {5, 6}),
     };
 
     {
       param.max_fused_size = 3;
-      auto fused_gates = Fuser::FuseGates(
+      auto fused_gates = Fuser::FuseGates<Gate>(
           param, num_qubits, circuit.begin(), circuit.end(), false);
 
       EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -856,7 +840,7 @@ TEST(FuserMultiQubitTest, ValidTimeOrder) {
 
     {
       param.max_fused_size = 5;
-      auto fused_gates = Fuser::FuseGates(
+      auto fused_gates = Fuser::FuseGates<Gate>(
           param, num_qubits, circuit.begin(), circuit.end(), false);
 
       EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -865,23 +849,24 @@ TEST(FuserMultiQubitTest, ValidTimeOrder) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(2, {1, 2}),
-      CreateDummyGate(1, {0, 3}),
-      CreateDummyGate(3, {1, 2}),
-      CreateDummyGate(3, {0, 3}),
-      CreateDummyGate(4, {0, 1}),
-      CreateDummyGate(4, {2, 3}),
-      CreateDummyGate(6, {0, 3}),
-      CreateDummyGate(5, {1, 2}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(2, {1, 2}),
+      CreateGate(1, {0, 3}),
+      CreateGate(3, {1, 2}),
+      CreateGate(3, {0, 3}),
+      CreateGate(4, {0, 1}),
+      CreateGate(4, {2, 3}),
+      CreateGate(6, {0, 3}),
+      CreateGate(5, {1, 2}),
     };
 
     param.max_fused_size = 4;
     std::vector<unsigned> time_boundary = {3};
-    auto fused_gates = Fuser::FuseGates(param, num_qubits, circuit.begin(),
-                                        circuit.end(), time_boundary, false);
+    auto fused_gates = Fuser::FuseGates<Gate>(
+        param, num_qubits, circuit.begin(), circuit.end(),
+        time_boundary, false);
 
     EXPECT_EQ(fused_gates.size(), 2);
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -889,21 +874,21 @@ TEST(FuserMultiQubitTest, ValidTimeOrder) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(2, {1, 2}),
-      CreateDummyGate(1, {0, 3}),
-      CreateDummyMeasurementGate(3, {1, 2}),
-      CreateDummyGate(3, {0, 3}),
-      CreateDummyGate(4, {0, 1}),
-      CreateDummyGate(4, {2, 3}),
-      CreateDummyGate(6, {0, 3}),
-      CreateDummyGate(5, {1, 2}),
+    std::vector<Operation> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(2, {1, 2}),
+      CreateGate(1, {0, 3}),
+      CreateMeasurement(3, {1, 2}),
+      CreateGate(3, {0, 3}),
+      CreateGate(4, {0, 1}),
+      CreateGate(4, {2, 3}),
+      CreateGate(6, {0, 3}),
+      CreateGate(5, {1, 2}),
     };
 
     param.max_fused_size = 4;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 3);
@@ -912,15 +897,16 @@ TEST(FuserMultiQubitTest, ValidTimeOrder) {
 
   {
     unsigned num_qubits = 2;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(1, {0, 1}),
-      CreateDummyGate(2, {}),
+    std::vector<Gate> circuit = {
+      CreateGate(1, {0, 1}),
+      CreateGate(2, {}),
     };
 
     param.max_fused_size = 2;
     std::vector<unsigned> time_boundary = {1};
-    auto fused_gates = Fuser::FuseGates(param, num_qubits, circuit.begin(),
-                                        circuit.end(), time_boundary, false);
+    auto fused_gates = Fuser::FuseGates<Gate>(
+        param, num_qubits, circuit.begin(), circuit.end(),
+        time_boundary, false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
     EXPECT_EQ(fused_gates.size(), 2);
@@ -928,13 +914,13 @@ TEST(FuserMultiQubitTest, ValidTimeOrder) {
 
   {
     unsigned num_qubits = 2;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(1, {0, 1}),
-      CreateDummyGate(0, {}),
+    std::vector<Gate> circuit = {
+      CreateGate(1, {0, 1}),
+      CreateGate(0, {}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -943,20 +929,22 @@ TEST(FuserMultiQubitTest, ValidTimeOrder) {
 }
 
 TEST(FuserMultiQubitTest, InvalidTimeOrder) {
-  using Fuser = MultiQubitGateFuser<IO, DummyGate>;
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using Fuser = MultiQubitGateFuser<IO>;
 
   Fuser::Parameter param;
   param.verbosity = 0;
 
   {
     unsigned num_qubits = 3;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {1, 2}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {1, 2}),
     };
 
     param.max_fused_size = 3;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -964,15 +952,15 @@ TEST(FuserMultiQubitTest, InvalidTimeOrder) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(2, {1, 2}),
-      CreateDummyGate(1, {0, 2}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(2, {1, 2}),
+      CreateGate(1, {0, 2}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -980,49 +968,51 @@ TEST(FuserMultiQubitTest, InvalidTimeOrder) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(2, {0, 3}),
-      CreateDummyGate(1, {1, 2}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(2, {0, 3}),
+      CreateGate(1, {1, 2}),
     };
 
     param.max_fused_size = 2;
     std::vector<unsigned> time_boundary = {1};
-    auto fused_gates = Fuser::FuseGates(param, num_qubits, circuit.begin(),
-                                        circuit.end(), time_boundary, false);
+    auto fused_gates = Fuser::FuseGates<Gate>(
+        param, num_qubits, circuit.begin(), circuit.end(),
+        time_boundary, false);
 
     EXPECT_EQ(fused_gates.size(), 0);
   }
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(2, {0, 3}),
-      CreateDummyGate(1, {1, 2}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(2, {0, 3}),
+      CreateGate(1, {1, 2}),
     };
 
     param.max_fused_size = 2;
     std::vector<unsigned> time_boundary = {2};
-    auto fused_gates = Fuser::FuseGates(param, num_qubits, circuit.begin(),
-                                        circuit.end(), time_boundary, false);
+    auto fused_gates = Fuser::FuseGates<Gate>(
+        param, num_qubits, circuit.begin(), circuit.end(),
+        time_boundary, false);
 
     EXPECT_EQ(fused_gates.size(), 0);
   }
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(2, {0, 3}),
-      CreateDummyMeasurementGate(1, {1, 2}),
+    std::vector<Operation> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(2, {0, 3}),
+      CreateMeasurement(1, {1, 2}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1030,15 +1020,15 @@ TEST(FuserMultiQubitTest, InvalidTimeOrder) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyMeasurementGate(2, {0, 3}),
-      CreateDummyGate(1, {1, 2}),
+    std::vector<Operation> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateMeasurement(2, {0, 3}),
+      CreateGate(1, {1, 2}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1046,15 +1036,15 @@ TEST(FuserMultiQubitTest, InvalidTimeOrder) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyGate(2, {0, 3}),
-      CreateDummyControlledGate(1, {1}, {3}),
+    std::vector<Operation> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateGate(2, {0, 3}),
+      CreateControlledGate(1, {1}, {3}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1062,15 +1052,15 @@ TEST(FuserMultiQubitTest, InvalidTimeOrder) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyGate(0, {2, 3}),
-      CreateDummyControlledGate(2, {1}, {3}),
-      CreateDummyGate(1, {0, 3}),
+    std::vector<Operation> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateGate(0, {2, 3}),
+      CreateControlledGate(2, {1}, {3}),
+      CreateGate(1, {0, 3}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1078,35 +1068,38 @@ TEST(FuserMultiQubitTest, InvalidTimeOrder) {
 
   {
     unsigned num_qubits = 2;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(1, {0, 1}),
-      CreateDummyGate(0, {}),
+    std::vector<Gate> circuit = {
+      CreateGate(1, {0, 1}),
+      CreateGate(0, {}),
     };
 
     param.max_fused_size = 2;
     std::vector<unsigned> time_boundary = {1};
-    auto fused_gates = Fuser::FuseGates(param, num_qubits, circuit.begin(),
-                                        circuit.end(), time_boundary, false);
+    auto fused_gates = Fuser::FuseGates<Gate>(
+        param, num_qubits, circuit.begin(), circuit.end(),
+        time_boundary, false);
 
     EXPECT_EQ(fused_gates.size(), 0);
   }
 }
 
 TEST(FuserMultiQubitTest, QubitsOutOfRange) {
-  using Fuser = MultiQubitGateFuser<IO, DummyGate>;
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using Fuser = MultiQubitGateFuser<IO>;
 
   Fuser::Parameter param;
   param.verbosity = 0;
 
   {
     unsigned num_qubits = 3;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 3}),
-      CreateDummyGate(0, {1, 2}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 3}),
+      CreateGate(0, {1, 2}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1114,13 +1107,13 @@ TEST(FuserMultiQubitTest, QubitsOutOfRange) {
 
   {
     unsigned num_qubits = 3;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 1}),
-      CreateDummyControlledGate(0, {2}, {3}),
+    std::vector<Operation> circuit = {
+      CreateGate(0, {0, 1}),
+      CreateControlledGate(0, {2}, {3}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 0);
@@ -1128,9 +1121,11 @@ TEST(FuserMultiQubitTest, QubitsOutOfRange) {
 }
 
 TEST(FuserMultiQubitTest, OrphanedGates) {
-  using Fuser = MultiQubitGateFuser<IO, DummyGate>;
+  using Gate = qsim::Gate<float>;
+  using Operation = qsim::Operation<float>;
+  using Fuser = MultiQubitGateFuser<IO>;
 
-  std::vector<DummyGate> circuit;
+  std::vector<Gate> circuit;
   circuit.reserve(6);
 
   Fuser::Parameter param;
@@ -1140,12 +1135,12 @@ TEST(FuserMultiQubitTest, OrphanedGates) {
     circuit.resize(0);
 
     for (unsigned q = 0; q < num_qubits; ++q) {
-      circuit.push_back(CreateDummyGate(0, {q}));
+      circuit.push_back(CreateGate(0, {q}));
     }
 
     for (unsigned f = 2; f <= num_qubits; ++f) {
       param.max_fused_size = f;
-      auto fused_gates = Fuser::FuseGates(
+      auto fused_gates = Fuser::FuseGates<Gate>(
           param, num_qubits, circuit.begin(), circuit.end(), false);
 
       EXPECT_TRUE(TestFusedGates(num_qubits, circuit, fused_gates));
@@ -1155,16 +1150,16 @@ TEST(FuserMultiQubitTest, OrphanedGates) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0}),
-      CreateDummyGate(0, {1}),
-      CreateDummyGate(0, {2}),
-      CreateDummyGate(0, {3}),
-      CreateDummyGate(1, {0, 3}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0}),
+      CreateGate(0, {1}),
+      CreateGate(0, {2}),
+      CreateGate(0, {3}),
+      CreateGate(1, {0, 3}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 2);
@@ -1172,16 +1167,16 @@ TEST(FuserMultiQubitTest, OrphanedGates) {
 
   {
     unsigned num_qubits = 4;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0, 3}),
-      CreateDummyGate(1, {0}),
-      CreateDummyGate(1, {1}),
-      CreateDummyGate(1, {2}),
-      CreateDummyGate(1, {3}),
+    std::vector<Gate> circuit = {
+      CreateGate(0, {0, 3}),
+      CreateGate(1, {0}),
+      CreateGate(1, {1}),
+      CreateGate(1, {2}),
+      CreateGate(1, {3}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Gate>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 2);
@@ -1189,13 +1184,13 @@ TEST(FuserMultiQubitTest, OrphanedGates) {
 
   {
     unsigned num_qubits = 3;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0}),
-      CreateDummyControlledGate(0, {1}, {2}),
+    std::vector<Operation> circuit = {
+      CreateGate(0, {0}),
+      CreateControlledGate(0, {1}, {2}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 2);
@@ -1203,13 +1198,13 @@ TEST(FuserMultiQubitTest, OrphanedGates) {
 
   {
     unsigned num_qubits = 3;
-    std::vector<DummyGate> circuit = {
-      CreateDummyGate(0, {0}),
-      CreateDummyMeasurementGate(0, {2}),
+    std::vector<Operation> circuit = {
+      CreateGate(0, {0}),
+      CreateMeasurement(0, {2}),
     };
 
     param.max_fused_size = 2;
-    auto fused_gates = Fuser::FuseGates(
+    auto fused_gates = Fuser::FuseGates<Operation>(
         param, num_qubits, circuit.begin(), circuit.end(), false);
 
     EXPECT_EQ(fused_gates.size(), 2);

--- a/tests/fuser_testfixture.h
+++ b/tests/fuser_testfixture.h
@@ -1,0 +1,191 @@
+// Copyright 2019 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUSER_TESTFIXTURE_H_
+#define FUSER_TESTFIXTURE_H_
+
+#include <algorithm>
+#include <map>
+#include <vector>
+#include <type_traits>
+
+#include "gtest/gtest.h"
+
+#include "../lib/gate.h"
+#include "../lib/operation.h"
+#include "../lib/operation_base.h"
+
+namespace qsim {
+
+template <typename Operation, typename Gate>
+bool TestGate(const std::vector<Operation>& ops, const Gate& gate,
+              std::vector<unsigned>& op_map) {
+  unsigned k = (std::size_t(&gate) - std::size_t(ops.data())) / sizeof(ops[0]);
+
+  if (op_map[k] != 0) {
+    return false;
+  } else {
+    op_map[k] = 1;
+    return true;
+  }
+}
+
+template <typename Operation, typename Map>
+bool TestMeasurement(const std::vector<Operation>& ops,
+                     const Measurement& mea, std::vector<unsigned>& op_map,
+                     const Map& mea_qubits, const Map& mea_at_time) {
+  std::vector<unsigned> qubits0;
+  qubits0.reserve(64);
+
+  if (std::size_t(&mea) >= std::size_t(ops.data())
+      && std::size_t(&mea) <= std::size_t(&ops.back())) {
+    unsigned k = (std::size_t(&mea) - std::size_t(ops.data())) / sizeof(ops[0]);
+
+    if (op_map[k] != 0) {
+      return false;
+    } else {
+      op_map[k] = 1;
+      return true;
+    }
+  }
+
+  auto it1 = mea_at_time.find(mea.time);
+  if (it1 == mea_at_time.end()) {
+    return false;
+  }
+
+  const auto& indices = it1->second;
+  for (unsigned i : indices) {
+    if (op_map[i] != 0) {
+      return false;
+    } else {
+      op_map[i] = 1;
+    }
+  }
+
+  std::vector<unsigned> qubits = mea.qubits;
+  std::sort(qubits.begin(), qubits.end());
+
+  auto it2 = mea_qubits.find(mea.time);
+  return it2 != mea_qubits.end() && qubits == it2->second;
+}
+
+template <typename Operation, typename OperationF>
+bool TestFusedGates(unsigned num_qubits,
+                    const std::vector<Operation>& ops,
+                    const std::vector<OperationF>& fused_ops) {
+  using Gate = qsim::Gate<float>;
+  using ControlledGate = qsim::ControlledGate<float>;
+  using DecomposedGate = qsim::DecomposedGate<float>;
+  using FusedGate = qsim::FusedGate<float>;
+
+  std::vector<unsigned> times(num_qubits, 0);
+  std::vector<unsigned> op_map(ops.size(), 0);
+
+  std::map<unsigned, std::vector<unsigned>> mea_qubits;
+  std::map<unsigned, std::vector<unsigned>> mea_at_time;
+
+  for (unsigned i = 0; i < ops.size(); ++i) {
+    const auto& op = ops[i];
+
+    if (const auto* pg = OpGetAlternative<Measurement>(op)) {
+      auto& qubits = mea_qubits[pg->time];
+      if (qubits.size() == 0) {
+        qubits.reserve(8);
+      }
+
+      for (auto q : pg->qubits) {
+        qubits.push_back(q);
+      }
+
+      auto& indices = mea_at_time[pg->time];
+      if (indices.size() == 0) {
+        indices.reserve(4);
+      }
+
+      indices.push_back(i);
+    }
+  }
+
+  for (auto it = mea_qubits.begin(); it != mea_qubits.end(); ++it) {
+    std::sort(it->second.begin(), it->second.end());
+  }
+
+  for (const auto& op : fused_ops) {
+    if (const auto* pg = OpGetAlternative<FusedGate>(op)) {
+      for (const auto& pv : pg->gates) {
+        if (const auto* pg = OpGetAlternative<Gate>(pv)) {
+          if (!TestGate(ops, *pg, op_map)) {
+            return false;
+          }
+
+          for (auto q : pg->qubits) {
+            if (pg->time < times[q]) {
+              return false;
+            }
+            times[q] = pg->time;
+          }
+        } else if (const auto* pg = OpGetAlternative<DecomposedGate>(pv)) {
+          if (!TestGate(ops, *pg, op_map)) {
+            return false;
+          }
+
+          for (auto q : pg->qubits) {
+            if (pg->time < times[q]) {
+              return false;
+            }
+            times[q] = pg->time;
+          }
+        }
+      }
+    } else if (const auto* pg = OpGetAlternative<Measurement>(op)) {
+      // Measurements can be fused or unfused.
+
+      if (!TestMeasurement(ops, *pg, op_map, mea_qubits, mea_at_time)) {
+        return false;
+      }
+    } else if (const auto* pg = OpGetAlternative<ControlledGate>(op)) {
+      if (!TestGate(ops, *pg, op_map)) {
+        return false;
+      }
+
+      for (auto q : pg->qubits) {
+        if (pg->time < times[q]) {
+          return false;
+        }
+        times[q] = pg->time;
+      }
+
+      for (auto q : pg->controlled_by) {
+        if (pg->time < times[q]) {
+          return false;
+        }
+        times[q] = pg->time;
+      }
+    }
+  }
+
+  // Test if all gates are present only once.
+  for (auto m : op_map) {
+    if (m != 1) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+}  // namespace qsim
+
+#endif  // FUSER_TESTFIXTURE_H_

--- a/tests/gates_cirq_testfixture.h
+++ b/tests/gates_cirq_testfixture.h
@@ -21,148 +21,149 @@
 
 #include "../lib/circuit.h"
 #include "../lib/gates_cirq.h"
+#include "../lib/operation.h"
 
 namespace qsim {
 
 namespace CirqCircuit1 {
 
 template <typename fp_type>
-Circuit<Cirq::GateCirq<fp_type>> GetCircuit(bool qsim) {
-  Circuit<Cirq::GateCirq<fp_type>> circuit{4, {}};
-  circuit.gates.reserve(128);
+Circuit<Operation<fp_type>> GetCircuit(bool qsim) {
+  Circuit<Operation<fp_type>> circuit{4, {}};
+  circuit.ops.reserve(128);
 
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(0, 0));
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(0, 1));
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(0, 2));
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(0, 3));
+  circuit.ops.push_back(Cirq::H<fp_type>::Create(0, 0));
+  circuit.ops.push_back(Cirq::H<fp_type>::Create(0, 1));
+  circuit.ops.push_back(Cirq::H<fp_type>::Create(0, 2));
+  circuit.ops.push_back(Cirq::H<fp_type>::Create(0, 3));
 
-  circuit.gates.emplace_back(Cirq::T<fp_type>::Create(1, 0));
-  circuit.gates.emplace_back(Cirq::T<fp_type>::Create(1, 1));
-  circuit.gates.emplace_back(Cirq::T<fp_type>::Create(1, 2));
-  circuit.gates.emplace_back(Cirq::T<fp_type>::Create(1, 3));
+  circuit.ops.push_back(Cirq::T<fp_type>::Create(1, 0));
+  circuit.ops.push_back(Cirq::T<fp_type>::Create(1, 1));
+  circuit.ops.push_back(Cirq::T<fp_type>::Create(1, 2));
+  circuit.ops.push_back(Cirq::T<fp_type>::Create(1, 3));
 
-  circuit.gates.emplace_back(
+  circuit.ops.push_back(
       Cirq::CZPowGate<fp_type>::Create(2, 0, 1, 0.7, 0.2));
-  circuit.gates.emplace_back(
+  circuit.ops.push_back(
       Cirq::CXPowGate<fp_type>::Create(2, 2, 3, 1.2, 0.4));
 
-  circuit.gates.emplace_back(Cirq::XPowGate<fp_type>::Create(3, 0, 0.3, 1.1));
-  circuit.gates.emplace_back(Cirq::YPowGate<fp_type>::Create(3, 1, 0.4, 1.0));
-  circuit.gates.emplace_back(Cirq::ZPowGate<fp_type>::Create(3, 2, 0.5, 0.9));
-  circuit.gates.emplace_back(Cirq::HPowGate<fp_type>::Create(3, 3, 0.6, 0.8));
+  circuit.ops.push_back(Cirq::XPowGate<fp_type>::Create(3, 0, 0.3, 1.1));
+  circuit.ops.push_back(Cirq::YPowGate<fp_type>::Create(3, 1, 0.4, 1.0));
+  circuit.ops.push_back(Cirq::ZPowGate<fp_type>::Create(3, 2, 0.5, 0.9));
+  circuit.ops.push_back(Cirq::HPowGate<fp_type>::Create(3, 3, 0.6, 0.8));
 
-  circuit.gates.emplace_back(Cirq::CX<fp_type>::Create(4, 0, 2));
-  circuit.gates.emplace_back(Cirq::CZ<fp_type>::Create(4, 1, 3));
+  circuit.ops.push_back(Cirq::CX<fp_type>::Create(4, 0, 2));
+  circuit.ops.push_back(Cirq::CZ<fp_type>::Create(4, 1, 3));
 
-  circuit.gates.emplace_back(Cirq::X<fp_type>::Create(5, 0));
-  circuit.gates.emplace_back(Cirq::Y<fp_type>::Create(5, 1));
-  circuit.gates.emplace_back(Cirq::Z<fp_type>::Create(5, 2));
-  circuit.gates.emplace_back(Cirq::S<fp_type>::Create(5, 3));
+  circuit.ops.push_back(Cirq::X<fp_type>::Create(5, 0));
+  circuit.ops.push_back(Cirq::Y<fp_type>::Create(5, 1));
+  circuit.ops.push_back(Cirq::Z<fp_type>::Create(5, 2));
+  circuit.ops.push_back(Cirq::S<fp_type>::Create(5, 3));
 
-  circuit.gates.emplace_back(
+  circuit.ops.push_back(
       Cirq::XXPowGate<fp_type>::Create(6, 0, 1, 0.4, 0.7));
-  circuit.gates.emplace_back(
+  circuit.ops.push_back(
       Cirq::YYPowGate<fp_type>::Create(6, 2, 3, 0.8, 0.5));
 
-  circuit.gates.emplace_back(Cirq::I1<fp_type>::Create(7, 0));
-  circuit.gates.emplace_back(Cirq::I1<fp_type>::Create(7, 1));
-  circuit.gates.emplace_back(Cirq::I2<fp_type>::Create(7, 2, 3));
+  circuit.ops.push_back(Cirq::I1<fp_type>::Create(7, 0));
+  circuit.ops.push_back(Cirq::I1<fp_type>::Create(7, 1));
+  circuit.ops.push_back(Cirq::I2<fp_type>::Create(7, 2, 3));
 
-  circuit.gates.emplace_back(Cirq::rx<fp_type>::Create(8, 0, 0.7));
-  circuit.gates.emplace_back(Cirq::ry<fp_type>::Create(8, 1, 0.2));
-  circuit.gates.emplace_back(Cirq::rz<fp_type>::Create(8, 2, 0.4));
-  circuit.gates.emplace_back(
+  circuit.ops.push_back(Cirq::rx<fp_type>::Create(8, 0, 0.7));
+  circuit.ops.push_back(Cirq::ry<fp_type>::Create(8, 1, 0.2));
+  circuit.ops.push_back(Cirq::rz<fp_type>::Create(8, 2, 0.4));
+  circuit.ops.push_back(
       Cirq::PhasedXPowGate<fp_type>::Create(8, 3, 0.8, 0.6, 0.3));
 
-  circuit.gates.emplace_back(
+  circuit.ops.push_back(
       Cirq::ZZPowGate<fp_type>::Create(9, 0, 2, 0.3, 1.3));
-  circuit.gates.emplace_back(
+  circuit.ops.push_back(
       Cirq::ISwapPowGate<fp_type>::Create(9, 1, 3, 0.6, 1.2));
 
-  circuit.gates.emplace_back(Cirq::XPowGate<fp_type>::Create(10, 0, 0.1, 0.9));
-  circuit.gates.emplace_back(Cirq::YPowGate<fp_type>::Create(10, 1, 0.2, 1.0));
-  circuit.gates.emplace_back(Cirq::ZPowGate<fp_type>::Create(10, 2, 0.3, 1.1));
-  circuit.gates.emplace_back(Cirq::HPowGate<fp_type>::Create(10, 3, 0.4, 1.2));
+  circuit.ops.push_back(Cirq::XPowGate<fp_type>::Create(10, 0, 0.1, 0.9));
+  circuit.ops.push_back(Cirq::YPowGate<fp_type>::Create(10, 1, 0.2, 1.0));
+  circuit.ops.push_back(Cirq::ZPowGate<fp_type>::Create(10, 2, 0.3, 1.1));
+  circuit.ops.push_back(Cirq::HPowGate<fp_type>::Create(10, 3, 0.4, 1.2));
 
-  circuit.gates.emplace_back(
+  circuit.ops.push_back(
       Cirq::SwapPowGate<fp_type>::Create(11, 0, 1, 0.2, 0.9));
-  circuit.gates.emplace_back(
+  circuit.ops.push_back(
       Cirq::PhasedISwapPowGate<fp_type>::Create(11, 2, 3, 0.8, 0.6));
 
-  circuit.gates.emplace_back(
+  circuit.ops.push_back(
       Cirq::PhasedXZGate<fp_type>::Create(12, 0, 0.2, 0.3, 1.4));
-  circuit.gates.emplace_back(Cirq::T<fp_type>::Create(12, 1));
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(12, 2));
-  circuit.gates.emplace_back(Cirq::S<fp_type>::Create(12, 3));
+  circuit.ops.push_back(Cirq::T<fp_type>::Create(12, 1));
+  circuit.ops.push_back(Cirq::H<fp_type>::Create(12, 2));
+  circuit.ops.push_back(Cirq::S<fp_type>::Create(12, 3));
 
-  circuit.gates.emplace_back(Cirq::SWAP<fp_type>::Create(13, 0, 2));
-  circuit.gates.emplace_back(Cirq::XX<fp_type>::Create(13, 1, 3));
+  circuit.ops.push_back(Cirq::SWAP<fp_type>::Create(13, 0, 2));
+  circuit.ops.push_back(Cirq::XX<fp_type>::Create(13, 1, 3));
 
-  circuit.gates.emplace_back(Cirq::rx<fp_type>::Create(14, 0, 0.8));
-  circuit.gates.emplace_back(Cirq::ry<fp_type>::Create(14, 1, 0.9));
-  circuit.gates.emplace_back(Cirq::rz<fp_type>::Create(14, 2, 1.2));
-  circuit.gates.emplace_back(Cirq::T<fp_type>::Create(14, 3));
+  circuit.ops.push_back(Cirq::rx<fp_type>::Create(14, 0, 0.8));
+  circuit.ops.push_back(Cirq::ry<fp_type>::Create(14, 1, 0.9));
+  circuit.ops.push_back(Cirq::rz<fp_type>::Create(14, 2, 1.2));
+  circuit.ops.push_back(Cirq::T<fp_type>::Create(14, 3));
 
-  circuit.gates.emplace_back(Cirq::YY<fp_type>::Create(15, 0, 1));
-  circuit.gates.emplace_back(Cirq::ISWAP<fp_type>::Create(15, 2, 3));
+  circuit.ops.push_back(Cirq::YY<fp_type>::Create(15, 0, 1));
+  circuit.ops.push_back(Cirq::ISWAP<fp_type>::Create(15, 2, 3));
 
-  circuit.gates.emplace_back(Cirq::T<fp_type>::Create(16, 0));
-  circuit.gates.emplace_back(Cirq::Z<fp_type>::Create(16, 1));
-  circuit.gates.emplace_back(Cirq::Y<fp_type>::Create(16, 2));
-  circuit.gates.emplace_back(Cirq::X<fp_type>::Create(16, 3));
+  circuit.ops.push_back(Cirq::T<fp_type>::Create(16, 0));
+  circuit.ops.push_back(Cirq::Z<fp_type>::Create(16, 1));
+  circuit.ops.push_back(Cirq::Y<fp_type>::Create(16, 2));
+  circuit.ops.push_back(Cirq::X<fp_type>::Create(16, 3));
 
-  circuit.gates.emplace_back(
+  circuit.ops.push_back(
       Cirq::FSimGate<fp_type>::Create(17, 0, 2, 0.3, 1.7));
-  circuit.gates.emplace_back(Cirq::ZZ<fp_type>::Create(17, 1, 3));
+  circuit.ops.push_back(Cirq::ZZ<fp_type>::Create(17, 1, 3));
 
   if (qsim) {
-    circuit.gates.emplace_back(Cirq::ry<fp_type>::Create(18, 0, 1.3));
-    circuit.gates.emplace_back(Cirq::rz<fp_type>::Create(18, 1, 0.4));
-    circuit.gates.emplace_back(Cirq::rx<fp_type>::Create(18, 2, 0.7));
-    circuit.gates.emplace_back(Cirq::S<fp_type>::Create(18, 3));
-    circuit.gates.emplace_back(
+    circuit.ops.push_back(Cirq::ry<fp_type>::Create(18, 0, 1.3));
+    circuit.ops.push_back(Cirq::rz<fp_type>::Create(18, 1, 0.4));
+    circuit.ops.push_back(Cirq::rx<fp_type>::Create(18, 2, 0.7));
+    circuit.ops.push_back(Cirq::S<fp_type>::Create(18, 3));
+    circuit.ops.push_back(
         Cirq::GlobalPhaseGate<fp_type>::Create(18, -1, 0));
 
-    circuit.gates.emplace_back(Cirq::I<fp_type>::Create(19, {0, 1, 2, 3}));
+    circuit.ops.push_back(Cirq::I<fp_type>::Create(19, {0, 1, 2, 3}));
 
-    circuit.gates.emplace_back(
+    circuit.ops.push_back(
         Cirq::CCZPowGate<fp_type>::Create(20, 2, 0, 1, 0.7, 0.3));
 
-    circuit.gates.emplace_back(Cirq::CCXPowGate<fp_type>::Create(
+    circuit.ops.push_back(Cirq::CCXPowGate<fp_type>::Create(
         21, 3, 1, 0, 0.4, 0.6).ControlledBy({2}, {0}));
 
-    circuit.gates.emplace_back(Cirq::rx<fp_type>::Create(22, 0, 0.3));
-    circuit.gates.emplace_back(Cirq::ry<fp_type>::Create(22, 1, 0.5));
-    circuit.gates.emplace_back(Cirq::rz<fp_type>::Create(22, 2, 0.7));
-    circuit.gates.emplace_back(Cirq::rx<fp_type>::Create(22, 3, 0.9));
+    circuit.ops.push_back(Cirq::rx<fp_type>::Create(22, 0, 0.3));
+    circuit.ops.push_back(Cirq::ry<fp_type>::Create(22, 1, 0.5));
+    circuit.ops.push_back(Cirq::rz<fp_type>::Create(22, 2, 0.7));
+    circuit.ops.push_back(Cirq::rx<fp_type>::Create(22, 3, 0.9));
 
-    circuit.gates.emplace_back(
+    circuit.ops.push_back(
         Cirq::TwoQubitDiagonalGate<fp_type>::Create(23, 0, 1,
                                                     {0.1f, 0.2f, 0.3f, 0.4f}));
 
-    circuit.gates.emplace_back(
+    circuit.ops.push_back(
         Cirq::ThreeQubitDiagonalGate<fp_type>::Create(
             24, 1, 2, 3, {0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.2, 1.3}));
 
-    circuit.gates.emplace_back(Cirq::CSwapGate<fp_type>::Create(25, 0, 3, 1));
+    circuit.ops.push_back(Cirq::CSwapGate<fp_type>::Create(25, 0, 3, 1));
 
-    circuit.gates.emplace_back(Cirq::rz<fp_type>::Create(26, 0, 0.6));
-    circuit.gates.emplace_back(Cirq::rx<fp_type>::Create(26, 1, 0.7));
-    circuit.gates.emplace_back(Cirq::ry<fp_type>::Create(26, 2, 0.8));
-    circuit.gates.emplace_back(Cirq::rz<fp_type>::Create(26, 3, 0.9));
+    circuit.ops.push_back(Cirq::rz<fp_type>::Create(26, 0, 0.6));
+    circuit.ops.push_back(Cirq::rx<fp_type>::Create(26, 1, 0.7));
+    circuit.ops.push_back(Cirq::ry<fp_type>::Create(26, 2, 0.8));
+    circuit.ops.push_back(Cirq::rz<fp_type>::Create(26, 3, 0.9));
 
-    circuit.gates.emplace_back(Cirq::TOFFOLI<fp_type>::Create(27, 3, 2, 0));
+    circuit.ops.push_back(Cirq::TOFFOLI<fp_type>::Create(27, 3, 2, 0));
 
-    circuit.gates.emplace_back(Cirq::FREDKIN<fp_type>::Create(28, 1, 3, 2));
+    circuit.ops.push_back(Cirq::FREDKIN<fp_type>::Create(28, 1, 3, 2));
 
     Matrix<fp_type> m40 = {0, 0, -0.5, -0.5, -0.5, -0.5, 0, 0,
                            0.5, -0.5, 0, 0, 0, 0, -0.5, 0.5,
                            0.5, -0.5, 0, 0, 0, 0, 0.5, -0.5,
                            0, 0, -0.5, -0.5, 0.5, 0.5, 0, 0};
 
-    circuit.gates.emplace_back(
+    circuit.ops.push_back(
         Cirq::MatrixGate2<fp_type>::Create(51, 0, 1, m40));
-    circuit.gates.emplace_back(
+    circuit.ops.push_back(
         Cirq::MatrixGate<fp_type>::Create(51, {2, 3},
                                           {0.5, -0.5, 0, 0, 0, 0, -0.5, 0.5,
                                            0, 0, 0.5, -0.5, -0.5, 0.5, 0, 0,
@@ -173,19 +174,19 @@ Circuit<Cirq::GateCirq<fp_type>> GetCircuit(bool qsim) {
   Matrix<fp_type> m20 = {1, 0, 0, 0, 0, 0, 0, 1};
   Matrix<fp_type> m21 = {0, 0, 0, -1, 0, 1, 0, 0};
   Matrix<fp_type> m22 = {0, 0, 1, 0, 1, 0, 0, 0};
-  circuit.gates.emplace_back(Cirq::MatrixGate1<fp_type>::Create(52, 0, m20));
-  circuit.gates.emplace_back(Cirq::MatrixGate1<fp_type>::Create(52, 1, m21));
-  circuit.gates.emplace_back(Cirq::MatrixGate1<fp_type>::Create(52, 2, m22));
-  circuit.gates.emplace_back(
+  circuit.ops.push_back(Cirq::MatrixGate1<fp_type>::Create(52, 0, m20));
+  circuit.ops.push_back(Cirq::MatrixGate1<fp_type>::Create(52, 1, m21));
+  circuit.ops.push_back(Cirq::MatrixGate1<fp_type>::Create(52, 2, m22));
+  circuit.ops.push_back(
       Cirq::MatrixGate1<fp_type>::Create(52, 3, {1, 0, 0, 0, 0, 0, -1, 0}));
 
-  circuit.gates.emplace_back(Cirq::riswap<fp_type>::Create(53, 0, 1, 0.7));
-  circuit.gates.emplace_back(Cirq::givens<fp_type>::Create(53, 2, 3, 1.2));
+  circuit.ops.push_back(Cirq::riswap<fp_type>::Create(53, 0, 1, 0.7));
+  circuit.ops.push_back(Cirq::givens<fp_type>::Create(53, 2, 3, 1.2));
 
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(54, 0));
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(54, 1));
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(54, 2));
-  circuit.gates.emplace_back(Cirq::H<fp_type>::Create(54, 3));
+  circuit.ops.push_back(Cirq::H<fp_type>::Create(54, 0));
+  circuit.ops.push_back(Cirq::H<fp_type>::Create(54, 1));
+  circuit.ops.push_back(Cirq::H<fp_type>::Create(54, 2));
+  circuit.ops.push_back(Cirq::H<fp_type>::Create(54, 3));
 
   return circuit;
 }

--- a/tests/gates_qsim_test.cc
+++ b/tests/gates_qsim_test.cc
@@ -16,6 +16,7 @@
 
 #include "gtest/gtest.h"
 
+#include "../lib/gate.h"
 #include "../lib/gates_qsim.h"
 
 namespace qsim {
@@ -329,13 +330,13 @@ TEST(GatesQsimTest, GateCP) {
 TEST(GatesQsimTest, GateMeasurement) {
   unsigned time = 5;
   std::vector<unsigned> qubits = {3, 2, 4, 0, 7, 5, 1};
-  auto gate = gate::Measurement<GateQSim<float>>::Create(time, qubits);
+  auto mea = CreateMeasurement(time, qubits);
 
-  EXPECT_EQ(gate.time, time);
-  EXPECT_EQ(gate.qubits.size(), qubits.size());
+  EXPECT_EQ(mea.time, time);
+  EXPECT_EQ(mea.qubits.size(), qubits.size());
 
   for (std::size_t i = 0; i < qubits.size(); ++i) {
-    EXPECT_EQ(gate.qubits[i], qubits[i]);
+    EXPECT_EQ(mea.qubits[i], qubits[i]);
   }
 }
 

--- a/tests/hybrid_testfixture.h
+++ b/tests/hybrid_testfixture.h
@@ -25,9 +25,9 @@
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_basic.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/hybrid.h"
 #include "../lib/io.h"
+#include "../lib/operation.h"
 
 namespace qsim {
 
@@ -61,42 +61,43 @@ R"(2
 14 sw 0 1
 )";
 
+  using fp_type = typename Factory::fp_type;
+
   std::stringstream ss(circuit_string);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<fp_type>> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 2);
-  EXPECT_EQ(circuit.gates.size(), 23);
+  EXPECT_EQ(circuit.ops.size(), 23);
 
-  using HybridSimulator = HybridSimulator<IO, GateQSim<float>, BasicGateFuser,
-                                          For>;
-  using Fuser = HybridSimulator::Fuser;
+  using Fuser = BasicGateFuser<IO>;
+  using HybridSimulator = HybridSimulator<IO, For>;
 
   std::vector<unsigned> parts = {0, 1};
 
-  HybridSimulator::HybridData hd;
-  EXPECT_TRUE(HybridSimulator::SplitLattice(parts, circuit.gates, hd));
+  typename HybridSimulator::HybridData<fp_type> hd;
+  EXPECT_TRUE(HybridSimulator::SplitLattice(parts, circuit.ops, hd));
 
-  EXPECT_EQ(hd.gates0.size(), 15);
-  EXPECT_EQ(hd.gates1.size(), 15);
+  EXPECT_EQ(hd.ops0.size(), 15);
+  EXPECT_EQ(hd.ops1.size(), 15);
   EXPECT_EQ(hd.gatexs.size(), 7);
   EXPECT_EQ(hd.qubit_map.size(), 2);
   EXPECT_EQ(hd.num_qubits0, 1);
   EXPECT_EQ(hd.num_qubits1, 1);
   EXPECT_EQ(hd.num_gatexs, 7);
 
-  HybridSimulator::Parameter param;
+  typename HybridSimulator::Parameter<Fuser::Parameter> param;
   param.prefix = 1;
   param.num_prefix_gatexs = 0;
   param.num_root_gatexs = 0;
   param.num_threads = 1;
   param.verbosity = 0;
 
-  auto fgates0 = Fuser::FuseGates(param, hd.num_qubits0, hd.gates0);
-  auto fgates1 = Fuser::FuseGates(param, hd.num_qubits1, hd.gates1);
+  auto fops0 = Fuser::FuseGates(param, hd.num_qubits0, hd.ops0);
+  auto fops1 = Fuser::FuseGates(param, hd.num_qubits1, hd.ops1);
 
-  EXPECT_EQ(fgates0.size(), 7);
-  EXPECT_EQ(fgates1.size(), 7);
+  EXPECT_EQ(fops0.size(), 7);
+  EXPECT_EQ(fops1.size(), 7);
 
   std::vector<uint64_t> bitstrings;
   bitstrings.reserve(4);
@@ -104,12 +105,12 @@ R"(2
     bitstrings.push_back(i);
   }
 
-  std::vector<std::complex<typename Factory::fp_type>> results(4, 0);
+  std::vector<std::complex<fp_type>> results(4, 0);
 
   std::complex<typename Factory::fp_type> zero(0, 0);
 
   EXPECT_TRUE(HybridSimulator(1).Run(
-      param, factory, hd, parts, fgates0, fgates1, bitstrings, results));
+      param, factory, hd, parts, fops0, fops1, bitstrings, results));
 
   EXPECT_NEAR(std::real(results[0]), -0.16006945, 1e-6);
   EXPECT_NEAR(std::imag(results[0]), -0.04964612, 1e-6);
@@ -125,7 +126,7 @@ R"(2
   param.num_root_gatexs = 1;
 
   EXPECT_TRUE(HybridSimulator(1).Run(
-      param, factory, hd, parts, fgates0, fgates1, bitstrings, results));
+      param, factory, hd, parts, fops0, fops1, bitstrings, results));
 
   EXPECT_NEAR(std::real(results[0]), -0.16006945, 1e-6);
   EXPECT_NEAR(std::imag(results[0]), -0.04964612, 1e-6);
@@ -141,7 +142,7 @@ R"(2
   param.num_root_gatexs = 2;
 
   EXPECT_TRUE(HybridSimulator(1).Run(
-      param, factory, hd, parts, fgates0, fgates1, bitstrings, results));
+      param, factory, hd, parts, fops0, fops1, bitstrings, results));
 
   EXPECT_NEAR(std::real(results[0]), -0.16006945, 1e-6);
   EXPECT_NEAR(std::imag(results[0]), -0.04964612, 1e-6);
@@ -157,7 +158,7 @@ R"(2
   param.num_root_gatexs = 5;
 
   EXPECT_TRUE(HybridSimulator(1).Run(
-      param, factory, hd, parts, fgates0, fgates1, bitstrings, results));
+      param, factory, hd, parts, fops0, fops1, bitstrings, results));
 
   EXPECT_NEAR(std::real(results[0]), -0.16006945, 1e-6);
   EXPECT_NEAR(std::imag(results[0]), -0.04964612, 1e-6);
@@ -167,10 +168,6 @@ R"(2
   EXPECT_NEAR(std::imag(results[2]), 0.56567556, 1e-6);
   EXPECT_NEAR(std::real(results[3]), 0.28935891, 1e-6);
   EXPECT_NEAR(std::imag(results[3]), 0.71751291, 1e-6);
-
-  std::fill(results.begin(), results.end(), zero);
-  param.num_prefix_gatexs = 0;
-  param.num_root_gatexs = 6;
 }
 
 template <typename Factory>
@@ -243,42 +240,43 @@ R"(4
 21 h 3
 )";
 
+  using fp_type = typename Factory::fp_type;
+
   std::stringstream ss(circuit_string);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<fp_type>> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 4);
-  EXPECT_EQ(circuit.gates.size(), 63);
+  EXPECT_EQ(circuit.ops.size(), 63);
 
-  using HybridSimulator = HybridSimulator<IO, GateQSim<float>, BasicGateFuser,
-                                          For>;
-  using Fuser = HybridSimulator::Fuser;
+  using Fuser = BasicGateFuser<IO>;
+  using HybridSimulator = HybridSimulator<IO, For>;
 
   std::vector<unsigned> parts = {0, 0, 1, 1};
 
-  HybridSimulator::HybridData hd;
-  EXPECT_TRUE(HybridSimulator::SplitLattice(parts, circuit.gates, hd));
+  typename HybridSimulator::HybridData<fp_type> hd;
+  EXPECT_TRUE(HybridSimulator::SplitLattice(parts, circuit.ops, hd));
 
-  EXPECT_EQ(hd.gates0.size(), 34);
-  EXPECT_EQ(hd.gates1.size(), 34);
+  EXPECT_EQ(hd.ops0.size(), 34);
+  EXPECT_EQ(hd.ops1.size(), 34);
   EXPECT_EQ(hd.gatexs.size(), 5);
   EXPECT_EQ(hd.qubit_map.size(), 4);
   EXPECT_EQ(hd.num_qubits0, 2);
   EXPECT_EQ(hd.num_qubits1, 2);
   EXPECT_EQ(hd.num_gatexs, 5);
 
-  HybridSimulator::Parameter param;
+  typename HybridSimulator::Parameter<Fuser::Parameter> param;
   param.prefix = 1;
   param.num_prefix_gatexs = 2;
   param.num_root_gatexs = 1;
   param.num_threads = 1;
   param.verbosity = 0;
 
-  auto fgates0 = Fuser::FuseGates(param, hd.num_qubits0, hd.gates0);
-  auto fgates1 = Fuser::FuseGates(param, hd.num_qubits1, hd.gates1);
+  auto fops0 = Fuser::FuseGates(param, hd.num_qubits0, hd.ops0);
+  auto fops1 = Fuser::FuseGates(param, hd.num_qubits1, hd.ops1);
 
-  EXPECT_EQ(fgates0.size(), 10);
-  EXPECT_EQ(fgates1.size(), 10);
+  EXPECT_EQ(fops0.size(), 10);
+  EXPECT_EQ(fops1.size(), 10);
 
   std::vector<uint64_t> bitstrings;
   bitstrings.reserve(8);
@@ -289,7 +287,7 @@ R"(4
   std::vector<std::complex<typename Factory::fp_type>> results(8, 0);
 
   EXPECT_TRUE(HybridSimulator(1).Run(
-      param, factory, hd, parts, fgates0, fgates1, bitstrings, results));
+      param, factory, hd, parts, fops0, fops1, bitstrings, results));
 
   EXPECT_NEAR(std::real(results[0]), -0.02852439, 1e-6);
   EXPECT_NEAR(std::imag(results[0]), -0.05243438, 1e-6);

--- a/tests/mps_simulator_test.cc
+++ b/tests/mps_simulator_test.cc
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../lib/mps_simulator.h"
+#include <vector>
+
+#include "gtest/gtest.h"
 
 #include "../lib/formux.h"
+#include "../lib/fuser.h"
+#include "../lib/gate.h"
 #include "../lib/gate_appl.h"
 #include "../lib/gates_cirq.h"
-#include "../lib/gates_qsim.h"
-#include "gtest/gtest.h"
+#include "../lib/mps_simulator.h"
 
 namespace qsim {
 
@@ -818,22 +821,21 @@ TEST(MPSSimulator, ApplyFusedGateLeft) {
   using MPSStateSpace = MPSSimulator<For, float>::MPSStateSpace_;
   auto ss = MPSStateSpace(1);
 
-  auto gate1 = GateCZ<float>::Create(2, 0, 1);
-  auto gate2 = GateHd<float>::Create(0, 0);
-  auto gate3 = GateHd<float>::Create(0, 1);
+  auto gate1 = Cirq::CZ<float>::Create(2, 0, 1);
+  auto gate2 = Cirq::H<float>::Create(0, 0);
+  auto gate3 = Cirq::H<float>::Create(0, 1);
 
-  GateFused<GateQSim<float>> fgate1{kGateCZ, 2, {0, 1}, &gate1,
-                                    {&gate2, &gate3}, {}};
+  FusedGate<float> fgate1{Cirq::kCZ, 2, {0, 1}, &gate1, {&gate2, &gate3}, {}};
   CalculateFusedMatrix(fgate1);
   auto mps = ss.Create(3, 4);
   ss.SetStateZero(mps);
-  ApplyFusedGate(sim, fgate1, mps);
+  ApplyGate(sim, fgate1, mps);
 
   float wf[32];
   float ground_truth[] = {0.5, 0., 0., 0., 0.5, 0., 0., 0.,
                           0.5, 0., 0., 0., 0.5, 0., 0., 0.};
   ss.ToWaveFunction(mps, wf);
-  for (int i = 0; i < 16; i++) {
+  for (unsigned i = 0; i < 16; ++i) {
     EXPECT_NEAR(wf[i], ground_truth[i], 1e-4);
   }
 }
@@ -844,7 +846,7 @@ TEST(MPSSimulator, ApplyFusedGateRight) {
   //   |     |     |
   //   |   +-+-----+-+
   //   |   |FusedGate|
-  //   |   +-+-----+-+ 
+  //   |   +-+-----+-+
   //   |     |     |
   // +-+-+ +-+-+ +-+-+
   // | 0 +-+ 1 +-+ 2 |
@@ -853,22 +855,21 @@ TEST(MPSSimulator, ApplyFusedGateRight) {
   using MPSStateSpace = MPSSimulator<For, float>::MPSStateSpace_;
   auto ss = MPSStateSpace(1);
 
-  auto gate1 = GateCZ<float>::Create(2, 1, 2);
-  auto gate2 = GateHd<float>::Create(0, 1);
-  auto gate3 = GateHd<float>::Create(0, 2);
+  auto gate1 = Cirq::CZ<float>::Create(2, 1, 2);
+  auto gate2 = Cirq::H<float>::Create(0, 1);
+  auto gate3 = Cirq::H<float>::Create(0, 2);
 
-  GateFused<GateQSim<float>> fgate1{kGateCZ, 2, {1, 2}, &gate1,
-                                    {&gate2, &gate3}, {}};
+  FusedGate<float> fgate1{Cirq::kCZ, 2, {1, 2}, &gate1, {&gate2, &gate3}, {}};
   CalculateFusedMatrix(fgate1);
   auto mps = ss.Create(3, 4);
   ss.SetStateZero(mps);
-  ApplyFusedGate(sim, fgate1, mps);
+  ApplyGate(sim, fgate1, mps);
 
   float wf[32];
   float ground_truth[] = {0.5, 0., 0.5, 0., 0.5, 0., 0.5, 0.,
                           0., 0., 0., 0., 0., 0., 0., 0.};
   ss.ToWaveFunction(mps, wf);
-  for (int i = 0; i < 16; i++) {
+  for (unsigned i = 0; i < 16; ++i) {
     EXPECT_NEAR(wf[i], ground_truth[i], 1e-4);
   }
 }
@@ -888,16 +889,15 @@ TEST(MPSSimulator, ApplyFusedGateMiddle) {
   using MPSStateSpace = MPSSimulator<For, float>::MPSStateSpace_;
   auto ss = MPSStateSpace(1);
 
-  auto gate1 = GateCZ<float>::Create(2, 1, 2);
-  auto gate2 = GateHd<float>::Create(0, 1);
-  auto gate3 = GateHd<float>::Create(0, 2);
+  auto gate1 = Cirq::CZ<float>::Create(2, 1, 2);
+  auto gate2 = Cirq::H<float>::Create(0, 1);
+  auto gate3 = Cirq::H<float>::Create(0, 2);
 
-  GateFused<GateQSim<float>> fgate1{kGateCZ, 2, {1, 2}, &gate1,
-                                    {&gate2, &gate3}, {}};
+  FusedGate<float> fgate1{Cirq::kCZ, 2, {1, 2}, &gate1, {&gate2, &gate3}, {}};
   CalculateFusedMatrix(fgate1);
   auto mps = ss.Create(4, 4);
   ss.SetStateZero(mps);
-  ApplyFusedGate(sim, fgate1, mps);
+  ApplyGate(sim, fgate1, mps);
 
   float wf[64];
   float ground_truth[] = {0.5, 0., 0., 0., 0.5, 0., 0., 0.,
@@ -905,7 +905,7 @@ TEST(MPSSimulator, ApplyFusedGateMiddle) {
                           0., 0., 0., 0., 0., 0., 0., 0.,
                           0., 0., 0., 0., 0., 0., 0., 0.};
   ss.ToWaveFunction(mps, wf);
-  for (int i = 0; i < 32; i++) {
+  for (unsigned i = 0; i < 32; ++i) {
     EXPECT_NEAR(wf[i], ground_truth[i], 1e-4);
   }
 }

--- a/tests/operation_test.cc
+++ b/tests/operation_test.cc
@@ -1,0 +1,334 @@
+// Copyright 2026 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <variant>
+
+#include "gtest/gtest.h"
+
+#include "../lib/gate.h"
+#include "../lib/operation.h"
+#include "../lib/operation_base.h"
+
+namespace qsim {
+
+TEST(OperationTest, Test1) {
+  using Gate = qsim::Gate<float>;
+  using ControlledGate = qsim::ControlledGate<float>;
+  using Operation = qsim::Operation<float>;
+
+  {
+    Gate op1 = {0, 1, {2}};
+    const Gate op2 = {0, 1, {2}};
+
+    Gate* pg1 = OpGetAlternative<Gate>(op1);
+    ASSERT_NE(pg1, nullptr);
+    EXPECT_EQ(pg1->time, 1);
+    EXPECT_EQ(pg1->qubits.size(), 1);
+
+    const Gate* pg2 = OpGetAlternative<Gate>(&op2);
+    ASSERT_NE(pg2, nullptr);
+    EXPECT_EQ(pg2->time, 1);
+    EXPECT_EQ(pg2->qubits.size(), 1);
+
+    unsigned time1 = OpTime(op1);
+    EXPECT_EQ(time1, 1);
+
+    unsigned time2 = OpTime(op2);
+    EXPECT_EQ(time2, 1);
+
+    const Qubits& qubits1 = OpQubits(op1);
+    EXPECT_EQ(qubits1.size(), 1);
+
+    const Qubits& qubits2 = OpQubits(&op2);
+    EXPECT_EQ(qubits2.size(), 1);
+
+    {
+      const BaseOperation& bop1 = OpBaseOperation(&op1);
+      EXPECT_EQ(bop1.time, 1);
+      EXPECT_EQ(bop1.qubits.size(), 1);
+
+      const BaseOperation& bop2 = OpBaseOperation(&op2);
+      EXPECT_EQ(bop2.time, 1);
+      EXPECT_EQ(bop2.qubits.size(), 1);
+    }
+
+    {
+      Gate* po1 = &op1;
+      const Gate* const po2 = &op2;
+
+      BaseOperation& bop1 = OpBaseOperation(po1);
+      EXPECT_EQ(bop1.time, 1);
+      EXPECT_EQ(bop1.qubits.size(), 1);
+
+      EXPECT_EQ(op1.time, 1);
+      bop1.time = 2;
+      EXPECT_EQ(op1.time, 2);
+
+      const BaseOperation& bop2 = OpBaseOperation(po2);
+      EXPECT_EQ(bop2.time, 1);
+      EXPECT_EQ(bop2.qubits.size(), 1);
+    }
+
+    ControlledGate* pg3 = OpGetAlternative<ControlledGate>(op1);
+    EXPECT_EQ(pg3, nullptr);
+  }
+
+  {
+    Operation op1 = Gate{0, 1, {2}};
+    const Operation op2 = Gate{0, 1, {2}};
+
+    Gate* pg1 = OpGetAlternative<Gate>(op1);
+    ASSERT_NE(pg1, nullptr);
+    EXPECT_EQ(pg1->time, 1);
+    EXPECT_EQ(pg1->qubits.size(), 1);
+
+    const Gate* pg2 = OpGetAlternative<Gate>(op2);
+    ASSERT_NE(pg2, nullptr);
+    EXPECT_EQ(pg2->time, 1);
+    EXPECT_EQ(pg2->qubits.size(), 1);
+
+    unsigned time1 = OpTime(op1);
+    EXPECT_EQ(time1, 1);
+
+    unsigned time2 = OpTime(op2);
+    EXPECT_EQ(time2, 1);
+
+    const Qubits& qubits1 = OpQubits(op1);
+    EXPECT_EQ(qubits1.size(), 1);
+
+    const Qubits& qubits2 = OpQubits(op2);
+    EXPECT_EQ(qubits2.size(), 1);
+
+    {
+      BaseOperation& bop1 = OpBaseOperation(op1);
+      EXPECT_EQ(bop1.time, 1);
+      EXPECT_EQ(bop1.qubits.size(), 1);
+
+      EXPECT_EQ(std::get<Gate>(op1).time, 1);
+      bop1.time = 2;
+      EXPECT_EQ(std::get<Gate>(op1).time, 2);
+
+      const BaseOperation& bop2 = OpBaseOperation(op2);
+      EXPECT_EQ(bop2.time, 1);
+      EXPECT_EQ(bop2.qubits.size(), 1);
+    }
+
+    {
+      Operation* const po1 = &op1;
+      const Operation* const po2 = &op2;
+
+      const BaseOperation& bop1 = OpBaseOperation(po1);
+      EXPECT_EQ(bop1.time, 2);
+      EXPECT_EQ(bop1.qubits.size(), 1);
+
+      const BaseOperation& bop2 = OpBaseOperation(po2);
+      EXPECT_EQ(bop2.time, 1);
+      EXPECT_EQ(bop2.qubits.size(), 1);
+    }
+
+    ControlledGate* pg3 = OpGetAlternative<ControlledGate>(op1);
+    EXPECT_EQ(pg3, nullptr);
+  }
+
+  {
+    Operation op1 = ControlledGate{Gate{0, 1, {2}}, {0, 1}};
+    const Operation op2 = ControlledGate{Gate{0, 1, {2}}, {0, 1}};
+    Operation* po1 = &op1;
+
+    ControlledGate* pg1 = OpGetAlternative<ControlledGate>(po1);
+    ASSERT_NE(pg1, nullptr);
+    EXPECT_EQ(pg1->time, 1);
+    EXPECT_EQ(pg1->qubits.size(), 1);
+    EXPECT_EQ(pg1->controlled_by.size(), 2);
+
+    const ControlledGate* pg2 = OpGetAlternative<ControlledGate>(&op2);
+    ASSERT_NE(pg2, nullptr);
+    EXPECT_EQ(pg2->time, 1);
+    EXPECT_EQ(pg2->qubits.size(), 1);
+    EXPECT_EQ(pg2->controlled_by.size(), 2);
+
+    unsigned time1 = OpTime(&op1);
+    EXPECT_EQ(time1, 1);
+
+    unsigned time2 = OpTime(&op2);
+    EXPECT_EQ(time2, 1);
+
+    const Qubits& qubits1 = OpQubits(op1);
+    EXPECT_EQ(qubits1.size(), 1);
+
+    const Qubits& qubits2 = OpQubits(&op2);
+    EXPECT_EQ(qubits2.size(), 1);
+
+    BaseOperation& bop1 = OpBaseOperation(op1);
+    EXPECT_EQ(bop1.time, 1);
+    EXPECT_EQ(bop1.qubits.size(), 1);
+
+    const BaseOperation& bop2 = OpBaseOperation(&op2);
+    EXPECT_EQ(bop2.time, 1);
+    EXPECT_EQ(bop2.qubits.size(), 1);
+
+    const Gate* pg3 = OpGetAlternative<Gate>(&op1);
+    EXPECT_EQ(pg3, nullptr);
+  }
+}
+
+TEST(OperationTest, Test2) {
+  using Gate = qsim::Gate<float>;
+  using FusedGate = qsim::FusedGate<float>;
+  using Operation = qsim::Operation<float>;
+  using OperationF = std::variant<FusedGate, Measurement, const Operation*>;
+
+  {
+    Operation op1 = Gate{0, 1, {2}};
+    const OperationF opf1 = &op1;
+
+    const Gate* pg1 = OpGetAlternative<Gate>(opf1);
+    ASSERT_NE(pg1, nullptr);
+    EXPECT_EQ(pg1->time, 1);
+    EXPECT_EQ(pg1->qubits.size(), 1);
+
+    unsigned time1 = OpTime(&opf1);
+    EXPECT_EQ(time1, 1);
+
+    const Qubits& qubits1 = OpQubits(&opf1);
+    EXPECT_EQ(qubits1.size(), 1);
+
+    const BaseOperation& bop1 = OpBaseOperation(opf1);
+    EXPECT_EQ(bop1.time, 1);
+    EXPECT_EQ(bop1.qubits.size(), 1);
+
+    const Measurement* pg3 = OpGetAlternative<Measurement>(&opf1);
+    EXPECT_EQ(pg3, nullptr);
+  }
+
+  {
+    OperationF opf1 = CreateMeasurement(1, {1});
+    const OperationF opf2 = CreateMeasurement(1, {1});
+
+    EXPECT_EQ(std::get<Measurement>(opf1).time, 1);
+
+    Measurement* pm1 = OpGetAlternative<Measurement>(opf1);
+    ASSERT_NE(pm1, nullptr);
+    EXPECT_EQ(pm1->time, 1);
+    EXPECT_EQ(pm1->qubits.size(), 1);
+
+    pm1->time = 2;
+    EXPECT_EQ(std::get<Measurement>(opf1).time, 2);
+
+    const Measurement* pm2 = OpGetAlternative<Measurement>(opf2);
+    ASSERT_NE(pm2, nullptr);
+    EXPECT_EQ(pm2->time, 1);
+    EXPECT_EQ(pm2->qubits.size(), 1);
+
+    unsigned time1 = OpTime(&opf1);
+    EXPECT_EQ(time1, 2);
+
+    unsigned time2 = OpTime(opf2);
+    EXPECT_EQ(time2, 1);
+
+    const Qubits& qubits1 = OpQubits(opf1);
+    EXPECT_EQ(qubits1.size(), 1);
+
+    const Qubits& qubits2 = OpQubits(&opf2);
+    EXPECT_EQ(qubits2.size(), 1);
+
+    const BaseOperation& bop2 = OpBaseOperation(&opf2);
+    EXPECT_EQ(bop2.time, 1);
+    EXPECT_EQ(bop2.qubits.size(), 1);
+
+    const Gate* pg3 = OpGetAlternative<Gate>(opf2);
+    EXPECT_EQ(pg3, nullptr);
+  }
+}
+
+TEST(OperationTest, Test3) {
+  using Gate = qsim::Gate<float>;
+  using FusedGate = qsim::FusedGate<float>;
+  using Operation = qsim::Operation<float>;
+  using OperationF = std::variant<FusedGate, Measurement, Operation*>;
+
+  {
+    Operation op1 = Gate{0, 1, {2}};
+    OperationF opf1 = &op1;
+
+    const Gate* pg1 = OpGetAlternative<Gate>(opf1);
+    ASSERT_NE(pg1, nullptr);
+    EXPECT_EQ(pg1->time, 1);
+    EXPECT_EQ(pg1->qubits.size(), 1);
+
+    unsigned time1 = OpTime(&opf1);
+    EXPECT_EQ(time1, 1);
+
+    const Qubits& qubits1 = OpQubits(&opf1);
+    EXPECT_EQ(qubits1.size(), 1);
+
+    BaseOperation& bop1 = OpBaseOperation(opf1);
+    EXPECT_EQ(bop1.time, 1);
+    EXPECT_EQ(bop1.qubits.size(), 1);
+
+    const Measurement* pg3 = OpGetAlternative<Measurement>(&opf1);
+    EXPECT_EQ(pg3, nullptr);
+  }
+
+  {
+    OperationF opf1 = CreateMeasurement(1, {1});
+    const OperationF opf2 = CreateMeasurement(1, {1});
+
+    EXPECT_EQ(std::get<Measurement>(opf1).time, 1);
+
+    Measurement* pm1 = OpGetAlternative<Measurement>(opf1);
+    ASSERT_NE(pm1, nullptr);
+    EXPECT_EQ(pm1->time, 1);
+    EXPECT_EQ(pm1->qubits.size(), 1);
+
+    pm1->time = 2;
+    EXPECT_EQ(std::get<Measurement>(opf1).time, 2);
+
+    const Measurement* pm2 = OpGetAlternative<Measurement>(opf2);
+    ASSERT_NE(pm2, nullptr);
+    EXPECT_EQ(pm2->time, 1);
+    EXPECT_EQ(pm2->qubits.size(), 1);
+
+    unsigned time1 = OpTime(&opf1);
+    EXPECT_EQ(time1, 2);
+
+    unsigned time2 = OpTime(opf2);
+    EXPECT_EQ(time2, 1);
+
+    const Qubits& qubits1 = OpQubits(opf1);
+    EXPECT_EQ(qubits1.size(), 1);
+
+    const Qubits& qubits2 = OpQubits(&opf2);
+    EXPECT_EQ(qubits2.size(), 1);
+
+    OperationF* pof1 = &opf1;
+    BaseOperation& bop1 = OpBaseOperation(pof1);
+    EXPECT_EQ(bop1.time, 2);
+    EXPECT_EQ(bop1.qubits.size(), 1);
+
+    const BaseOperation& bop2 = OpBaseOperation(&opf2);
+    EXPECT_EQ(bop2.time, 1);
+    EXPECT_EQ(bop2.qubits.size(), 1);
+
+    const Gate* pg3 = OpGetAlternative<Gate>(opf2);
+    EXPECT_EQ(pg3, nullptr);
+  }
+}
+
+}  // namespace qsim
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/qtrajectory_avx_test.cc
+++ b/tests/qtrajectory_avx_test.cc
@@ -41,43 +41,43 @@ struct Factory {
 };
 
 TEST(QTrajectoryAVXTest, BitFlip) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<SequentialFor>>;
   TestBitFlip<Runner>(Factory<SequentialFor>());
 }
 
 TEST(QTrajectoryAVXTest, GenDump) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<SequentialFor>>;
   TestGenDump<Runner>(Factory<SequentialFor>());
 }
 
 TEST(QTrajectoryAVXTest, ReusingResults) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<SequentialFor>>;
   TestReusingResults<Runner>(Factory<SequentialFor>());
 }
 
 TEST(QTrajectoryAVXTest, CollectKopStat) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<SequentialFor>>;
   TestCollectKopStat<Runner>(Factory<SequentialFor>());
 }
 
 TEST(QTrajectoryAVXTest, CleanCircuit) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<SequentialFor>>;
   TestCleanCircuit<Runner>(Factory<SequentialFor>());
 }
 
 TEST(QTrajectoryAVXTest, InitialState) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<SequentialFor>>;
   TestInitialState<Runner>(Factory<SequentialFor>());
 }
 
 TEST(QTrajectoryAVXTest, UncomputeFinalState) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<SequentialFor>>;
   TestUncomputeFinalState<Runner>(Factory<SequentialFor>());
 }

--- a/tests/qtrajectory_cuda_test.cu
+++ b/tests/qtrajectory_cuda_test.cu
@@ -45,7 +45,7 @@ struct Factory {
 
 TEST(QTrajectoryCUDATest, BitFlip) {
   using Factory = qsim::Factory<float>;
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory>;
   Factory::StateSpace::Parameter param;
   Factory factory(param);
@@ -54,7 +54,7 @@ TEST(QTrajectoryCUDATest, BitFlip) {
 
 TEST(QTrajectoryCUDATest, GenDump) {
   using Factory = qsim::Factory<float>;
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory>;
   Factory::StateSpace::Parameter param;
   Factory factory(param);
@@ -63,7 +63,7 @@ TEST(QTrajectoryCUDATest, GenDump) {
 
 TEST(QTrajectoryCUDATest, ReusingResults) {
   using Factory = qsim::Factory<float>;
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory>;
   Factory::StateSpace::Parameter param;
   Factory factory(param);
@@ -72,7 +72,7 @@ TEST(QTrajectoryCUDATest, ReusingResults) {
 
 TEST(QTrajectoryCUDATest, CollectKopStat) {
   using Factory = qsim::Factory<float>;
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory>;
   Factory::StateSpace::Parameter param;
   Factory factory(param);
@@ -81,7 +81,7 @@ TEST(QTrajectoryCUDATest, CollectKopStat) {
 
 TEST(QTrajectoryCUDATest, CleanCircuit) {
   using Factory = qsim::Factory<float>;
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory>;
   Factory::StateSpace::Parameter param;
   Factory factory(param);
@@ -90,7 +90,7 @@ TEST(QTrajectoryCUDATest, CleanCircuit) {
 
 TEST(QTrajectoryCUDATest, InitialState) {
   using Factory = qsim::Factory<float>;
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory>;
   Factory::StateSpace::Parameter param;
   Factory factory(param);
@@ -99,7 +99,7 @@ TEST(QTrajectoryCUDATest, InitialState) {
 
 TEST(QTrajectoryCUDATest, UncomputeFinalState) {
   using Factory = qsim::Factory<float>;
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory>;
   Factory::StateSpace::Parameter param;
   Factory factory(param);

--- a/tests/qtrajectory_custatevec_test.cu
+++ b/tests/qtrajectory_custatevec_test.cu
@@ -56,43 +56,43 @@ struct Factory {
 };
 
 TEST(QTrajectoryCuStateVecTest, BitFlip) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<float>>;
   TestBitFlip<Runner>(Factory<float>());
 }
 
 TEST(QTrajectoryCuStateVecTest, GenDump) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<float>>;
   TestGenDump<Runner>(Factory<float>());
 }
 
 TEST(QTrajectoryCuStateVecTest, ReusingResults) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<float>>;
   TestReusingResults<Runner>(Factory<float>());
 }
 
 TEST(QTrajectoryCuStateVecTest, CollectKopStat) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<float>>;
   TestCollectKopStat<Runner>(Factory<float>());
 }
 
 TEST(QTrajectoryCuStateVecTest, CleanCircuit) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<float>>;
   TestCleanCircuit<Runner>(Factory<float>());
 }
 
 TEST(QTrajectoryCuStateVecTest, InitialState) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<float>>;
   TestInitialState<Runner>(Factory<float>());
 }
 
 TEST(QTrajectoryCuStateVecTest, UncomputeFinalState) {
-  using Fuser = MultiQubitGateFuser<IO, const Cirq::GateCirq<float>*>;
+  using Fuser = MultiQubitGateFuser<IO>;
   using Runner = QSimRunner<IO, Fuser, Factory<float>>;
   TestUncomputeFinalState<Runner>(Factory<float>());
 }

--- a/tests/qtrajectory_testfixture.h
+++ b/tests/qtrajectory_testfixture.h
@@ -23,66 +23,76 @@
 
 #include "../lib/channel.h"
 #include "../lib/channels_cirq.h"
+#include "../lib/circuit.h"
 #include "../lib/circuit_noisy.h"
 #include "../lib/expect.h"
 #include "../lib/fuser_mqubit.h"
+#include "../lib/gate.h"
 #include "../lib/gate_appl.h"
 #include "../lib/gates_cirq.h"
 #include "../lib/io.h"
+#include "../lib/operation.h"
+#include "../lib/operation_base.h"
 #include "../lib/qtrajectory.h"
 
 namespace qsim {
 
-template <typename Gate>
-void AddBitFlipNoise1(
-    unsigned time, unsigned q, double p, NoisyCircuit<Gate>& ncircuit) {
-  using fp_type = typename Gate::fp_type;
-
+template <typename fp_type>
+void AddBitFlipNoise1(unsigned time, unsigned q, double p,
+                      Circuit<Operation<fp_type>>& ncircuit) {
   double p1 = 1 - p;
   double p2 = p;
 
-  auto normal = KrausOperator<Gate>::kNormal;
-
-  ncircuit.channels.push_back(
-      {{normal, 1, p1, {Cirq::I1<fp_type>::Create(time, q)}},
-       {normal, 1, p2, {Cirq::X<fp_type>::Create(time, q)}}});
+  ncircuit.ops.push_back(Channel<fp_type>{
+    {kChannel, time, {q}},
+    {
+      {true, p1, {Cirq::I1<fp_type>::Create(time, q)}},
+      {true, p2, {Cirq::X<fp_type>::Create(time, q)}},
+    }
+  });
 }
 
-template <typename Gate>
-void AddBitFlipNoise2(unsigned time, double p, NoisyCircuit<Gate>& ncircuit) {
-  using fp_type = typename Gate::fp_type;
-
+template <typename fp_type>
+void AddBitFlipNoise2(unsigned time, double p,
+                      Circuit<Operation<fp_type>>& ncircuit) {
   double p1 = 1 - p;
   double p2 = p;
 
-  auto normal = KrausOperator<Gate>::kNormal;
-
-  ncircuit.channels.push_back({
-    {normal, 1, p1 * p1, {Cirq::I1<fp_type>::Create(time, 0),
-                          Cirq::I1<fp_type>::Create(time, 1)}},
-    {normal, 1, p1 * p2, {Cirq::I1<fp_type>::Create(time, 0),
-                          Cirq::X<fp_type>::Create(time, 1)}},
-    {normal, 1, p2 * p1, {Cirq::X<fp_type>::Create(time, 0),
-                          Cirq::I1<fp_type>::Create(time, 1)}},
-    {normal, 1, p2 * p2, {Cirq::X<fp_type>::Create(time, 0),
-                          Cirq::X<fp_type>::Create(time, 1)}},
+  ncircuit.ops.push_back(Channel<fp_type>{
+    {kChannel, time, {0, 1}},
+    {
+      {true, p1 * p1, {Cirq::I1<fp_type>::Create(time, 0),
+                       Cirq::I1<fp_type>::Create(time, 1)}},
+      {true, p1 * p2, {Cirq::I1<fp_type>::Create(time, 0),
+                       Cirq::X<fp_type>::Create(time, 1)}},
+      {true, p2 * p1, {Cirq::X<fp_type>::Create(time, 0),
+                       Cirq::I1<fp_type>::Create(time, 1)}},
+      {true, p2 * p2, {Cirq::X<fp_type>::Create(time, 0),
+                       Cirq::X<fp_type>::Create(time, 1)}},
+    }
   });
 
 //  This can also be imnplemented as the following.
 //
-//  ncircuit.channels.push_back(
-//    {{normal, 1, p1, {Cirq::I1<fp_type>::Create(time, 0)}},
-//     {normal, 1, p2, {Cirq::X<fp_type>::Create(time, 0)}}});
-//  ncircuit.channels.push_back(
-//    {{normal, 1, p1, {Cirq::I1<fp_type>::Create(time, 1)}},
-//     {normal, 1, p2, {Cirq::X<fp_type>::Create(time, 1)}}});
+//  ncircuit.ops.push_back(Channel<fp_type>{
+//    {kChannel, time, {0}},
+//    {
+//      {true, p1, {Cirq::I1<fp_type>::Create(time, 0)}},
+//      {true, p2, {Cirq::X<fp_type>::Create(time, 0)}},
+//    }
+//  });
+//  ncircuit.ops.push_back(Channel<fp_type>{
+//    {kChannel, time, {1}},
+//    {
+//      {true, p1, {Cirq::I1<fp_type>::Create(time, 1)}},
+//      {true, p2, {Cirq::X<fp_type>::Create(time, 1)}},
+//    }
+//  });
 }
 
-template <typename Gate>
-void AddGenAmplDumpNoise1(
-    unsigned time, unsigned q, double g, NoisyCircuit<Gate>& ncircuit) {
-  using fp_type = typename Gate::fp_type;
-
+template <typename fp_type>
+void AddGenAmplDumpNoise1(unsigned time, unsigned q, double g,
+                          Circuit<Operation<fp_type>>& ncircuit) {
   // Probability of exchanging energy with the environment.
   double p = 0.5;
 
@@ -97,26 +107,28 @@ void AddGenAmplDumpNoise1(
   fp_type r2 = std::sqrt((1 - p) * (1 - g));
   fp_type s2 = std::sqrt((1 - p) * g);
 
-  auto normal = KrausOperator<Gate>::kNormal;
-
   using M = Cirq::MatrixGate1<fp_type>;
 
-  ncircuit.channels.push_back(
-      {{normal, 0, p1, {M::Create(time, q, {t1, 0, 0, 0, 0, 0, r1, 0})}},
-       {normal, 0, p2, {M::Create(time, q, {r2, 0, 0, 0, 0, 0, t2, 0})}},
-       {normal, 0, p3, {M::Create(time, q, {0, 0, s1, 0, 0, 0, 0, 0})}},
-       {normal, 0, p3, {M::Create(time, q, {0, 0, 0, 0, s2, 0, 0, 0})}}});
+  Channel<fp_type> channel = {
+    {kChannel, time, {q}},
+    {
+      {false, p1, {M::Create(time, q, {t1, 0, 0, 0, 0, 0, r1, 0})}},
+      {false, p2, {M::Create(time, q, {r2, 0, 0, 0, 0, 0, t2, 0})}},
+      {false, p3, {M::Create(time, q, {0, 0, s1, 0, 0, 0, 0, 0})}},
+      {false, p3, {M::Create(time, q, {0, 0, 0, 0, s2, 0, 0, 0})}},
+    }
+  };
 
-  for (auto& kop : ncircuit.channels.back()) {
+  for (auto& kop : channel.kops) {
     kop.CalculateKdKMatrix();
   }
+
+  ncircuit.ops.push_back(std::move(channel));
 }
 
-template <typename Gate>
-void AddGenAmplDumpNoise2(
-    unsigned time, double g, NoisyCircuit<Gate>& ncircuit) {
-  using fp_type = typename Gate::fp_type;
-
+template <typename fp_type>
+void AddGenAmplDumpNoise2(unsigned time, double g,
+                          Circuit<Operation<fp_type>>& ncircuit) {
   // Probability of exchanging energy with the environment.
   double p = 0.5;
 
@@ -131,37 +143,45 @@ void AddGenAmplDumpNoise2(
   fp_type r2 = std::sqrt((1 - p) * (1 - g));
   fp_type s2 = std::sqrt((1 - p) * g);
 
-  auto normal = KrausOperator<Gate>::kNormal;
-
   using M = Cirq::MatrixGate1<fp_type>;
 
-  ncircuit.channels.push_back(
-      {{normal, 0, p1, {M::Create(time, 0, {t1, 0, 0, 0, 0, 0, r1, 0})}},
-       {normal, 0, p2, {M::Create(time, 0, {r2, 0, 0, 0, 0, 0, t2, 0})}},
-       {normal, 0, p3, {M::Create(time, 0, {0, 0, s1, 0, 0, 0, 0, 0})}},
-       {normal, 0, p3, {M::Create(time, 0, {0, 0, 0, 0, s2, 0, 0, 0})}}});
+  Channel<fp_type> channel1 = {
+    {kChannel, time, {0}},
+    {
+      {false, p1, {M::Create(time, 0, {t1, 0, 0, 0, 0, 0, r1, 0})}},
+      {false, p2, {M::Create(time, 0, {r2, 0, 0, 0, 0, 0, t2, 0})}},
+      {false, p3, {M::Create(time, 0, {0, 0, s1, 0, 0, 0, 0, 0})}},
+      {false, p3, {M::Create(time, 0, {0, 0, 0, 0, s2, 0, 0, 0})}},
+    }
+  };
 
-  for (auto& kop : ncircuit.channels.back()) {
+  for (auto& kop : channel1.kops) {
     kop.CalculateKdKMatrix();
   }
 
-  ncircuit.channels.push_back(
-      {{normal, 0, p1, {M::Create(time, 1, {t1, 0, 0, 0, 0, 0, r1, 0})}},
-       {normal, 0, p2, {M::Create(time, 1, {r2, 0, 0, 0, 0, 0, t2, 0})}},
-       {normal, 0, p3, {M::Create(time, 1, {0, 0, s1, 0, 0, 0, 0, 0})}},
-       {normal, 0, p3, {M::Create(time, 1, {0, 0, 0, 0, s2, 0, 0, 0})}}});
+  ncircuit.ops.push_back(std::move(channel1));
 
-  for (auto& kop : ncircuit.channels.back()) {
+  Channel<fp_type> channel2 = {
+    {kChannel, time, {1}},
+    {
+      {false, p1, {M::Create(time, 1, {t1, 0, 0, 0, 0, 0, r1, 0})}},
+      {false, p2, {M::Create(time, 1, {r2, 0, 0, 0, 0, 0, t2, 0})}},
+      {false, p3, {M::Create(time, 1, {0, 0, s1, 0, 0, 0, 0, 0})}},
+      {false, p3, {M::Create(time, 1, {0, 0, 0, 0, s2, 0, 0, 0})}},
+    }
+  };
+
+  for (auto& kop : channel2.kops) {
     kop.CalculateKdKMatrix();
   }
+
+  ncircuit.ops.push_back(std::move(channel2));
 }
 
 // Adds the same channel as in AddGenAmplDumpNoise2 above.
-template <typename Gate>
-void AddGenAmplDumpNoise2Alt(
-    unsigned time, double g, NoisyCircuit<Gate>& ncircuit) {
-  using fp_type = typename Gate::fp_type;
-
+template <typename fp_type>
+void AddGenAmplDumpNoise2Alt(unsigned time, double g,
+                             Circuit<Operation<fp_type>>& ncircuit) {
   // Probability of exchanging energy with the environment.
   double p = 0.5;
 
@@ -176,178 +196,170 @@ void AddGenAmplDumpNoise2Alt(
   fp_type r2 = std::sqrt((1 - p) * (1 - g));
   fp_type s2 = std::sqrt((1 - p) * g);
 
-  auto normal = KrausOperator<Gate>::kNormal;
-
   using M = Cirq::MatrixGate1<fp_type>;
 
-  ncircuit.channels.push_back(
-      {{normal, 0, p1 * p1,
-        {M::Create(time, 0, {t1, 0, 0, 0, 0, 0, r1, 0}),
-         M::Create(time, 1, {t1, 0, 0, 0, 0, 0, r1, 0})}},
-       {normal, 0, p1 * p2,
-        {M::Create(time, 0, {t1, 0, 0, 0, 0, 0, r1, 0}),
-         M::Create(time, 1, {r2, 0, 0, 0, 0, 0, t2, 0})}},
-       {normal, 0, p1 * p3,
-        {M::Create(time, 0, {t1, 0, 0, 0, 0, 0, r1, 0}),
-         M::Create(time, 1, {0, 0, s1, 0, 0, 0, 0, 0})}},
-       {normal, 0, p1 * p3,
-        {M::Create(time, 0, {t1, 0, 0, 0, 0, 0, r1, 0}),
-         M::Create(time, 1, {0, 0, 0, 0, s2, 0, 0, 0})}},
+  Channel<fp_type> channel = {
+    {kChannel, time, {0, 1}},
+    {
+      {false, p1 * p1, {M::Create(time, 0, {t1, 0, 0, 0, 0, 0, r1, 0}),
+                        M::Create(time, 1, {t1, 0, 0, 0, 0, 0, r1, 0})}},
+      {false, p1 * p2, {M::Create(time, 0, {t1, 0, 0, 0, 0, 0, r1, 0}),
+                        M::Create(time, 1, {r2, 0, 0, 0, 0, 0, t2, 0})}},
+      {false, p1 * p3, {M::Create(time, 0, {t1, 0, 0, 0, 0, 0, r1, 0}),
+                        M::Create(time, 1, {0, 0, s1, 0, 0, 0, 0, 0})}},
+      {false, p1 * p3, {M::Create(time, 0, {t1, 0, 0, 0, 0, 0, r1, 0}),
+                        M::Create(time, 1, {0, 0, 0, 0, s2, 0, 0, 0})}},
 
-       {normal, 0, p2 * p1,
-        {M::Create(time, 0, {r2, 0, 0, 0, 0, 0, t2, 0}),
-         M::Create(time, 1, {t1, 0, 0, 0, 0, 0, r1, 0})}},
-       {normal, 0, p2 * p2,
-        {M::Create(time, 0, {r2, 0, 0, 0, 0, 0, t2, 0}),
-         M::Create(time, 1, {r2, 0, 0, 0, 0, 0, t2, 0})}},
-       {normal, 0, p2 * p3,
-        {M::Create(time, 0, {r2, 0, 0, 0, 0, 0, t2, 0}),
-         M::Create(time, 1, {0, 0, s1, 0, 0, 0, 0, 0})}},
-       {normal, 0, p2 * p3,
-        {M::Create(time, 0, {r2, 0, 0, 0, 0, 0, t2, 0}),
-         M::Create(time, 1, {0, 0, 0, 0, s2, 0, 0, 0})}},
+      {false, p2 * p1, {M::Create(time, 0, {r2, 0, 0, 0, 0, 0, t2, 0}),
+                        M::Create(time, 1, {t1, 0, 0, 0, 0, 0, r1, 0})}},
+      {false, p2 * p2, {M::Create(time, 0, {r2, 0, 0, 0, 0, 0, t2, 0}),
+                        M::Create(time, 1, {r2, 0, 0, 0, 0, 0, t2, 0})}},
+      {false, p2 * p3, {M::Create(time, 0, {r2, 0, 0, 0, 0, 0, t2, 0}),
+                        M::Create(time, 1, {0, 0, s1, 0, 0, 0, 0, 0})}},
+      {false, p2 * p3, {M::Create(time, 0, {r2, 0, 0, 0, 0, 0, t2, 0}),
+                        M::Create(time, 1, {0, 0, 0, 0, s2, 0, 0, 0})}},
 
-       {normal, 0, p3 * p1,
-        {M::Create(time, 0, {0, 0, s1, 0, 0, 0, 0, 0}),
-         M::Create(time, 1, {t1, 0, 0, 0, 0, 0, r1, 0})}},
-       {normal, 0, p3 * p2,
-        {M::Create(time, 0, {0, 0, s1, 0, 0, 0, 0, 0}),
-         M::Create(time, 1, {r2, 0, 0, 0, 0, 0, t2, 0})}},
-       {normal, 0, p3 * p3,
-        {M::Create(time, 0, {0, 0, s1, 0, 0, 0, 0, 0}),
-         M::Create(time, 1, {0, 0, s1, 0, 0, 0, 0, 0})}},
-       {normal, 0, p3 * p3,
-        {M::Create(time, 0, {0, 0, s1, 0, 0, 0, 0, 0}),
-         M::Create(time, 1, {0, 0, 0, 0, s2, 0, 0, 0})}},
+      {false, p3 * p1, {M::Create(time, 0, {0, 0, s1, 0, 0, 0, 0, 0}),
+                        M::Create(time, 1, {t1, 0, 0, 0, 0, 0, r1, 0})}},
+      {false, p3 * p2, {M::Create(time, 0, {0, 0, s1, 0, 0, 0, 0, 0}),
+                        M::Create(time, 1, {r2, 0, 0, 0, 0, 0, t2, 0})}},
+      {false, p3 * p3, {M::Create(time, 0, {0, 0, s1, 0, 0, 0, 0, 0}),
+                        M::Create(time, 1, {0, 0, s1, 0, 0, 0, 0, 0})}},
+      {false, p3 * p3, {M::Create(time, 0, {0, 0, s1, 0, 0, 0, 0, 0}),
+                        M::Create(time, 1, {0, 0, 0, 0, s2, 0, 0, 0})}},
 
-       {normal, 0, p3 * p1,
-        {M::Create(time, 0, {0, 0, 0, 0, s2, 0, 0, 0}),
-         M::Create(time, 1, {t1, 0, 0, 0, 0, 0, r1, 0})}},
-       {normal, 0, p3 * p2,
-        {M::Create(time, 0, {0, 0, 0, 0, s2, 0, 0, 0}),
-         M::Create(time, 1, {r2, 0, 0, 0, 0, 0, t2, 0})}},
-       {normal, 0, p3 * p3,
-        {M::Create(time, 0, {0, 0, 0, 0, s2, 0, 0, 0}),
-         M::Create(time, 1, {0, 0, s1, 0, 0, 0, 0, 0})}},
-       {normal, 0, p3 * p3,
-        {M::Create(time, 0, {0, 0, 0, 0, s2, 0, 0, 0}),
-         M::Create(time, 1, {0, 0, 0, 0, s2, 0, 0, 0})}},
-      });
+      {false, p3 * p1, {M::Create(time, 0, {0, 0, 0, 0, s2, 0, 0, 0}),
+                        M::Create(time, 1, {t1, 0, 0, 0, 0, 0, r1, 0})}},
+      {false, p3 * p2, {M::Create(time, 0, {0, 0, 0, 0, s2, 0, 0, 0}),
+                        M::Create(time, 1, {r2, 0, 0, 0, 0, 0, t2, 0})}},
+      {false, p3 * p3, {M::Create(time, 0, {0, 0, 0, 0, s2, 0, 0, 0}),
+                        M::Create(time, 1, {0, 0, s1, 0, 0, 0, 0, 0})}},
+      {false, p3 * p3, {M::Create(time, 0, {0, 0, 0, 0, s2, 0, 0, 0}),
+                      M::Create(time, 1, {0, 0, 0, 0, s2, 0, 0, 0})}},
+    }
+  };
 
-  for (auto& kop : ncircuit.channels.back()) {
+  for (auto& kop : channel.kops) {
     kop.CalculateKdKMatrix();
   }
+
+  ncircuit.ops.push_back(std::move(channel));
 }
 
-template <typename Gate>
-void AddAmplDumpNoise1(
-    unsigned time, unsigned q, double g, NoisyCircuit<Gate>& ncircuit) {
-  using fp_type = typename Gate::fp_type;
-
+template <typename fp_type>
+void AddAmplDumpNoise1(unsigned time, unsigned q, double g,
+                       Circuit<Operation<fp_type>>& ncircuit) {
   double p1 = 1 - g;
   double p2 = 0;
 
   fp_type r = std::sqrt(p1);
   fp_type s = std::sqrt(g);
 
-  auto normal = KrausOperator<Gate>::kNormal;
-
   using M = Cirq::MatrixGate1<fp_type>;
 
-  ncircuit.channels.push_back(
-      {{normal, 0, p1, {M::Create(time, q, {1, 0, 0, 0, 0, 0, r, 0})}},
-       {normal, 0, p2, {M::Create(time, q, {0, 0, s, 0, 0, 0, 0, 0})}}});
+  Channel<fp_type> channel = {
+    {kChannel, time, {q}},
+    {
+      {false, p1, {M::Create(time, q, {1, 0, 0, 0, 0, 0, r, 0})}},
+      {false, p2, {M::Create(time, q, {0, 0, s, 0, 0, 0, 0, 0})}},
+    }
+  };
 
-  for (auto& kop : ncircuit.channels.back()) {
+  for (auto& kop : channel.kops) {
     kop.CalculateKdKMatrix();
   }
+
+  ncircuit.ops.push_back(std::move(channel));
 }
 
-template <typename Gate>
-void AddAmplDumpNoise2(
-    unsigned time, double g, NoisyCircuit<Gate>& ncircuit) {
-  using fp_type = typename Gate::fp_type;
-
+template <typename fp_type>
+void AddAmplDumpNoise2(unsigned time, double g,
+                       Circuit<Operation<fp_type>>& ncircuit) {
   double p1 = 1 - g;
   double p2 = 0;
 
   fp_type r = std::sqrt(p1);
   fp_type s = std::sqrt(g);
 
-  auto normal = KrausOperator<Gate>::kNormal;
-
   using M = Cirq::MatrixGate1<fp_type>;
 
-  ncircuit.channels.push_back(
-      {{normal, 0, p1, {M::Create(time, 0, {1, 0, 0, 0, 0, 0, r, 0})}},
-       {normal, 0, p2, {M::Create(time, 0, {0, 0, s, 0, 0, 0, 0, 0})}}});
+  Channel<fp_type> channel1 = {
+    {kChannel, time, {0}},
+    {
+      {false, p1, {M::Create(time, 0, {1, 0, 0, 0, 0, 0, r, 0})}},
+      {false, p2, {M::Create(time, 0, {0, 0, s, 0, 0, 0, 0, 0})}},
+    }
+  };
 
-  for (auto& kop : ncircuit.channels.back()) {
+  for (auto& kop : channel1.kops) {
     kop.CalculateKdKMatrix();
   }
 
-  ncircuit.channels.push_back(
-      {{normal, 0, p1, {M::Create(time, 1, {1, 0, 0, 0, 0, 0, r, 0})}},
-       {normal, 0, p2, {M::Create(time, 1, {0, 0, s, 0, 0, 0, 0, 0})}}});
+  ncircuit.ops.push_back(std::move(channel1));
 
-  for (auto& kop : ncircuit.channels.back()) {
+  Channel<fp_type> channel2 = {
+    {kChannel, time, {1}},
+    {
+      {false, p1, {M::Create(time, 1, {1, 0, 0, 0, 0, 0, r, 0})}},
+      {false, p2, {M::Create(time, 1, {0, 0, s, 0, 0, 0, 0, 0})}},
+    }
+  };
+
+  for (auto& kop : channel2.kops) {
     kop.CalculateKdKMatrix();
   }
+
+  ncircuit.ops.push_back(std::move(channel2));
 }
 
-template <typename Gate, typename AddNoise1, typename AddNoise2>
-NoisyCircuit<Gate> GenerateNoisyCircuit(
+template <typename fp_type, typename AddNoise1, typename AddNoise2>
+Circuit<Operation<fp_type>> GenerateNoisyCircuit(
     double p, AddNoise1&& add_noise1, AddNoise2&& add_noise2,
     bool add_measurement = true) {
-  using fp_type = typename Gate::fp_type;
-
-  NoisyCircuit<Gate> ncircuit;
+  Circuit<Operation<fp_type>> ncircuit;
 
   ncircuit.num_qubits = 2;
-  ncircuit.channels.reserve(24);
+  ncircuit.ops.reserve(24);
 
   using Hd = Cirq::H<fp_type>;
   using IS = Cirq::ISWAP<fp_type>;
   using Rx = Cirq::rx<fp_type>;
   using Ry = Cirq::ry<fp_type>;
 
-  auto normal = KrausOperator<Gate>::kNormal;
-
-  ncircuit.channels.push_back({{normal, 1, 1.0, {Hd::Create(0, 0)}}});
+  ncircuit.ops.push_back(Hd::Create(0, 0));
   add_noise1(1, 0, p, ncircuit);
-  ncircuit.channels.push_back({{normal, 1, 1.0, {Hd::Create(0, 1)}}});
+  ncircuit.ops.push_back(Hd::Create(0, 1));
   add_noise1(1, 1, p, ncircuit);
-  ncircuit.channels.push_back({{normal, 1, 1.0, {IS::Create(2, 0, 1)}}});
+  ncircuit.ops.push_back(IS::Create(2, 0, 1));
   add_noise2(3, p, ncircuit);
-  ncircuit.channels.push_back({{normal, 1, 1.0, {Rx::Create(4, 0, 0.7)}}});
+  ncircuit.ops.push_back(Rx::Create(4, 0, 0.7));
   add_noise1(5, 0, p, ncircuit);
-  ncircuit.channels.push_back({{normal, 1, 1.0, {Ry::Create(4, 1, 0.1)}}});
+  ncircuit.ops.push_back(Ry::Create(4, 1, 0.1));
   add_noise1(5, 1, p, ncircuit);
-  ncircuit.channels.push_back({{normal, 1, 1.0, {IS::Create(6, 0, 1)}}});
+  ncircuit.ops.push_back(IS::Create(6, 0, 1));
   add_noise2(7, p, ncircuit);
-  ncircuit.channels.push_back({{normal, 1, 1.0, {Ry::Create(8, 0, 0.4)}}});
+  ncircuit.ops.push_back(Ry::Create(8, 0, 0.4));
   add_noise1(9, 0, p, ncircuit);
-  ncircuit.channels.push_back({{normal, 1, 1.0, {Rx::Create(8, 1, 0.7)}}});
+  ncircuit.ops.push_back(Rx::Create(8, 1, 0.7));
   add_noise1(9, 1, p, ncircuit);
-  ncircuit.channels.push_back({{normal, 1, 1.0, {IS::Create(10, 0, 1)}}});
+  ncircuit.ops.push_back(IS::Create(10, 0, 1));
   add_noise2(11, p, ncircuit);
+
   if (add_measurement) {
-    ncircuit.channels.push_back(
-        {{KrausOperator<Gate>::kMeasurement, 1, 1.0,
-          {gate::Measurement<Gate>::Create(12, {0, 1})}}});
+    ncircuit.ops.push_back(CreateMeasurement(12, {0, 1}));
     add_noise2(13, p, ncircuit);
   }
 
   return ncircuit;
 }
 
-template <typename Runner, typename Factory, typename Gate>
-void RunBatch(const Factory& factory, const NoisyCircuit<Gate>& ncircuit,
+template <typename Runner, typename Factory, typename NoisyCircuit>
+void RunBatch(const Factory& factory, const NoisyCircuit& ncircuit,
               const std::vector<double>& expected_results) {
   using Simulator = typename Factory::Simulator;
   using StateSpace = typename Simulator::StateSpace;
   using State = typename StateSpace::State;
-  using QTSimulator = QuantumTrajectorySimulator<IO, Gate, Runner>;
+  using QTSimulator = QuantumTrajectorySimulator<IO, Runner>;
 
   unsigned num_qubits = 2;
   unsigned num_reps = 25000;
@@ -375,14 +387,13 @@ void RunBatch(const Factory& factory, const NoisyCircuit<Gate>& ncircuit,
   }
 }
 
-template <typename Runner, typename Factory, typename Gate>
-void RunOnceRepeatedly(const Factory& factory,
-                       const NoisyCircuit<Gate>& ncircuit,
+template <typename Runner, typename Factory, typename NoisyCircuit>
+void RunOnceRepeatedly(const Factory& factory, const NoisyCircuit& ncircuit,
                        const std::vector<double>& expected_results) {
   using Simulator = typename Factory::Simulator;
   using StateSpace = typename Factory::StateSpace;
   using State = typename StateSpace::State;
-  using QTSimulator = QuantumTrajectorySimulator<IO, Gate, Runner>;
+  using QTSimulator = QuantumTrajectorySimulator<IO, Runner>;
 
   unsigned num_qubits = 2;
   unsigned num_reps = 25000;
@@ -415,15 +426,15 @@ void RunOnceRepeatedly(const Factory& factory,
   }
 }
 
-template <typename Runner, typename Factory, typename Gate>
+template <typename Runner, typename fp_type, typename Factory>
 std::vector<std::complex<double>> ExpValsRunBatch(
-    const Factory& factory, const NoisyCircuit<Gate>& ncircuit,
+    const Factory& factory, const Circuit<Operation<fp_type>>& ncircuit,
     bool reuse_results) {
   using Simulator = typename Factory::Simulator;
   using StateSpace = typename Factory::StateSpace;
   using State = typename StateSpace::State;
-  using Fuser = MultiQubitGateFuser<IO, Gate>;
-  using QTSimulator = QuantumTrajectorySimulator<IO, Gate, Runner>;
+  using Fuser = MultiQubitGateFuser<IO>;
+  using QTSimulator = QuantumTrajectorySimulator<IO, Runner>;
 
   unsigned num_qubits = 2;
   unsigned num_reps = 25000;
@@ -439,11 +450,11 @@ std::vector<std::complex<double>> ExpValsRunBatch(
   typename QTSimulator::Parameter param;
   param.apply_last_deferred_ops = !reuse_results;
 
-  using Observables = std::vector<std::vector<qsim::OpString<Gate>>>;
+  using Observables = std::vector<std::vector<qsim::OpString<fp_type>>>;
   Observables observables;
   observables.reserve(num_qubits);
 
-  using rx = qsim::Cirq::rx<typename Gate::fp_type>;
+  using rx = qsim::Cirq::rx<fp_type>;
 
   for (unsigned q = 0; q < num_qubits; ++q) {
     observables.push_back({{{1.0, 0.0}, {rx::Create(0, q, 1.7 + 0.6 * q)}}});
@@ -504,15 +515,15 @@ std::vector<std::complex<double>> ExpValsRunBatch(
   return results;
 }
 
-template <typename Runner, typename Factory, typename Gate>
+template <typename Runner, typename fp_type, typename Factory>
 std::vector<std::complex<double>> ExpValsRunOnceRepeatedly(
-    const Factory& factory, const NoisyCircuit<Gate>& ncircuit,
+    const Factory& factory, const Circuit<Operation<fp_type>>& ncircuit,
     bool reuse_results) {
   using Simulator = typename Factory::Simulator;
   using StateSpace = typename Factory::StateSpace;
   using State = typename StateSpace::State;
-  using Fuser = MultiQubitGateFuser<IO, Gate>;
-  using QTSimulator = QuantumTrajectorySimulator<IO, Gate, Runner>;
+  using Fuser = MultiQubitGateFuser<IO>;
+  using QTSimulator = QuantumTrajectorySimulator<IO, Runner>;
 
   unsigned num_qubits = 2;
   unsigned num_reps = 25000;
@@ -528,10 +539,10 @@ std::vector<std::complex<double>> ExpValsRunOnceRepeatedly(
   typename QTSimulator::Parameter param;
   param.apply_last_deferred_ops = true;
 
-  std::vector<std::vector<qsim::OpString<Gate>>> observables;
+  std::vector<std::vector<qsim::OpString<fp_type>>> observables;
   observables.reserve(num_qubits);
 
-  using rx = qsim::Cirq::rx<typename Gate::fp_type>;
+  using rx = qsim::Cirq::rx<fp_type>;
 
   for (unsigned q = 0; q < num_qubits; ++q) {
     observables.push_back({{{1.0, 0.0}, {rx::Create(0, q, 1.7 + 0.6 * q)}}});
@@ -625,10 +636,10 @@ for key, val in sorted(res.histogram(key='m').items()):
     0.389352, 0.242790, 0.081009, 0.286850,
   };
 
-  using Gate = Cirq::GateCirq<typename Factory::fp_type>;
+  using fp_type = typename Factory::fp_type;
 
-  auto ncircuit = GenerateNoisyCircuit<Gate>(0.01, AddBitFlipNoise1<Gate>,
-                                             AddBitFlipNoise2<Gate>);
+  auto ncircuit = GenerateNoisyCircuit<fp_type>(
+      0.01, AddBitFlipNoise1<fp_type>, AddBitFlipNoise2<fp_type>);
   RunBatch<Runner>(factory, ncircuit, expected_results);
 }
 
@@ -683,32 +694,34 @@ for key, val in sorted(res.histogram(key='m').items()):
     0.318501, 0.260538, 0.164616, 0.256345,
   };
 
-  using Gate = Cirq::GateCirq<typename Factory::fp_type>;
+  using fp_type = typename Factory::fp_type;
 
   {
-    auto ncircuit = GenerateNoisyCircuit<Gate>(0.1, AddGenAmplDumpNoise1<Gate>,
-                                               AddGenAmplDumpNoise2<Gate>);
+    auto ncircuit = GenerateNoisyCircuit<fp_type>(
+        0.1, AddGenAmplDumpNoise1<fp_type>, AddGenAmplDumpNoise2<fp_type>);
     RunOnceRepeatedly<Runner>(factory, ncircuit, expected_results);
   }
 
   {
-    auto ncircuit = GenerateNoisyCircuit<Gate>(0.1, AddGenAmplDumpNoise1<Gate>,
-                                               AddGenAmplDumpNoise2Alt<Gate>);
+    auto ncircuit = GenerateNoisyCircuit<fp_type>(
+        0.1, AddGenAmplDumpNoise1<fp_type>, AddGenAmplDumpNoise2Alt<fp_type>);
     RunOnceRepeatedly<Runner>(factory, ncircuit, expected_results);
   }
 }
 
 template <typename Runner, typename Factory>
 void TestReusingResults(const Factory& factory) {
-  using Gate = Cirq::GateCirq<typename Factory::fp_type>;
+  using fp_type = typename Factory::fp_type;
 
-  auto ncircuit = GenerateNoisyCircuit<Gate>(0.02, AddAmplDumpNoise1<Gate>,
-                                             AddAmplDumpNoise2<Gate>, false);
+  auto ncircuit = GenerateNoisyCircuit<fp_type>(
+      0.02, AddAmplDumpNoise1<fp_type>, AddAmplDumpNoise2<fp_type>, false);
 
-  auto results1 = ExpValsRunOnceRepeatedly<Runner>(factory, ncircuit, false);
-  auto results2 = ExpValsRunOnceRepeatedly<Runner>(factory, ncircuit, true);
-  auto results3 = ExpValsRunBatch<Runner>(factory, ncircuit, false);
-  auto results4 = ExpValsRunBatch<Runner>(factory, ncircuit, true);
+  auto results1 =
+      ExpValsRunOnceRepeatedly<Runner, fp_type>(factory, ncircuit, false);
+  auto results2 =
+      ExpValsRunOnceRepeatedly<Runner, fp_type>(factory, ncircuit, true);
+  auto results3 = ExpValsRunBatch<Runner, fp_type>(factory, ncircuit, false);
+  auto results4 = ExpValsRunBatch<Runner, fp_type>(factory, ncircuit, true);
 
   for (std::size_t k = 0; k < results1.size(); ++k) {
     EXPECT_NEAR(std::real(results1[k]), std::real(results2[k]), 1e-8);
@@ -726,8 +739,7 @@ void TestCollectKopStat(const Factory& factory) {
   using StateSpace = typename Factory::StateSpace;
   using State = typename StateSpace::State;
   using fp_type = typename StateSpace::fp_type;
-  using GateCirq = Cirq::GateCirq<fp_type>;
-  using QTSimulator = QuantumTrajectorySimulator<IO, GateCirq, Runner>;
+  using QTSimulator = QuantumTrajectorySimulator<IO, Runner>;
 
   unsigned num_qubits = 4;
   unsigned num_reps = 20000;
@@ -740,27 +752,41 @@ void TestCollectKopStat(const Factory& factory) {
   using I = Cirq::I1<fp_type>;
   using X = Cirq::X<fp_type>;
 
-  auto normal = KrausOperator<GateCirq>::kNormal;
-
-  NoisyCircuit<GateCirq> ncircuit;
+  Circuit<Operation<fp_type>> ncircuit;
 
   ncircuit.num_qubits = num_qubits;
-  ncircuit.channels.reserve(8);
+  ncircuit.ops.reserve(8);
 
-  ncircuit.channels.push_back({{normal, 1, 1.0, {Hd::Create(0, 0)}}});
-  ncircuit.channels.push_back({{normal, 1, 1.0, {Hd::Create(0, 1)}}});
-  ncircuit.channels.push_back({{normal, 1, 1.0, {Hd::Create(0, 2)}}});
-  ncircuit.channels.push_back({{normal, 1, 1.0, {Hd::Create(0, 3)}}});
+  ncircuit.ops.push_back(Hd::Create(0, 0));
+  ncircuit.ops.push_back(Hd::Create(0, 1));
+  ncircuit.ops.push_back(Hd::Create(0, 2));
+  ncircuit.ops.push_back(Hd::Create(0, 3));
+
+  Channel<fp_type> channel1 = {
+    {kChannel, 1, {0}},
+    {{true, p1, {I::Create(1, 0)}}, {true, p2, {X::Create(1, 0)}}},
+  };
+
+  Channel<fp_type> channel2 = {
+    {kChannel, 1, {1}},
+    {{true, p1, {I::Create(1, 1)}}, {true, p2, {X::Create(1, 1)}}},
+  };
+
+  Channel<fp_type> channel3 = {
+    {kChannel, 1, {2}},
+    {{true, p1, {I::Create(1, 2)}}, {true, p2, {X::Create(1, 2)}}},
+  };
+
+  Channel<fp_type> channel4 = {
+    {kChannel, 1, {3}},
+    {{true, p1, {I::Create(1, 3)}}, {true, p2, {X::Create(1, 3)}}},
+  };
 
   // Add bit flip noise.
-  ncircuit.channels.push_back({{normal, 1, p1, {I::Create(1, 0)}},
-                      {normal, 1, p2, {X::Create(1, 0)}}});
-  ncircuit.channels.push_back({{normal, 1, p1, {I::Create(1, 1)}},
-                      {normal, 1, p2, {X::Create(1, 1)}}});
-  ncircuit.channels.push_back({{normal, 1, p1, {I::Create(1, 2)}},
-                      {normal, 1, p2, {X::Create(1, 2)}}});
-  ncircuit.channels.push_back({{normal, 1, p1, {I::Create(1, 3)}},
-                      {normal, 1, p2, {X::Create(1, 3)}}});
+  ncircuit.ops.push_back(std::move(channel1));
+  ncircuit.ops.push_back(std::move(channel2));
+  ncircuit.ops.push_back(std::move(channel3));
+  ncircuit.ops.push_back(std::move(channel4));
 
   auto measure = [](uint64_t r, const State& state,
                     const typename QTSimulator::Stat& stat,
@@ -800,7 +826,7 @@ void TestCleanCircuit(const Factory& factory) {
   using State = typename StateSpace::State;
   using fp_type = typename StateSpace::fp_type;
   using GateCirq = Cirq::GateCirq<fp_type>;
-  using QTSimulator = QuantumTrajectorySimulator<IO, GateCirq, Runner>;
+  using QTSimulator = QuantumTrajectorySimulator<IO, Runner>;
 
   unsigned num_qubits = 4;
   auto size = uint64_t{1} << num_qubits;
@@ -834,15 +860,13 @@ void TestCleanCircuit(const Factory& factory) {
   circuit.push_back(Cirq::YPowGate<fp_type>::Create(5, 2, 0.9, 0.4));
   circuit.push_back(Cirq::ZPowGate<fp_type>::Create(5, 3, 1.0, 0.5));
 
-  NoisyCircuit<GateCirq> ncircuit;
+  Circuit<Operation<fp_type>> ncircuit;
 
   ncircuit.num_qubits = num_qubits;
-  ncircuit.channels.reserve(circuit.size());
-
-  auto normal = KrausOperator<GateCirq>::kNormal;
+  ncircuit.ops.reserve(circuit.size());
 
   for (std::size_t i = 0; i < circuit.size(); ++i) {
-    ncircuit.channels.push_back({{normal, 1, 1.0, {circuit[i]}}});
+    ncircuit.ops.push_back(MakeChannelFromGate(circuit[i]));
   }
 
   Simulator simulator = factory.CreateSimulator();
@@ -863,15 +887,14 @@ void TestCleanCircuit(const Factory& factory) {
   EXPECT_FALSE(state_space.IsNull(nstate));
 
   typename QTSimulator::Stat stat;
-
   typename QTSimulator::Parameter param;
 
   state_space.SetStateZero(nstate);
 
   // Run quantum trajectory simulator.
-  EXPECT_TRUE(QTSimulator::RunOnce(param, num_qubits, ncircuit.channels.begin(),
-                                   ncircuit.channels.end(), 0, state_space,
-                                   simulator, nstate, stat));
+  EXPECT_TRUE(QTSimulator::template RunOnce<Operation<fp_type>>(
+      param, num_qubits, ncircuit.ops.begin(), ncircuit.ops.end(),
+      0, state_space, simulator, nstate, stat));
 
   EXPECT_EQ(stat.samples.size(), 0);
 
@@ -890,24 +913,33 @@ void TestInitialState(const Factory& factory) {
   using StateSpace = typename Factory::StateSpace;
   using State = typename StateSpace::State;
   using fp_type = typename StateSpace::fp_type;
-  using GateCirq = Cirq::GateCirq<fp_type>;
-  using QTSimulator = QuantumTrajectorySimulator<IO, GateCirq, Runner>;
+  using QTSimulator = QuantumTrajectorySimulator<IO, Runner>;
 
   unsigned num_qubits = 3;
 
-  NoisyCircuit<GateCirq> ncircuit;
+  Circuit<Operation<fp_type>> ncircuit;
 
   ncircuit.num_qubits = num_qubits;
-  ncircuit.channels.reserve(3);
+  ncircuit.ops.reserve(3);
 
-  auto normal = KrausOperator<GateCirq>::kNormal;
+  Channel<fp_type> channel1 = {
+    {kChannel, 0, {0}},
+    {{true, 1.0, {Cirq::X<fp_type>::Create(0, 0)}}},
+  };
 
-  ncircuit.channels.push_back(
-      {{normal, 1, 1.0, {Cirq::X<fp_type>::Create(0, 0)}}});
-  ncircuit.channels.push_back(
-      {{normal, 1, 1.0, {Cirq::X<fp_type>::Create(0, 1)}}});
-  ncircuit.channels.push_back(
-      {{normal, 1, 1.0, {Cirq::X<fp_type>::Create(0, 2)}}});
+  Channel<fp_type> channel2 = {
+    {kChannel, 0, {1}},
+    {{true, 1.0, {Cirq::X<fp_type>::Create(0, 1)}}},
+  };
+
+  Channel<fp_type> channel3 = {
+    {kChannel, 0, {2}},
+    {{true, 1.0, {Cirq::X<fp_type>::Create(0, 2)}}},
+  };
+
+  ncircuit.ops.push_back(std::move(channel1));
+  ncircuit.ops.push_back(std::move(channel2));
+  ncircuit.ops.push_back(std::move(channel3));
 
   Simulator simulator = factory.CreateSimulator();
   StateSpace state_space = factory.CreateStateSpace();
@@ -938,12 +970,11 @@ void TestUncomputeFinalState(const Factory& factory) {
   using StateSpace = typename Factory::StateSpace;
   using State = typename StateSpace::State;
   using fp_type = typename StateSpace::fp_type;
-  using GateCirq = Cirq::GateCirq<fp_type>;
-  using QTSimulator = QuantumTrajectorySimulator<IO, GateCirq, Runner>;
+  using QTSimulator = QuantumTrajectorySimulator<IO, Runner>;
 
   unsigned num_qubits = 4;
 
-  std::vector<GateCirq> circuit = {
+  std::vector<Operation<fp_type>> circuit = {
     Cirq::H<fp_type>::Create(0, 0),
     Cirq::H<fp_type>::Create(0, 1),
     Cirq::H<fp_type>::Create(0, 2),
@@ -964,7 +995,7 @@ void TestUncomputeFinalState(const Factory& factory) {
 
   // Works only with mixtures.
   auto channel = Cirq::bit_flip<fp_type>(0.3);
-  auto ncircuit = MakeNoisy(num_qubits, circuit, channel);
+  auto ncircuit = MakeNoisy<fp_type>(num_qubits, circuit, channel);
 
   Simulator simulator = factory.CreateSimulator();
   StateSpace state_space = factory.CreateStateSpace();
@@ -984,16 +1015,21 @@ void TestUncomputeFinalState(const Factory& factory) {
   EXPECT_TRUE(QTSimulator::RunOnce(
       param, ncircuit, 0, state_space, simulator, state, stat));
 
-  EXPECT_EQ(ncircuit.channels.size(), stat.samples.size());
+  EXPECT_EQ(ncircuit.ops.size(), stat.samples.size());
 
   // Uncompute the final state back to |0000> (up to round-off errors).
-  for (std::size_t i = 0; i < ncircuit.channels.size(); ++i) {
-    auto k = ncircuit.channels.size() - 1 - i;
+  for (std::size_t i = 0; i < ncircuit.ops.size(); ++i) {
+    auto k = ncircuit.ops.size() - 1 - i;
+    const auto& op = ncircuit.ops[k];
 
-    const auto& ops = ncircuit.channels[k][stat.samples[k]].ops;
+    if (const auto* pg = OpGetAlternative<Channel<fp_type>>(op)) {
+      const auto& ops = pg->kops[stat.samples[k]].ops;
 
-    for (auto it = ops.rbegin(); it != ops.rend(); ++it) {
-      ApplyGateDagger(simulator, *it, state);
+      for (auto it = ops.rbegin(); it != ops.rend(); ++it) {
+        ApplyGateDagger(simulator, *it, state);
+      }
+    } else {
+      ApplyGateDagger(simulator, op, state);
     }
   }
 

--- a/tests/run_custatevecex_test.cu
+++ b/tests/run_custatevecex_test.cu
@@ -24,7 +24,6 @@
 #include "gtest/gtest.h"
 
 #include "../lib/circuit_qsim_parser.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/io.h"
 #include "../lib/multiprocess_custatevecex.h"
 #include "../lib/run_custatevecex.h"
@@ -82,11 +81,11 @@ struct Factory {
 
 TEST(RunQSimTest, QSimRunner1) {
   std::stringstream ss(circuit_string);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 4);
-  EXPECT_EQ(circuit.gates.size(), 27);
+  EXPECT_EQ(circuit.ops.size(), 27);
 
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;
@@ -120,11 +119,11 @@ TEST(RunQSimTest, QSimRunner1) {
 
 TEST(RunQSimTest, QSimRunner2) {
   std::stringstream ss(circuit_string);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 4);
-  EXPECT_EQ(circuit.gates.size(), 27);
+  EXPECT_EQ(circuit.ops.size(), 27);
 
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;
@@ -176,11 +175,11 @@ R"(2
 
 TEST(RunQSimTest, QSimSampler) {
   std::stringstream ss(sample_circuit_string);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 2);
-  EXPECT_EQ(circuit.gates.size(), 11);
+  EXPECT_EQ(circuit.ops.size(), 11);
 
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;

--- a/tests/run_qsim_test.cc
+++ b/tests/run_qsim_test.cc
@@ -24,8 +24,8 @@
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_basic.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/io.h"
+#include "../lib/operation.h"
 #include "../lib/run_qsim.h"
 #include "../lib/simmux.h"
 
@@ -79,16 +79,16 @@ struct Factory {
 
 TEST(RunQSimTest, QSimRunner1) {
   std::stringstream ss(circuit_string);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 4);
-  EXPECT_EQ(circuit.gates.size(), 27);
+  EXPECT_EQ(circuit.ops.size(), 27);
 
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
-  using Runner = QSimRunner<IO, BasicGateFuser<IO, GateQSim<float>>, Factory>;
+  using Runner = QSimRunner<IO, BasicGateFuser<IO>, Factory>;
 
   float entropy = 0;
 
@@ -117,16 +117,16 @@ TEST(RunQSimTest, QSimRunner1) {
 
 TEST(RunQSimTest, QSimRunner2) {
   std::stringstream ss(circuit_string);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 4);
-  EXPECT_EQ(circuit.gates.size(), 27);
+  EXPECT_EQ(circuit.ops.size(), 27);
 
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
-  using Runner = QSimRunner<IO, BasicGateFuser<IO, GateQSim<float>>, Factory>;
+  using Runner = QSimRunner<IO, BasicGateFuser<IO>, Factory>;
 
   StateSpace state_space = Factory::CreateStateSpace();
   State state = state_space.Create(circuit.num_qubits);
@@ -172,17 +172,17 @@ R"(2
 
 TEST(RunQSimTest, QSimSampler) {
   std::stringstream ss(sample_circuit_string);
-  Circuit<GateQSim<float>> circuit;
+  Circuit<Operation<float>> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 2);
-  EXPECT_EQ(circuit.gates.size(), 11);
+  EXPECT_EQ(circuit.ops.size(), 11);
 
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;
   using Result = StateSpace::MeasurementResult;
   using State = StateSpace::State;
-  using Runner = QSimRunner<IO, BasicGateFuser<IO, GateQSim<float>>, Factory>;
+  using Runner = QSimRunner<IO, BasicGateFuser<IO>, Factory>;
 
   StateSpace state_space = Factory::CreateStateSpace();
   State state = state_space.Create(circuit.num_qubits);
@@ -220,8 +220,7 @@ TEST(RunQSimTest, CirqGates) {
   using Simulator = Factory::Simulator;
   using StateSpace = Simulator::StateSpace;
   using State = StateSpace::State;
-  using Runner = QSimRunner<IO, BasicGateFuser<IO, Cirq::GateCirq<float>>,
-                            Factory>;
+  using Runner = QSimRunner<IO, BasicGateFuser<IO>, Factory>;
 
   StateSpace state_space = Factory::CreateStateSpace();
   State state = state_space.Create(circuit.num_qubits);

--- a/tests/run_qsimh_test.cc
+++ b/tests/run_qsimh_test.cc
@@ -24,8 +24,8 @@
 #include "../lib/circuit_qsim_parser.h"
 #include "../lib/formux.h"
 #include "../lib/fuser_basic.h"
-#include "../lib/gates_qsim.h"
 #include "../lib/io.h"
+#include "../lib/operation.h"
 #include "../lib/run_qsimh.h"
 #include "../lib/simulator_basic.h"
 
@@ -116,15 +116,15 @@ struct Factory {
 
 TEST(RunQSimHTest, QSimHRunner) {
   std::stringstream ss(circuit_string);
-  Circuit<GateQSim<Factory::fp_type>> circuit;
+  Circuit<Operation<Factory::fp_type>> circuit;
 
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(99, provider, ss, circuit));
   EXPECT_EQ(circuit.num_qubits, 4);
-  EXPECT_EQ(circuit.gates.size(), 63);
+  EXPECT_EQ(circuit.ops.size(), 63);
 
-  using HybridSimulator =
-      HybridSimulator<IO, GateQSim<Factory::fp_type>, BasicGateFuser, For>;
-  using Runner = QSimHRunner<IO, HybridSimulator>;
+  using Fuser = BasicGateFuser<IO>;
+  using HybridSimulator = HybridSimulator<IO, For>;
+  using Runner = QSimHRunner<IO, Fuser, HybridSimulator>;
 
   Runner::Parameter param;
   param.prefix = 0;
@@ -183,9 +183,9 @@ TEST(RunQSimHTest, CirqGates) {
   auto circuit = CirqCircuit1::GetCircuit<Factory::fp_type>(false);
   const auto& expected_results = CirqCircuit1::expected_results0;
 
-  using HybridSimulator = HybridSimulator<IO, Cirq::GateCirq<Factory::fp_type>,
-                                          BasicGateFuser, For>;
-  using Runner = QSimHRunner<IO, HybridSimulator>;
+  using Fuser = BasicGateFuser<IO>;
+  using HybridSimulator = HybridSimulator<IO, For>;
+  using Runner = QSimHRunner<IO, Fuser, HybridSimulator>;
 
   Runner::Parameter param;
   param.prefix = 0;

--- a/tests/simulator_testfixture.h
+++ b/tests/simulator_testfixture.h
@@ -23,10 +23,12 @@
 #include "gtest/gtest.h"
 
 #include "../lib/expect.h"
+#include "../lib/fuser.h"
 #include "../lib/fuser_mqubit.h"
 #include "../lib/gate_appl.h"
 #include "../lib/gates_qsim.h"
 #include "../lib/io.h"
+#include "../lib/operation.h"
 #include "../lib/util_cpu.h"
 
 namespace qsim {
@@ -224,10 +226,10 @@ void TestApplyGate5(const Factory& factory) {
   auto gate25 = GateRX<fp_type>::Create(11, 4, 0.3);
   auto gate26 = GateGPh<fp_type>::Create(12, -1, 0);
 
-  GateFused<GateQSim<fp_type>> fgate1{kGateCZ, 2, {0, 1},  &gate11,
+  FusedGate<fp_type> fgate1{kGateCZ, 2, {0, 1},  &gate11,
       {&gate1, &gate2, &gate6, &gate7, &gate11, &gate12, &gate13}, {}};
   CalculateFusedMatrix(fgate1);
-  ApplyFusedGate(simulator, fgate1, state);
+  ApplyGate(simulator, fgate1, state);
 
   EXPECT_NEAR(state_space.Norm(state), 1, 1e-6);
 
@@ -246,10 +248,10 @@ void TestApplyGate5(const Factory& factory) {
     EXPECT_NEAR(std::imag(ampl3), 0.5, 1e-6);
   }
 
-  GateFused<GateQSim<fp_type>> fgate2{kGateIS, 4, {1, 2}, &gate14,
+  FusedGate<fp_type> fgate2{kGateIS, 4, {1, 2}, &gate14,
       {&gate3, &gate8, &gate14, &gate15, &gate16}, {}};
   CalculateFusedMatrix(fgate2);
-  ApplyFusedGate(simulator, fgate2, state);
+  ApplyGate(simulator, fgate2, state);
 
   EXPECT_NEAR(state_space.Norm(state), 1, 1e-6);
 
@@ -268,10 +270,10 @@ void TestApplyGate5(const Factory& factory) {
     EXPECT_NEAR(std::imag(ampl3), 0, 1e-6);
   }
 
-  GateFused<GateQSim<fp_type>> fgate3{kGateCNot, 6, {2, 3}, &gate17,
+  FusedGate<fp_type> fgate3{kGateCNot, 6, {2, 3}, &gate17,
       {&gate4, &gate9, &gate17, &gate18, &gate19},{}};
   CalculateFusedMatrix(fgate3);
-  ApplyFusedGate(simulator, fgate3, state);
+  ApplyGate(simulator, fgate3, state);
 
   EXPECT_NEAR(state_space.Norm(state), 1, 1e-6);
 
@@ -290,10 +292,10 @@ void TestApplyGate5(const Factory& factory) {
     EXPECT_NEAR(std::imag(ampl3), 0.00031570, 1e-6);
   }
 
-  GateFused<GateQSim<fp_type>> fgate4{kGateFS, 8, {3, 4}, &gate20,
+  FusedGate<fp_type> fgate4{kGateFS, 8, {3, 4}, &gate20,
       {&gate5, &gate10, &gate20, &gate21, &gate22}, {}};
   CalculateFusedMatrix(fgate4);
-  ApplyFusedGate(simulator, fgate4, state);
+  ApplyGate(simulator, fgate4, state);
 
   EXPECT_NEAR(state_space.Norm(state), 1, 1e-6);
 
@@ -312,10 +314,10 @@ void TestApplyGate5(const Factory& factory) {
     EXPECT_NEAR(std::imag(ampl3), -0.00987822, 1e-6);
   }
 
-  GateFused<GateQSim<fp_type>> fgate5{kGateCP, 10, {0, 1}, &gate23,
+  FusedGate<fp_type> fgate5{kGateCP, 10, {0, 1}, &gate23,
       {&gate23, &gate26}, {}};
   CalculateFusedMatrix(fgate5);
-  ApplyFusedGate(simulator, fgate5, state);
+  ApplyGate(simulator, fgate5, state);
 
   EXPECT_NEAR(state_space.Norm(state), 1, 1e-6);
 
@@ -360,12 +362,12 @@ void TestCircuitWithControlledGates(const Factory& factory) {
   using Simulator = typename Factory::Simulator;
   using StateSpace = typename Simulator::StateSpace;
   using fp_type = typename StateSpace::fp_type;
-  using Gate = GateQSim<fp_type>;
+  using Operation = qsim::Operation<fp_type>;
 
   unsigned num_qubits = 7;
   unsigned size = 1 << (num_qubits - 1);
 
-  std::vector<Gate> gates;
+  std::vector<Operation> gates;
   gates.reserve(128);
 
   gates.push_back(GateHd<fp_type>::Create(0, 0));
@@ -767,12 +769,12 @@ void TestCircuitWithControlledGatesDagger(const Factory& factory) {
   using Simulator = typename Factory::Simulator;
   using StateSpace = typename Simulator::StateSpace;
   using fp_type = typename StateSpace::fp_type;
-  using Gate = GateQSim<fp_type>;
+  using Operation = qsim::Operation<fp_type>;
 
   unsigned num_qubits = 7;
   unsigned size = 1 << (num_qubits - 1);
 
-  std::vector<Gate> gates;
+  std::vector<Operation> gates;
   gates.reserve(128);
 
   gates.push_back(GateHd<fp_type>::Create(0, 0));
@@ -1475,7 +1477,7 @@ void TestExpectationValue2(const Factory& factory) {
   using StateSpace = typename Simulator::StateSpace;
   using State = typename StateSpace::State;
   using fp_type = typename StateSpace::fp_type;
-  using Fuser = MultiQubitGateFuser<IO, GateQSim<fp_type>>;
+  using Fuser = MultiQubitGateFuser<IO>;
 
   unsigned num_qubits = 16;
   unsigned depth = 16;
@@ -1591,7 +1593,7 @@ for k in range(1, 7):
   };
 
   for (unsigned k = 1; k <= 6; ++k) {
-    std::vector<OpString<GateQSim<fp_type>>> strings;
+    std::vector<OpString<fp_type>> strings;
     strings.reserve(num_qubits);
 
     for (unsigned i = 0; i <= num_qubits - k; ++i) {

--- a/tests/statespace_testfixture.h
+++ b/tests/statespace_testfixture.h
@@ -29,6 +29,7 @@
 #include "../lib/fuser_basic.h"
 #include "../lib/gates_qsim.h"
 #include "../lib/io.h"
+#include "../lib/operation.h"
 #include "../lib/run_qsim.h"
 
 namespace qsim {
@@ -467,14 +468,14 @@ void TestNormAndInnerProduct(const Factory& factory) {
   using StateSpace = typename Simulator::StateSpace;
   using State = typename StateSpace::State;
   using fp_type = typename StateSpace::fp_type;
-  using Runner = QSimRunner<IO, BasicGateFuser<IO, GateQSim<fp_type>>, Factory>;
+  using Runner = QSimRunner<IO, BasicGateFuser<IO>, Factory>;
 
   unsigned depth = 8;
 
   std::stringstream ss(circuit_string);
-  Circuit<GateQSim<fp_type>> circuit;
+  Circuit<Operation<fp_type>> circuit;
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(depth, provider, ss, circuit));
-  circuit.gates.emplace_back(GateT<fp_type>::Create(depth + 1, 0));
+  circuit.ops.push_back(GateT<fp_type>::Create(depth + 1, 0));
 
   StateSpace state_space = factory.CreateStateSpace();
   State state0 = state_space.Create(circuit.num_qubits);
@@ -562,13 +563,13 @@ void TestSamplingCrossEntropyDifference(const Factory& factory) {
   using StateSpace = typename Simulator::StateSpace;
   using State = typename StateSpace::State;
   using fp_type = typename StateSpace::fp_type;
-  using Runner = QSimRunner<IO, BasicGateFuser<IO, GateQSim<fp_type>>, Factory>;
+  using Runner = QSimRunner<IO, BasicGateFuser<IO>, Factory>;
 
   unsigned depth = 30;
   uint64_t num_samples = 2000000;
 
   std::stringstream ss(circuit_string);
-  Circuit<GateQSim<fp_type>> circuit;
+  Circuit<Operation<fp_type>> circuit;
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(depth, provider, ss, circuit));
 
   StateSpace state_space = factory.CreateStateSpace();
@@ -778,12 +779,12 @@ void TestMeasurementLarge(const Factory& factory) {
   using StateSpace = typename Simulator::StateSpace;
   using State = typename StateSpace::State;
   using fp_type = typename StateSpace::fp_type;
-  using Runner = QSimRunner<IO, BasicGateFuser<IO, GateQSim<fp_type>>, Factory>;
+  using Runner = QSimRunner<IO, BasicGateFuser<IO>, Factory>;
 
   unsigned depth = 20;
 
   std::stringstream ss(circuit_string);
-  Circuit<GateQSim<fp_type>> circuit;
+  Circuit<Operation<fp_type>> circuit;
   EXPECT_TRUE(CircuitQsimParser<IO>::FromStream(depth, provider, ss, circuit));
 
   StateSpace state_space = factory.CreateStateSpace();

--- a/tests/unitary_calculator_testfixture.h
+++ b/tests/unitary_calculator_testfixture.h
@@ -20,10 +20,12 @@
 #include <cmath>
 #include <vector>
 
+#include "gtest/gtest.h"
+
 #include "../lib/fuser.h"
+#include "../lib/gate.h"
 #include "../lib/gate_appl.h"
 #include "../lib/gates_cirq.h"
-#include "gtest/gtest.h"
 
 namespace qsim {
 
@@ -425,11 +427,11 @@ void TestApplyFusedGate() {
   std::vector<Gate> gates = {Cirq::H<fp_type>::Create(0, 0),
                              Cirq::H<fp_type>::Create(1, 0)};
 
-  GateFused<Gate> fgate {Cirq::kH, 0, {0}, &gates[0],
-                         {&gates[0], &gates[1]}, {}};
+  FusedGate<fp_type> fgate {Cirq::kH, 0, {0}, &gates[0],
+                            {&gates[0], &gates[1]}, {}};
 
   CalculateFusedMatrix(fgate);
-  ApplyFusedGate(uc, fgate, u);
+  ApplyGate(uc, fgate, u);
 
   unsigned size = 1 << num_qubits;
   for (unsigned i = 0; i < size; ++i) {


### PR DESCRIPTION
## Summary
This PR implements a major refactoring of the gate interface and circuit representation within `qsim`. To improve type safety and extensibility, the monolithic `Gate` struct has been decomposed into specialized types. The core circuit element is now transitioned to an `Operation` variant, allowing for more granular handling of gates, measurements, and noise channels. This is a **breaking change** for internal APIs.

### Key Changes

* **Type Decomposition:** Split the original `Gate` struct into distinct types:
    * `Gate`: Standard unitary operations.
    * `ControlledGate`: Operations with control.
    * `Measurement`: Measurement operations.
    * `Channel`: Unitary and non-unitary quantum channels.
    * `DecomposedGate`: Schmidt-decomposed gates.
* **New Operation Model:** Introduced `std::variant` to define the basic unit of a circuit.
    * **Standard:** `using Operation = std::variant<Gate, ControlledGate, Measurement, Channel>;`
    * **Fused:** `using Operation = std::variant<FusedGate, Measurement, const Operation*>;`
* **Infrastructure Updates:** Updated quantum trajectory and hybrid simulators, circuit parsers, fusion logic, gate application dispatching logic, and pybind11 interface to consume the new `Operation` types. Unified clean and noisy circuits.

### Future-Proofing & Extensibility
By moving to a variant-based `Operation` model, the architecture is now significantly more flexible. This refactoring explicitly paves the way for:
* **Classical Control:** Easier integration of conditional operations and classical feed-forward logic.
* **Custom Entities:** Simplified path for adding new specialized entities without bloating the core `Gate` logic.