### PR TITLE
Fix two syntax errors in `.github/actions/set-up-bazel`

### DIFF
--- a/.github/actions/set-up-bazel/action.yaml
+++ b/.github/actions/set-up-bazel/action.yaml
@@ -23,7 +23,7 @@ inputs:
   debug:
     description: 'Run with debugging options'
     required: false
-    default: true
+    default: 'true'
   bazel-version:
     description: 'Version of Bazel to use:'
     required: false

--- a/.github/actions/set-up-bazel/action.yaml
+++ b/.github/actions/set-up-bazel/action.yaml
@@ -29,10 +29,6 @@ inputs:
     required: false
     default: ''
 
-permissions:
-  actions: write
-  contents: read
-
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION
Fix two syntax errors in the action definition: the presence of `permissions:` at the top level, and the use of a non-string default value for action inputs.