### PR TITLE
Update `pyproject.toml` to support building wheels for Python 3.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,7 +223,7 @@ jobs:
           - windows-2025-x64-8-core
         python_version:
           - '3.10'
-          - '3.13'
+          - '3.14'
     steps:
       - name: Check out a copy of the git repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,6 @@ test-command = "pytest --import-mode=importlib -n auto -s -v {package}/qsimcirq_
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
-skip = "*musllinux*"
 
 [[tool.cibuildwheel.overrides]]
 # For Python 3.14, have to use a more recent manylinux image.
@@ -144,6 +143,7 @@ select = ["cp314*"]
 inherit.environment = "append"
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
+skip = ["*musllinux*", "*manylinux_i686*"]
 # Help increase the chances that pip will find binary wheels for NumPy.
 # See https://cibuildwheel.pypa.io/en/stable/faq/#building-with-numpy
 environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,18 +128,26 @@ dependencies = {file = ["requirements.txt"] }
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 dependency-versions = "latest"
 enable = ["cpython-prerelease"]
-environment.PIP_PREFER_BINARY = "1"
 before-test = "pip install --group dev"
 # import-mode=importlib prevents local source shadowing when importing qsimcirq.
 test-command = "pytest --import-mode=importlib -n auto -s -v {package}/qsimcirq_tests/qsimcirq_test.py"
-
-[[tool.cibuildwheel.overrides]]
 # Help increase the chances that pip will find binary wheels for NumPy.
 # See https://cibuildwheel.pypa.io/en/stable/faq/#building-with-numpy
-select = ["cp314*"]
-inherit.environment = "append"
 environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
 environment.PIP_PRERELEASE = "allow"
+environment.PIP_PREFER_BINARY = "1"
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
+skip = "*musllinux*"
+
+[[tool.cibuildwheel.overrides]]
+# For Python 3.14, have to use a more recent manylinux image.
+select = ["cp314*"]
+inherit.environment = "append"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
 before-build = """
@@ -153,11 +161,6 @@ repair-wheel-command = """
 delocate-listdeps {wheel} &&
 delocate-wheel --verbose --require-archs {delocate_archs} -w {dest_dir} {wheel}
 """
-
-[tool.cibuildwheel.linux]
-manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
-skip = "*musllinux*"
 
 [tool.black]
 target-version = ['py310', 'py311', 'py312', 'py313', 'py314']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ test-command = "pytest --import-mode=importlib -n auto -s -v {package}/qsimcirq_
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
+skip = ["*musllinux*", "*manylinux_i686*"]
 
 [[tool.cibuildwheel.overrides]]
 # For Python 3.14, have to use a more recent manylinux image.
@@ -143,7 +144,6 @@ select = ["cp314*"]
 inherit.environment = "append"
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
-skip = ["*musllinux*", "*manylinux_i686*"]
 # Help increase the chances that pip will find binary wheels for NumPy.
 # See https://cibuildwheel.pypa.io/en/stable/faq/#building-with-numpy
 environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ dependencies = {file = ["requirements.txt"] }
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 dependency-versions = "latest"
 enable = ["cpython-prerelease"]
+environment.PIP_PREFER_BINARY = "1"
 before-test = "pip install --group dev"
 # import-mode=importlib prevents local source shadowing when importing qsimcirq.
 test-command = "pytest --import-mode=importlib -n auto -s -v {package}/qsimcirq_tests/qsimcirq_test.py"
@@ -147,7 +148,6 @@ manylinux-aarch64-image = "manylinux_2_28"
 # See https://cibuildwheel.pypa.io/en/stable/faq/#building-with-numpy
 environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
 environment.PIP_PRERELEASE = "allow"
-environment.PIP_PREFER_BINARY = "1"
 
 [tool.cibuildwheel.macos]
 before-build = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ dependencies = {file = ["requirements.txt"] }
 
 [tool.cibuildwheel]
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
+skip = ["*musllinux*", "*manylinux_i686*"]
 dependency-versions = "latest"
 enable = ["cpython-prerelease"]
 environment.PIP_PREFER_BINARY = "1"
@@ -136,7 +137,6 @@ test-command = "pytest --import-mode=importlib -n auto -s -v {package}/qsimcirq_
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
-skip = ["*musllinux*", "*manylinux_i686*"]
 
 [[tool.cibuildwheel.overrides]]
 # For Python 3.14, have to use a more recent manylinux image.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,11 +131,6 @@ enable = ["cpython-prerelease"]
 before-test = "pip install --group dev"
 # import-mode=importlib prevents local source shadowing when importing qsimcirq.
 test-command = "pytest --import-mode=importlib -n auto -s -v {package}/qsimcirq_tests/qsimcirq_test.py"
-# Help increase the chances that pip will find binary wheels for NumPy.
-# See https://cibuildwheel.pypa.io/en/stable/faq/#building-with-numpy
-environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
-environment.PIP_PRERELEASE = "allow"
-environment.PIP_PREFER_BINARY = "1"
 
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"
@@ -148,6 +143,11 @@ select = ["cp314*"]
 inherit.environment = "append"
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
+# Help increase the chances that pip will find binary wheels for NumPy.
+# See https://cibuildwheel.pypa.io/en/stable/faq/#building-with-numpy
+environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
+environment.PIP_PRERELEASE = "allow"
+environment.PIP_PREFER_BINARY = "1"
 
 [tool.cibuildwheel.macos]
 before-build = """


### PR DESCRIPTION
This partly resolves #1017. This PR makes some adjustments to `pyproject.toml` to make building wheels on Python 3.14 actually work. This adjusts CI to test on Python 3.14 too.

In addition, I also moved the settings around a little bit to group them in a (hopefully) more logical manner, and due to the need to make it pass validation, ended up moving the `skip` property and thereby fixing #1084.