### PR TITLE
Micro-optimization: replace list lookup with set membership

### DIFF
--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -20,7 +20,7 @@ import numpy as np
 from . import qsim
 
 # List of parameter names that appear in valid Cirq protos.
-GATE_PARAMS = [
+GATE_PARAMS = {
     "exponent",
     "phase_exponent",
     "global_shift",
@@ -29,7 +29,7 @@ GATE_PARAMS = [
     "axis_phase_exponent",
     "phi",
     "theta",
-]
+}
 
 
 def _translate_ControlledGate(gate: cirq.ControlledGate):

--- a/qsimcirq/qsim_circuit.py
+++ b/qsimcirq/qsim_circuit.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from . import qsim
 
-# List of parameter names that appear in valid Cirq protos.
+# Set of parameter names that appear in valid Cirq protos.
 GATE_PARAMS = {
     "exponent",
     "phase_exponent",


### PR DESCRIPTION
In `qsimcirq/qsim_circuit.py`, changing the list `GATE_PARAMS` to a set will result in O(1) lookups. Not likely to make a big difference for the small set size, but perhaps it might shave some time off when many simulations are executed.