### PR TITLE
Use `mkdir -p`, not `mkdir`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -289,7 +289,7 @@ jobs:
       - name: Build the Python bindings
         shell: bash
         run: |
-          mkdir build
+          mkdir -p build
           cd build
           cmake ${{inputs.debug && '--debug-output' || ''}} ..
           cmake --build . -j ${{inputs.debug && '--verbose' || ''}}


### PR DESCRIPTION
For reasons that I don't understand, CI checks started failing in the library tests because the `build` directory already exists. Possibly in some environments, one of the earlier steps in the job has a side-effect. Easy enough to resolve by using `mkdir -p`.