### PR TITLE
Have Bazel disable GCC SFrame option if possible

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,7 @@ common --enable_platform_specific_config
 
 build:linux --copt=-std=c++17
 build:linux --cxxopt=-std=c++17
+build:linux --per_file_copt="googletest/.*@-Xassembler,-W"
 
 build:macos --copt=-std=c++17
 build:macos --cxxopt=-std=c++17
@@ -86,14 +87,12 @@ build:nosan --
 build:avx --copt=-O3
 build:avx --copt=-mavx2
 build:avx --copt=-mfma
-build:avx --per_file_copt="googletest/.*@-Xassembler,-W"
 build:avx --build_tag_filters=avx --ui_event_filters=-WARNING
 test:avx --test_tag_filters=avx --ui_event_filters=-WARNING
 
 # Build with SSE
 build:sse --copt=-O3
 build:sse --copt=-msse4
-build:sse --per_file_copt="googletest/.*@-Xassembler,-W"
 build:sse --build_tag_filters=sse --ui_event_filters=-WARNING
 test:sse --test_tag_filters=sse --ui_event_filters=-WARNING
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -86,12 +86,14 @@ build:nosan --
 build:avx --copt=-O3
 build:avx --copt=-mavx2
 build:avx --copt=-mfma
+build:avx --per_file_copt="googletest/.*@-Xassembler,-W"
 build:avx --build_tag_filters=avx --ui_event_filters=-WARNING
 test:avx --test_tag_filters=avx --ui_event_filters=-WARNING
 
 # Build with SSE
 build:sse --copt=-O3
 build:sse --copt=-msse4
+build:sse --per_file_copt="googletest/.*@-Xassembler,-W"
 build:sse --build_tag_filters=sse --ui_event_filters=-WARNING
 test:sse --test_tag_filters=sse --ui_event_filters=-WARNING
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,6 +55,10 @@ load("@org_tensorflow//tensorflow:workspace0.bzl", "tf_workspace0")
 
 tf_workspace0()
 
+load("//dev_tools:compiler_probe.bzl", "compiler_probe")
+
+compiler_probe(name = "local_compiler_config")
+
 # https://gitlab.com/libeigen/eigen/-/releases/3.4.1
 EIGEN_COMMIT = "b66188b5dfd147265bfa9ec47595ca0db72d21f5"
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,6 +28,8 @@ http_archive(
     sha256 = "40d4ec942217dcc84a9ebe2a68584ada7d4a33a8ee958755763278ea1c5e18ff",
     strip_prefix = "googletest-1.17.0",
     url = "https://github.com/google/googletest/archive/refs/tags/v1.17.0.zip",
+    patches = ["//third_party:googletest.patch"],
+    patch_args = ["-p1"],
 )
 
 # Required for testing compatibility with TF Quantum:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,11 +25,11 @@ http_archive(
 
 http_archive(
     name = "com_google_googletest",
+    patch_args = ["-p1"],
+    patches = ["//third_party:googletest.patch"],
     sha256 = "40d4ec942217dcc84a9ebe2a68584ada7d4a33a8ee958755763278ea1c5e18ff",
     strip_prefix = "googletest-1.17.0",
     url = "https://github.com/google/googletest/archive/refs/tags/v1.17.0.zip",
-    patches = ["//third_party:googletest.patch"],
-    patch_args = ["-p1"],
 )
 
 # Required for testing compatibility with TF Quantum:

