### PR TITLE
Have Bazel add `--linkopt=-fuse-ld=bfd` for GCC on Linux

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,7 @@ common --enable_platform_specific_config
 
 build:linux --copt=-std=c++17
 build:linux --cxxopt=-std=c++17
+build:linux --linkopt=-fuse-ld=bfd
 
 build:macos --copt=-std=c++17
 build:macos --cxxopt=-std=c++17


### PR DESCRIPTION
There seems to be a new incompatibility involving GCC and the default linker. It shows up when compiling the googletest library under GCC 15.2. The error looks like this:

```
ERROR: .cache/bazel/_bazel_mhucka/98e81a22328beb3f0639164a65512085/external/com_google_googletest/BUILD.bazel:90:11: Linking external/com_google_googletest/libgtest.so failed: (Exit 1): gcc failed: error executing command (from target @com_google_googletest//:gtest)
  (cd .cache/bazel/_bazel_mhucka/98e81a22328beb3f0639164a65512085/sandbox/linux-sandbox/113/execroot/__main__ && \
  exec env - \
    PATH=.pyenv/plugins/pyenv-virtualenv/shims:.pyenv/shims:system/bin:.pyenv/bin:.pixi/bin:.npm/bin:.cargo/bin:.cabal/bin:.pub-cache/bin:.local/bin:.local/share/gem/ruby/3.1.0/bin:/Library/GoogleCorpSupport/bin:/Library/GoogleCorpSupport/Python/3.10/bin:/usr/local/google/cloud-sdk/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin:/snap/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin \
    PWD=/proc/self/cwd \
  /usr/bin/gcc @bazel-out/k8-fastbuild/bin/external/com_google_googletest/libgtest.so-2.params)
# Configuration: 2b05c133728dd537123217a36fabb8f7c94452374c31639acd9dea8169bda614
# Execution platform: @local_execution_config_platform//:platform

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
ld.lld: error: relocation refers to a discarded section: .text._ZNSt11char_traitsIcE6assignERcRKc
>>> defined in bazel-out/k8-fastbuild/bin/external/com_google_googletest/_objs/gtest/gtest-assertion-result.pic.o
>>> referenced by gtest-assertion-result.cc
>>>               bazel-out/k8-fastbuild/bin/external/com_google_googletest/_objs/gtest/gtest-assertion-result.pic.o:(.sframe+0x1C)
```

Adding `-fuse-ld=bfd` explicitly tells the compiler to use the GNU BFD (Binary File Descriptor): linker (`ld.bfd`) instead of the default system linker during the linking stage.