### PR TITLE
Install MSVC before running CMake in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -291,6 +291,10 @@ jobs:
           export CXXFLAGS="-I${xcode_prefix}/usr/include -I${brew_prefix}/include -O3 -std=c++17 -flto=auto -Xpreprocessor -fopenmp"
           echo "CXXFLAGS=${CXXFLAGS}" >> "$GITHUB_ENV"
 
+      - name: Set up MSVC Developer Command on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
       - name: Build the Python bindings
         shell: bash
         run: |


### PR DESCRIPTION
It seems that the failure in CI on Windows is because CMake attempts to use the NMake Makefiles generator by default on Windows, but the `nmake` executable (and the MSVC C++ compiler environment) is not present in the system `PATH` of the GitHub Actions runner. I don't know why this started happening when it clearly worked in the past.

This PR adds a step to the build job on Windows to install MSVC tools. Doing so seems to resolve the problem.

