### PR TITLE
Add pytest-randomly to dev requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,8 +109,8 @@ dev = [
     "py-cpuinfo",
     "pylint~=4.0.2",
     "pytest",
-    "pytest-xdist",
     "pytest-randomly",
+    "pytest-xdist",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ dev = [
     "pylint~=4.0.2",
     "pytest",
     "pytest-xdist",
+    "pytest-randomly",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
This simply adds the [pytest-randomly](https://github.com/pytest-dev/pytest-randomly) package to the dev dependencies to automatically shuffle the order of tests run by Pytest. This can be helpful to uncover possible inter-test dependencies.