### PR TITLE
Ignore warnings due to intentional non-unitary matrices

### DIFF
--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -1018,6 +1018,7 @@ class NoiseStep(cirq.Gate):
         return str(self)
 
 
+@pytest.mark.filterwarnings("ignore:.*skipping renormalization.*")
 def test_mixture_simulation():
     q0, q1 = cirq.LineQubit.range(2)
     pflip = cirq.phase_flip(p=0.4)
@@ -1058,6 +1059,7 @@ def test_mixture_simulation():
     assert all(result_count > 0 for result_count in result_hist)
 
 
+@pytest.mark.filterwarnings("ignore:.*skipping renormalization.*")
 def test_channel_simulation():
     q0, q1 = cirq.LineQubit.range(2)
     # These probabilities are set unreasonably high in order to reduce the number
@@ -1155,6 +1157,7 @@ class NoiseMixture(NoiseChannel):
     ],
 )
 @pytest.mark.parametrize("noise_type", [NoiseMixture, NoiseChannel])
+@pytest.mark.filterwarnings("ignore:.*skipping renormalization.*")
 def test_multi_qubit_noise(cx_qubits, noise_type):
     # Tests that noise across multiple qubits works correctly.
     qs = cirq.LineQubit.range(3)


### PR DESCRIPTION
In `qsimcirq_tests/qsimcirq_test.py`, tests `test_channel_simulation`, `test_mixture_simulation`, and `test_multi_qubit_noise` intentionally apply non-unitary Kraus matrices using a custom `NoiseStep` gate. The `NoiseStep` class defines `_unitary_` returning these non-unitary matrices.

When `cirq.Simulator().simulate(pc)` is called with these non-unitary "gates", Cirq simulates them but notices that the output state vector's norm is no longer exactly 1.0. Because the default simulator in Cirq assumes operations defining `_unitary_` are perfectly unitary, it issues a warning about the final state vector being unnormalized ("skipping renormalization").

This is expected behavior for these particular tests since they're manually reconstructing the trajectories of quantum channels.