### PR TITLE
Update .dockerignore, .gitignore, and .geminiignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,37 @@
 
 # Ignore this in case the user previously did a "pip install -e ."
 qsimcirq.egg-info
+
+# Additional generic things to ignore.
+**/*.bak
+**/*.DS_Store
+**/*.log
+**/*.py,cover
+**/*.pyc
+**/*.swp
+**/*.tmp
+**/*.whl
+**/.*_cache/
+**/.git/
+**/.ipynb_checkpoints/
+**/__pycache__/
+*.cover
+*.coverage
+*.coverage.*
+*.egg
+*.egg-info/
+*~
+.coverage
+.dockerignore
+.env*
+.github/
+.idea/
+.venv/
+.vscode/
+bazel-*
+build/
+coverage.xml
+dist/
+env/
+jupyter_kernel.lock
+venv/

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Git metadata (wildcarded because this project uses a git submodule).
+**/.git
+
 # Coverage & test artifacts.
+**/*.benchmarks
 **/*.cover
 **/*.py,cover
 **/.coverage
@@ -22,28 +26,35 @@
 # Environments & IDEs.
 .dockerignore
 .env*
-.git/
-.github/
-.idea/
+.gemini*
+.github
+.idea
 .python-version
-.venv/
-.vscode/
-env/
-venv/
+.venv
+.vscode
+CirqDevEnv
+env
+venv
 
 # Build outputs & tool caches.
 **/.*_cache
-**/.ipynb_checkpoints/
-**/__pycache__/
+**/.cache
+**/.eggs
+**/.ipynb_checkpoints
+**/__pycache__
+**/cmake_install.cmake
 **/CMakeCache.txt
-**/CMakeFiles/
+**/CMakeFiles
 bazel-*
-build/
-dist/
-eigen/
+build
+dist
+eigen
+sdist
+wheelhouse
 
 # Compilation artifacts.
 **/*.a
+**/*.dSYM
 **/*.dll
 **/*.dylib
 **/*.exe
@@ -51,6 +62,7 @@ eigen/
 **/*.mod
 **/*.o
 **/*.obj
+**/*.out
 **/*.py[cod]
 **/*.so
 **/*.x
@@ -58,13 +70,17 @@ eigen/
 # Local PyPI config files.
 .pypirc
 
+# Things that don't need to be in a Docker inage.
+dev_tools/ci
+docs
+
 # Miscellaneous other files.
+**/*~
 **/*.bak
 **/*.egg
-**/*.egg-info/
+**/*.egg-info
 **/*.log
 **/*.swp
 **/*.tmp
 **/*.whl
 **/.DS_Store
-**/.gemini/

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-**/*~
 **/*.bak
-**/.DS_Store
+**/*.egg
+**/*.egg-info/
 **/*.log
 **/*.pyc
 **/*.swp
 **/*.tmp
 **/*.whl
-**/*.egg
-**/*.egg-info/
 **/*_cache/
+**/*~
+**/.DS_Store
 **/.git/
 **/.ipynb_checkpoints/
 **/__pycache__/
@@ -44,24 +44,24 @@ env/
 venv/
 
 # Build outputs & tool caches.
+**/cmake_install.cmake
+**/CMakeCache.txt
+**/CMakeFiles/
+**/jupyter_kernel.lock
+*.tar.gz
 .eggs/
 bazel-*
 build/
 dist/
 eigen/
-*.tar.gz
-**/jupyter_kernel.lock
-**/CMakeCache.txt
-**/CMakeFiles/
-**/cmake_install.cmake
 
 # Native compilation artifacts.
-**/*.o
 **/*.a
-**/*.so
-**/*.dylib
 **/*.dll
-**/*.pyd
-**/*.x
-**/*.mod
 **/*.dSYM/
+**/*.dylib
+**/*.mod
+**/*.o
+**/*.pyd
+**/*.so
+**/*.x

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,7 @@
 
 **/*~
 **/*.bak
-**/*.DS_Store
+**/.DS_Store
 **/*.log
 **/*.pyc
 **/*.swp
@@ -31,7 +31,7 @@
 **/*.cover
 **/*.py,cover
 **/.coverage*
-coverage.xml
+**/coverage.xml
 
 # Environments & IDEs.
 .dockerignore
@@ -48,9 +48,12 @@ venv/
 bazel-*
 build/
 dist/
-jupyter_kernel.lock
-CMakeCache.txt
+eigen/
+*.tar.gz
+**/jupyter_kernel.lock
+**/CMakeCache.txt
 **/CMakeFiles/
+**/cmake_install.cmake
 
 # Native compilation artifacts.
 **/*.o
@@ -58,3 +61,7 @@ CMakeCache.txt
 **/*.so
 **/*.dylib
 **/*.dll
