### PR TITLE
fix: support linux/arm64 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,13 +34,6 @@ else()
     message(STATUS "${MSG_PREFIX} did not detect Apple Silicon")
 endif()
 
-# SSE/AVX pybind modules use x86 intrinsics; only build them on x86.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|i386|i486|i586|i686)$")
-    set(QSIM_X86 TRUE)
-else()
-    set(QSIM_X86 FALSE)
-endif()
-
 if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)
     message(STATUS "${MSG_PREFIX} found CUDA compiler "
@@ -109,7 +102,8 @@ if(NOT CMAKE_APPLE_SILICON_PROCESSOR)
     endif()
 endif()
 
-if(QSIM_X86)
+# SSE/AVX pybind modules use x86 intrinsics; only build them on x86.
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|i386|i486|i586|i686)$")
     add_subdirectory(pybind_interface/sse)
     add_subdirectory(pybind_interface/avx512)
     add_subdirectory(pybind_interface/avx2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,13 @@ else()
     message(STATUS "${MSG_PREFIX} did not detect Apple Silicon")
 endif()
 
+# SSE/AVX pybind modules use x86 intrinsics; only build them on x86.
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|i386|i486|i586|i686)$")
+    set(QSIM_X86 TRUE)
+else()
+    set(QSIM_X86 FALSE)
+endif()
+
 if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)
     message(STATUS "${MSG_PREFIX} found CUDA compiler "
@@ -100,7 +107,9 @@ if(NOT CMAKE_APPLE_SILICON_PROCESSOR)
     elseif(has_hipcc)
         add_subdirectory(pybind_interface/hip)
     endif()
+endif()
 
+if(QSIM_X86)
     add_subdirectory(pybind_interface/sse)
     add_subdirectory(pybind_interface/avx512)
     add_subdirectory(pybind_interface/avx2)

--- a/pybind_interface/decide/decide.cpp
+++ b/pybind_interface/decide/decide.cpp
@@ -16,8 +16,8 @@
 
 namespace py = pybind11;
 
-#ifdef _WIN32
-//  Windows
+#if defined(_WIN32) && (defined(_M_IX86) || defined(_M_X64))
+//  Windows with cpuid
 #include <intrin.h>
 #define cpuid(info, x)    __cpuidex(info, x, 0)
 
@@ -35,7 +35,7 @@ enum Instructions { AVX512F = 0, AVX2 = 1, SSE4_1 = 2, BASIC = 3};
 int detect_instructions() {
   Instructions instr = BASIC;
 
-  #if !defined(__aarch64__) || !defined(__APPLE__)
+  #if (defined(_WIN32) && (defined(_M_IX86) || defined(_M_X64))) || defined(__x86_64__) || defined(__i386__)
   // Existing x86/x86_64 specific instruction set detection logic
   int info[4];
   cpuid(info, 0);


### PR DESCRIPTION
The previous directives supported macos arm but did not correctly trigger off of macosx, this applies the same codepaths for linux arm, supporting them natively.