### PR TITLE
Add configuration file for Buildifier

### DIFF
--- a/.buildifier.json
+++ b/.buildifier.json
@@ -1,0 +1,5 @@
+{
+  "warningsList": [
+    "-native-cc-info"
+  ]
+}


### PR DESCRIPTION
Add `.buildifier.json` to tell [Buildifier](https://github.com/bazelbuild/buildtools/blob/main/buildifier/README.md) that it should not complain about the use of `CcInfo` in our Bazel files. We still use an old version of Bazel, and Buildifier complains about uses of `CcInfo` with a message like this:

```
native-cc-info: Symbol "CcInfo" is not global anymore
and needs to be loaded from "@rules_cc//cc/common:cc_info.bzl".
```

But CcInfo works as expected in Bazel 6.5.0.