+**/*.pyd
+**/*.x
+**/*.mod
+**/*.dSYM/

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,39 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Ignore this in case the user previously did a "pip install -e ."
-qsimcirq.egg-info
-
-# Additional generic things to ignore.
+**/*~
 **/*.bak
 **/*.DS_Store
 **/*.log
-**/*.py,cover
 **/*.pyc
 **/*.swp
 **/*.tmp
 **/*.whl
-**/.*_cache/
+**/*.egg
+**/*.egg-info/
+**/*_cache/
 **/.git/
 **/.ipynb_checkpoints/
 **/__pycache__/
-*.cover
-*.coverage
-*.coverage.*
-*.egg
-*.egg-info/
-*~
-.coverage
+
+# Coverage & test artifacts.
+**/*.cover
+**/*.py,cover
+**/.coverage*
+coverage.xml
+
+# Environments & IDEs.
 .dockerignore
-.env*
 .github/
 .idea/
 .venv/
 .vscode/
+venv/
+
+# Build outputs & tool caches.
 bazel-*
 build/
-coverage.xml
 dist/
-env/
 jupyter_kernel.lock
-venv/

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,56 +12,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-**/*.bak
-**/*.egg
-**/*.egg-info/
-**/*.log
-**/*.pyc
-**/*.swp
-**/*.tmp
-**/*.whl
-**/*_cache/
-**/*~
-**/.DS_Store
-**/.git/
-**/.ipynb_checkpoints/
-**/__pycache__/
-
 # Coverage & test artifacts.
 **/*.cover
 **/*.py,cover
-**/.coverage*
+**/.coverage
+**/.coverage.*
 **/coverage.xml
 
 # Environments & IDEs.
 .dockerignore
 .env*
+.git/
 .github/
 .idea/
+.python-version
 .venv/
 .vscode/
 env/
 venv/
 
 # Build outputs & tool caches.
-**/cmake_install.cmake
+**/.*_cache
+**/.ipynb_checkpoints/
+**/__pycache__/
 **/CMakeCache.txt
 **/CMakeFiles/
-**/jupyter_kernel.lock
-*.tar.gz
-.eggs/
 bazel-*
 build/
 dist/
 eigen/
 
-# Native compilation artifacts.
+# Compilation artifacts.
 **/*.a
 **/*.dll
-**/*.dSYM/
 **/*.dylib
+**/*.exe
+**/*.lib
 **/*.mod
 **/*.o
-**/*.pyd
+**/*.obj
+**/*.py[cod]
 **/*.so
 **/*.x
+
+# Local PyPI config files.
+.pypirc
+
+# Miscellaneous other files.
+**/*.bak
+**/*.egg
+**/*.egg-info/
+**/*.log
+**/*.swp
+**/*.tmp
+**/*.whl
+**/.DS_Store
+**/.gemini/

--- a/.dockerignore
+++ b/.dockerignore
@@ -35,14 +35,26 @@ coverage.xml
 
 # Environments & IDEs.
 .dockerignore
+.env*
 .github/
 .idea/
 .venv/
 .vscode/
+env/
 venv/
 
 # Build outputs & tool caches.
+.eggs/
 bazel-*
 build/
 dist/
 jupyter_kernel.lock
+CMakeCache.txt
+**/CMakeFiles/
+
+# Native compilation artifacts.
+**/*.o
+**/*.a
+**/*.so
+**/*.dylib
+**/*.dll

--- a/.geminiignore
+++ b/.geminiignore
@@ -19,3 +19,7 @@
 
 # Not in .gitignore because it's a git submodule. Tell Gemini to ignore it.
 /tests/googletest/
+
+# The next one (for Emacs versioned backups) _should_ be covered by *~ in our
+# .gitignore, but Gemini currently doesn't seem to interpret *~ that way.
+*.~*~

--- a/.gitignore
+++ b/.gitignore
@@ -38,12 +38,9 @@ ipython_config.py
 .cache/
 .dmypy.json
 .mypy_cache/
-.nox/
 .pytest_cache/
 .python-version
-.pytype/
 .ruff_cache/
-.tox/
 __pycache__/
 build/
 coverage.xml


### PR DESCRIPTION
This PR:

- Greatly revises `.dockerignore` to be more selective and handle more cases on different platforms.

- Removes some things from `.gitignore` that this project doesn't use.

- Adds a pattern for Emacs version backups to `.geminiignore`. It _should_ not be needed because there's a pattern in `.gitignore` that handles it, but Gemini doesn't seem to interpret that pattern as expected. Though the best practice for Emacs users is to configure their editor to put checkpoint files outside the source directory, sometimes they may not. In those cases, adding this pattern avoids an easy-to-miss cause of problems when using Gemini CLI.