--- a/apps/BUILD
+++ b/apps/BUILD
@@ -15,11 +15,15 @@
 # TODO: remove reliance on getopt (unistd.h) to allow apps to run on Windows.
 
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@local_compiler_config//:compiler_config.bzl", "SUPPORTS_GSFRAME")
+
+gsframe_copts = ["-Wa,--gsframe=no"] if SUPPORTS_GSFRAME else []
 
 cc_binary(
     name = "qsim_base",
     srcs = ["qsim_base.cc"],
     data = ["//circuits:circuit_q24"],
+    copts = gsframe_copts,
     deps = [
         "//lib:run_qsim_lib",
     ],
@@ -28,6 +32,7 @@ cc_binary(
 cc_binary(
     name = "qsim_von_neumann",
     srcs = ["qsim_von_neumann.cc"],
+    copts = gsframe_copts,
     deps = [
         "//lib:run_qsim_lib",
     ],
@@ -36,6 +41,7 @@ cc_binary(
 cc_binary(
     name = "qsim_amplitudes",
     srcs = ["qsim_amplitudes.cc"],
+    copts = gsframe_copts,
     deps = [
         "//lib:bitstring",
         "//lib:run_qsim_lib",
@@ -45,6 +51,7 @@ cc_binary(
 cc_binary(
     name = "qsimh_base",
     srcs = ["qsimh_base.cc"],
+    copts = gsframe_copts,
     deps = [
         "//lib:bitstring",
         "//lib:run_qsimh_lib",
@@ -54,6 +61,7 @@ cc_binary(
 cc_binary(
     name = "qsimh_amplitudes",
     srcs = ["qsimh_amplitudes.cc"],
+    copts = gsframe_copts,
     deps = [
         "//lib:bitstring",
         "//lib:run_qsimh_lib",

--- a/apps/BUILD
+++ b/apps/BUILD
@@ -14,16 +14,16 @@
 
 # TODO: remove reliance on getopt (unistd.h) to allow apps to run on Windows.
 
-load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@local_compiler_config//:compiler_config.bzl", "SUPPORTS_GSFRAME")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 
 gsframe_copts = ["-Wa,--gsframe=no"] if SUPPORTS_GSFRAME else []
 
 cc_binary(
     name = "qsim_base",
     srcs = ["qsim_base.cc"],
-    data = ["//circuits:circuit_q24"],
     copts = gsframe_copts,
+    data = ["//circuits:circuit_q24"],
     deps = [
         "//lib:run_qsim_lib",
     ],

--- a/apps/BUILD
+++ b/apps/BUILD
@@ -17,7 +17,10 @@
 load("@local_compiler_config//:compiler_config.bzl", "SUPPORTS_GSFRAME")
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 
-gsframe_copts = ["-Wa,--gsframe=no"] if SUPPORTS_GSFRAME else []
+gsframe_copts = select({
+    "@platforms//os:linux": ["-Wa,--gsframe=no"] if SUPPORTS_GSFRAME else [],
+    "//conditions:default": [],
+})
 
 cc_binary(
     name = "qsim_base",

--- a/dev_tools/BUILD
+++ b/dev_tools/BUILD
@@ -1,0 +1,1 @@
+# Empty BUILD file to make dev_tools a package.

--- a/dev_tools/compiler_probe.bzl
+++ b/dev_tools/compiler_probe.bzl
@@ -1,0 +1,43 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Repository rule to probe compiler support for SFrame flags."""
+
+def _compiler_probe_impl(repository_ctx):
+    # Try to determine the compiler. Prefer CC from environment.
+    cc = repository_ctx.os.environ.get("CC", "c++")
+
+    # Run a test compilation to test if the flag is recognized.
+    # This is hacky and I wish there was a better way.
+    res = repository_ctx.execute([
+        cc,
+        "-Wa,--gsframe=no",
+        "-c",
+        "-x",
+        "c++",
+        "/dev/null",
+        "-o",
+        "/dev/null",
+    ])
+
+    supports_gsframe = (res.return_code == 0)
+
+    repository_ctx.file("BUILD.bazel", "package(default_visibility = ['//visibility:public'])\n")
+    repository_ctx.file("compiler_config.bzl", "SUPPORTS_GSFRAME = %s\n" % supports_gsframe)
+
+compiler_probe = repository_rule(
+    implementation = _compiler_probe_impl,
+    local = True,
+    environ = ["CC", "PATH"],
+)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@local_compiler_config//:compiler_config.bzl", "SUPPORTS_GSFRAME")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 # Options for testing different simulator types.
 gsframe_copts = ["-Wa,--gsframe=no"] if SUPPORTS_GSFRAME else []

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -15,9 +15,9 @@
 load("@local_compiler_config//:compiler_config.bzl", "SUPPORTS_GSFRAME")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
-# Options for testing different simulator types.
 gsframe_copts = ["-Wa,--gsframe=no"] if SUPPORTS_GSFRAME else []
 
+# Options for testing different simulator types.
 avx_copts = [
     "-mavx2",
     "-mfma",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -13,16 +13,19 @@
 # limitations under the License.
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@local_compiler_config//:compiler_config.bzl", "SUPPORTS_GSFRAME")
 
 # Options for testing different simulator types.
+gsframe_copts = ["-Wa,--gsframe=no"] if SUPPORTS_GSFRAME else []
+
 avx_copts = [
     "-mavx2",
     "-mfma",
-]
+] + gsframe_copts
 
-avx512_copts = ["-march=native"]
+avx512_copts = ["-march=native"] + gsframe_copts
 
-sse_copts = ["-msse4"]
+sse_copts = ["-msse4"] + gsframe_copts
 
 windows_copts = [
     "/arch:AVX",

--- a/third_party/googletest.patch
+++ b/third_party/googletest.patch
@@ -1,0 +1,22 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -32,6 +32,10 @@
+ 
+ package(default_visibility = ["//visibility:public"])
+ 
++load("@local_compiler_config//:compiler_config.bzl", "SUPPORTS_GSFRAME")
++gsframe_copts = ["-Wa,--gsframe=no"] if SUPPORTS_GSFRAME else []
++
++
+ licenses(["notice"])
+ 
+ exports_files(["LICENSE"])
+@@ -108,7 +112,7 @@
+         "googletest/include/gtest/*.h",
+         "googlemock/include/gmock/*.h",
+     ]),
+-    copts = select({
++    copts = gsframe_copts + select({
+         ":qnx": [],
+         ":windows": [],
+         "//conditions:default": ["-pthread"],

--- a/third_party/googletest.patch
+++ b/third_party/googletest.patch
@@ -1,15 +1,17 @@
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -32,6 +32,10 @@
- 
+@@ -32,6 +32,12 @@
+
  package(default_visibility = ["//visibility:public"])
- 
+
 +load("@local_compiler_config//:compiler_config.bzl", "SUPPORTS_GSFRAME")
-+gsframe_copts = ["-Wa,--gsframe=no"] if SUPPORTS_GSFRAME else []
-+
++gsframe_copts = select({
++    "@platforms//os:linux": ["-Wa,--gsframe=no"] if SUPPORTS_GSFRAME else [],
++    "//conditions:default": [],
++})
 +
  licenses(["notice"])
- 
+
  exports_files(["LICENSE"])
 @@ -108,7 +112,7 @@
          "googletest/include/gtest/*.h",


### PR DESCRIPTION
This adds the flag `-Wa,--gsframe=no` to the Bazel configuration for Linux systems, to deal with an error that happens with GCC 15.2. A similar addition was made to the Makefiles in a past PR.