### PR TITLE
Add a test for an uncovered case involving `add_op_to_opstring`

### DIFF
--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -858,7 +858,7 @@ def test_decompose_to_matrix_gates():
 
 def test_add_op_to_opstring_controlled_gate_error():
     q0, q1 = cirq.LineQubit.range(2)
-    op = cirq.X(q0).controlled_by(q1)
+    op = cirq.CX(q1, q0)
     opstring = qsimcirq.qsim.OpString()
     qubit_to_index_dict = {q0: 0, q1: 1}
     with pytest.raises(

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -856,6 +856,15 @@ def test_decompose_to_matrix_gates():
     )
 
 
+def test_add_op_to_opstring_controlled_gate_error():
+    q0, q1 = cirq.LineQubit.range(2)
+    op = cirq.X(q0).controlled_by(q1)
+    opstring = qsimcirq.qsim.OpString()
+    qubit_to_index_dict = {q0: 0, q1: 1}
+    with pytest.raises(ValueError, match="OpString should only have Paulis; got GateKind.kCX"):
+        qsimcirq.add_op_to_opstring(op, qubit_to_index_dict, opstring)
+
+
 def test_basic_controlled_gate():
     qubits = cirq.LineQubit.range(3)
 

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -861,7 +861,9 @@ def test_add_op_to_opstring_controlled_gate_error():
     op = cirq.X(q0).controlled_by(q1)
     opstring = qsimcirq.qsim.OpString()
     qubit_to_index_dict = {q0: 0, q1: 1}
-    with pytest.raises(ValueError, match="OpString should only have Paulis; got GateKind.kCX"):
+    with pytest.raises(
+        ValueError, match="OpString should only have Paulis; got GateKind.kCX"
+    ):
         qsimcirq.add_op_to_opstring(op, qubit_to_index_dict, opstring)
 
 


### PR DESCRIPTION
Added a new test case `test_add_op_to_opstring_controlled_gate_error` to `qsimcirq_tests/qsimcirq_test.py` to verify that `add_op_to_opstring` correctly raises a `ValueError` when a controlled operation is passed.