### PR TITLE
Explicitly export symbols in `qsimcirq/__init__.py`

### DIFF
--- a/qsimcirq/__init__.py
+++ b/qsimcirq/__init__.py
@@ -72,3 +72,17 @@ from qsimcirq._version import __version__
 from .qsim_circuit import QSimCircuit, add_op_to_circuit, add_op_to_opstring
 from .qsim_simulator import QSimOptions, QSimSimulator
 from .qsimh_simulator import QSimhSimulator
+
+__all__ = [
+    "QSimCircuit",
+    "add_op_to_circuit",
+    "add_op_to_opstring",
+    "QSimOptions",
+    "QSimSimulator",
+    "QSimhSimulator",
+    "qsim",
+    "qsim_gpu",
+    "qsim_custatevec",
+    "qsim_custatevecex",
+    "__version__",
+]


### PR DESCRIPTION
This makes `qsimcirq/__init__.py` explicitly define the public API using `__all__`. This should silence "unused import" warnings for re-exported symbols, and also improve module maintainability and discoverability.

(This PR was created with the help of [Jules](https://jules.google.com).)