### PR TITLE
Add test for reserved keys in `QSimSimulator`

### DIFF
--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -2299,7 +2299,7 @@ def test_qsim_simulator_reserved_keys():
     for key in ("c", "i", "s"):
         with pytest.raises(
             ValueError,
-            match='Keys {"c", "i", "s"} are reserved for internal use and cannot be '
+            match=r'Keys \{"c", "i", "s"\} are reserved for internal use and cannot be '
             "used in QSimCircuit instantiation.",
         ):
             _ = qsimcirq.QSimSimulator(qsim_options={key: 1})

--- a/qsimcirq_tests/qsimcirq_test.py
+++ b/qsimcirq_tests/qsimcirq_test.py
@@ -2290,3 +2290,13 @@ def test_get_seed():
     sim = qsimcirq.QSimSimulator(seed=42)
     seeds = {sim.get_seed() for _ in range(10)}
     assert len(seeds) > 1
+
+
+def test_qsim_simulator_reserved_keys():
+    for key in ("c", "i", "s"):
+        with pytest.raises(
+            ValueError,
+            match='Keys {"c", "i", "s"} are reserved for internal use and cannot be '
+            "used in QSimCircuit instantiation.",
+        ):
+            _ = qsimcirq.QSimSimulator(qsim_options={key: 1})


### PR DESCRIPTION
This simple PR adds a basic test, `test_qsim_simulator_reserved_keys()`, to `qsimcirq_tests/qsimcirq_test.py` in order to verify that instantiating `QSimSimulator` with reserved keys `('c', 'i', 's')` in `qsim_options` raises the expected `ValueError`.

(This PR was created with the help of [Jules](https://jules.google.com).)