### PR TITLE
Add config file for `cmake-format`

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -19,6 +19,10 @@
 # forcing the closing parenthesis to be on a separate line if a split is done.
 
 format:
+  line_width: 80
+  tab_size: 4
+  use_tabchars: false
+
   # If a stmt is split across lines, put the closing paren on its own line.
   dangle_parens: true
 

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -14,9 +14,9 @@
 
 # Summary: configure cmake-format (from https://pypi.org/project/cmakelang/) to
 # apply a consistent style to CMakeLists.txt and *.cmake files. For readability
-# and maintainability, the Quantumlib style diverges slightly from cmake-format
-# defaults, specifically in (1) how splitting across lines is done and (2)
-# forcing the closing parenthesis to be on a separate line if a split is done.
+# and maintainability, the Quantumlib style diverges slightly from the defaults,
+# specifically in (1) using 4-space indent, (2) how splitting across lines is
+# done, and (3) putting the closing paren on a separate line when splitting.
 
 format:
   line_width: 80

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,67 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Summary: configure cmake-format (from https://pypi.org/project/cmakelang/) to
+# apply a consistent style to CMakeLists.txt and *.cmake files. For readability
+# and maintainability, the Quantumlib style diverges slightly from cmake-format
+# defaults, specifically in (1) how splitting across lines is done and (2)
+# forcing the closing parenthesis to be on a separate line if a split is done.
+
+format:
+  # If a stmt is split across lines, put the closing paren on its own line.
+  dangle_parens: true
+
+  # Properties that control splitting statements across multiple lines. From the
+  # cmake-format docs, I couldn't understand how they interacted, so these
+  # values were obtained empirically by varying the values until the output
+  # produced by cmake-format was acceptable.
+  max_pargs_hwrap: 4
+  max_rows_cmdline: 2
+  max_subgroups_hwrap: 1
+  max_prefix_chars: 24
+  min_prefix_chars: 4
+
+parse:
+  additional_commands:
+    # The following commands (project, set, etc.) are standard CMake commands,
+    # not additions; their presence here overrides cmake-format's default
+    # behavior for them because the default resulted in awkward splits.
+    project:
+      flags:
+      kwargs:
+    set:
+      flags:
+        - CACHE
+        - ENV
+        - FORCE
+        - HELP
+        - TYPE
+        - VALUE
+      kwargs:
+    message:
+      flags:
+        - AUTHOR_WARNING
+        - DEBUG
+        - DEPRECATION
+        - FATAL_ERROR
+        - NOTICE
+        - SEND_ERROR
+        - STATUS
+        - TRACE
+        - VERBOSE
+        - WARNING
+
+markup:
+  # Don't reformat comments.
+  enable_markup: false


### PR DESCRIPTION
This adds a configuration file for `cmake-format` (from https://pypi.org/project/cmakelang/). The settings do no diverge much from the style in the current CMakeLists.txt files, and the results are more self-consistent and should be easier to maintain.

This PR only adds the configuration file. Another PR will reformat the existing files so that we can add the commit to `.git-blame-ignore-revs`, and a third PR will add a check to the CI workflow.