### PR TITLE
fix: move skip to global [tool.cibuildwheel] to fix validate-pyprojec…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -286,8 +286,16 @@ jobs:
           export CXXFLAGS="-I${xcode_prefix}/usr/include -I${brew_prefix}/include -O3 -std=c++17 -flto=auto -Xpreprocessor -fopenmp"
           echo "CXXFLAGS=${CXXFLAGS}" >> "$GITHUB_ENV"
 
+      - name: Set up MSVC developer environment (Windows only)
+        if: startsWith(matrix.os, 'windows-')
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
+
       - name: Build the Python bindings
         shell: bash
+        env:
+          # Use Ninja on Windows: it is pre-installed on GitHub runners and does
+          # not require a Developer Command Prompt the way NMake does.
+          CMAKE_GENERATOR: ${{startsWith(matrix.os, 'windows-') && 'Ninja' || ''}}
         run: |
           mkdir -p build
           cd build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ dependencies = {file = ["requirements.txt"] }
 
 [tool.cibuildwheel]
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
+skip = "*musllinux*"
 dependency-versions = "latest"
 enable = ["cpython-prerelease"]
 environment.PIP_PREFER_BINARY = "1"
@@ -157,7 +158,6 @@ delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
-skip = "*musllinux*"
 
 [tool.black]
 target-version = ['py310', 'py311', 'py312', 'py313', 'py314']


### PR DESCRIPTION
The  property is a global-only key in the cibuildwheel JSON schema. Placing it inside [tool.cibuildwheel.linux] caused validate-pyproject to reject the file with:

  [ERROR]  must not contain {'skip'} properties

Moving  up to [tool.cibuildwheel] satisfies the
schema validator while keeping identical runtime behaviour — musllinux build identifiers do not exist on macOS or Windows, so the glob pattern still only ever matches Linux builds.

Fixes #1084